### PR TITLE
PRT-139 Only add params when not nil

### DIFF
--- a/relayer/chainproxy/jsonRPC.go
+++ b/relayer/chainproxy/jsonRPC.go
@@ -57,9 +57,12 @@ func convertMsg(rpcMsg *rpcclient.JsonrpcMessage) (*JsonrpcMessage, error) {
 		Version: rpcMsg.Version,
 		ID:      rpcMsg.ID,
 		Method:  rpcMsg.Method,
-		Params:  rpcMsg.Params,
 		Error:   rpcMsg.Error,
 		Result:  rpcMsg.Result,
+	}
+
+	if rpcMsg.Params != nil {
+		msg.Params = rpcMsg.Params
 	}
 
 	return msg, nil


### PR DESCRIPTION
This PR solves the null params problem we are having. msg.Params would only be filled if rpcMsg.Params is not nil.