### PR TITLE
Prt 111 support rest optional additional params just parser

### DIFF
--- a/relayer/chainproxy/rest.go
+++ b/relayer/chainproxy/rest.go
@@ -220,7 +220,13 @@ func (cp *RestChainProxy) PortalStart(ctx context.Context, privKey *btcec.Privat
 	// Catch the others
 	app.Use("/:dappId/*", func(c *fiber.Ctx) error {
 		cp.portalLogs.LogStartTransaction("rest-http")
-		query := "?" + string(c.Request().URI().QueryString())
+
+		URI := c.Request().URI()
+		if strings.Contains(URI.String(), "favicon.ico") {
+			return nil
+		}
+
+		query := "?" + string(URI.QueryString())
 		path := "/" + c.Params("*")
 		log.Println("in <<< ", path)
 		reply, _, err := SendRelay(ctx, cp, privKey, path, query, http.MethodGet)


### PR DESCRIPTION
This PR adds support for optional parameters. There is no need to make a parser since the current rest implementation sends a plain http request to the RPC I just need to add the removed parameters back.

You can test this with http://127.0.0.1:3340/1/lavanet/lava/spec/spec?pagination.limit=1