### PR TITLE
PRT-178 Remove double save log

### DIFF
--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -250,7 +250,6 @@ func (lt *lavaTest) listenCmdCommand(cmd exec.Cmd, panicReason string) {
 	if lt.testFinishedProperly {
 		return
 	}
-	lt.saveLogs()
 	panic(panicReason)
 }
 


### PR DESCRIPTION
When listenCmdCommand throws a panic the defer statement would catch it so no need to save logs here.