### PR TITLE
fix blockheight bug when doing a param change in provider

### DIFF
--- a/relayer/sentry/sentry.go
+++ b/relayer/sentry/sentry.go
@@ -1753,13 +1753,6 @@ func (s *Sentry) ExpecedBlockHeight() (int64, int) {
 	return median(listExpectedBlockHeights) - s.serverSpec.AllowedBlockLagForQosSync, len(listExpectedBlockHeights)
 }
 
-// TODO:: Dont calc. get this info from blockchain - if LAVA params change, this calc is obsolete
-func (s *Sentry) GetEpochFromBlockHeight(blockHeight int64) uint64 {
-	epochSize := s.GetEpochSize()
-	epoch := uint64(blockHeight - blockHeight%int64(epochSize))
-	return epoch
-}
-
 func NewSentry(
 	clientCtx client.Context,
 	chainID string,

--- a/relayer/server.go
+++ b/relayer/server.go
@@ -352,8 +352,9 @@ func getOrCreateSession(ctx context.Context, userAddr string, req *pairingtypes.
 				"userAddr": userAddr,
 			})
 		}
-		// TODO:: dont use GetEpochFromBlockHeight
-		sessionEpoch = g_sentry.GetEpochFromBlockHeight(req.BlockHeight)
+
+		// TODO:: should validate req.BlockHeight ?
+		sessionEpoch = uint64(req.BlockHeight)
 
 		userSessions.Lock.Lock()
 		session = &RelaySession{userSessionsParent: userSessions, RelayNum: 0, UniqueIdentifier: req.SessionId, PairingEpoch: sessionEpoch}


### PR DESCRIPTION
That math is no longer valid after changing epochblocks. 