### PR TITLE
PRT-26 add provider data reliability verification for relay num 0 and cu sum 0

### DIFF
--- a/relayer/chainproxy/chainproxy.go
+++ b/relayer/chainproxy/chainproxy.go
@@ -199,9 +199,9 @@ func SendRelay(
 			Provider:              providerAddress,
 			ApiUrl:                url,
 			Data:                  []byte(req),
-			SessionId:             uint64(0), //sessionID for reliability is 0
+			SessionId:             lavasession.DataReliabilitySessionId, //sessionID for reliability is 0
 			ChainID:               sentry.ChainID,
-			CuSum:                 0, // consumerSession.CuSum == 0
+			CuSum:                 lavasession.DataReliabilityCuSum, // consumerSession.CuSum == 0
 			BlockHeight:           blockHeight,
 			RelayNum:              0, // consumerSession.RelayNum == 0
 			RequestBlock:          requestedBlock,

--- a/relayer/lavasession/common.go
+++ b/relayer/lavasession/common.go
@@ -14,6 +14,7 @@ const (
 	MaximumNumberOfFailuresAllowedPerConsumerSession = 3
 	RelayNumberIncrement                             = 1
 	DataReliabilitySessionId                         = 0 // data reliability session id is 0. we can change to more sessions later if needed.
+	DataReliabilityCuSum                             = 0
 )
 
 var AvailabilityPercentage sdk.Dec = sdk.NewDecWithPrec(5, 2) //TODO move to params pairing

--- a/relayer/server.go
+++ b/relayer/server.go
@@ -571,6 +571,12 @@ func (s *relayServer) initRelay(ctx context.Context, request *pairingtypes.Relay
 	var relaySession *RelaySession
 	var userSessions *UserSessions
 	if request.DataReliability != nil {
+		if request.RelayNum > lavasession.DataReliabilitySessionId {
+			return nil, nil, nil, nil, utils.LavaFormatError("request's relay num is larger than the data reliability session ID", nil, &map[string]string{"relayNum": strconv.FormatUint(request.RelayNum, 10), "DataReliabilitySessionId": strconv.Itoa(lavasession.DataReliabilitySessionId)})
+		}
+		if request.CuSum != lavasession.DataReliabilityCuSum {
+			return nil, nil, nil, nil, utils.LavaFormatError("request's CU sum is not equal to the data reliability CU sum", nil, &map[string]string{"cuSum": strconv.FormatUint(request.CuSum, 10), "DataReliabilityCuSum": strconv.Itoa(lavasession.DataReliabilityCuSum)})
+		}
 		userSessions = getOrCreateUserSessions(userAddr.String())
 		vrf_pk, maxcuRes, err := g_sentry.GetVrfPkAndMaxCuForUser(ctx, userAddr.String(), request.ChainID, request.BlockHeight)
 		if err != nil {
@@ -640,6 +646,7 @@ func (s *relayServer) initRelay(ctx context.Context, request *pairingtypes.Relay
 		getOrCreateDataByEpoch(userSessions, uint64(request.BlockHeight), maxcuRes, vrf_pk, userAddr.String())
 		userSessions.dataByEpoch[uint64(request.BlockHeight)].DataReliability = request.DataReliability
 		userSessions.Lock.Unlock()
+
 	} else {
 		relaySession, err = getOrCreateSession(ctx, userAddr.String(), request)
 		if err != nil {


### PR DESCRIPTION
This PR was not merged before because I didn't perform proper checks of the code.

According to Omer, to check this code I had to:
1. run test_client of COS3 on several epochs and make sure it prints "Reliability verified successfully!" every time
2. make sure there are no errors in the providers

I've performed the checks and they were all successful. Please merge this PR so PRT-26 can be done.