### PR TITLE
PRT-142 Fix issue where provider cannot extract the consumer address

### DIFF
--- a/relayer/server.go
+++ b/relayer/server.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -694,9 +693,8 @@ func (s *relayServer) initRelay(ctx context.Context, request *pairingtypes.Relay
 
 		relaySession.Lock.Lock()
 
-		// Make copy of relay request and save it as session proof
-		relaySession.Proof = &pairingtypes.RelayRequest{}
-		reflect.ValueOf(relaySession.Proof).Elem().Set(reflect.ValueOf(request).Elem())
+		// Make a shallow copy of relay request and save it as session proof
+		relaySession.Proof = request.ShallowCopy()
 
 		relaySession.Lock.Unlock()
 	}

--- a/x/pairing/types/relay_extensions.go
+++ b/x/pairing/types/relay_extensions.go
@@ -1,0 +1,13 @@
+package types
+
+// ShallowCopy makes a shallow copy of the relay request, and returns it
+// A shallow copy includes the values of all fields in the original struct,
+// but any nested values (such as slices, maps, and pointers) are shared between the original and the copy.
+func (m *RelayRequest) ShallowCopy() *RelayRequest {
+	if m == nil {
+		return nil
+	}
+
+	requestCopy := *m
+	return &requestCopy
+}

--- a/x/pairing/types/relay_test.go
+++ b/x/pairing/types/relay_test.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// getDummyRequest creates dummy request used in tests
+func createDummyRequest(requestedBlock int64, dataReliability *VRFData) *RelayRequest {
+	return &RelayRequest{
+		ChainID:         "testID",
+		Data:            []byte("Dummy data"),
+		RequestBlock:    requestedBlock,
+		DataReliability: dataReliability,
+	}
+}
+
+// TestRelayShallowCopy tests shallow copy method of relay request
+func TestRelayShallowCopy(t *testing.T) {
+	t.Parallel()
+	t.Run(
+		"Check if copy object has same data as original",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dataReliability := &VRFData{
+				Differentiator: true,
+			}
+
+			request := createDummyRequest(-2, dataReliability)
+			copy := request.ShallowCopy()
+
+			assert.Equal(t, request, copy)
+		})
+	t.Run(
+		"Only nested values should be shared",
+		func(t *testing.T) {
+			t.Parallel()
+			
+			dataReliability := &VRFData{
+				Differentiator: true,
+			}
+
+			requestedBlock := int64(-2)
+
+			request := createDummyRequest(requestedBlock, dataReliability)
+			copy := request.ShallowCopy()
+
+			// Change RequestBlock
+			copy.RequestBlock = 1000
+
+			// Check that Requested block has not changed in the original
+			assert.Equal(t, request.RequestBlock, requestedBlock)
+
+			// Change shared dataReliability
+			dataReliability.Differentiator = false
+
+			// DataReliability should be changed on both objects
+			assert.Equal(t, request.DataReliability, copy.DataReliability)
+		})
+}


### PR DESCRIPTION
# Description

To understand the issue, one needs to know how a signature is created and how we extract pub key from it later. Basically, the only important thing for this bag is that the data needs to be identical. If the data has even 1 byte of a difference the recovered public key will be different.

Checking the request upon signing and recovering when the issue happened we can see that the requestedBlock has changed. 

`{ChainID:ETH1 ConnectionType: ApiUrl: SessionId:6304003046640637942 CuSum:1219 Data:[123 34 106 115 111 110 114 112 99 34 58 34 50 46 48 34 44 34 105 100 34 58 50 48 44 34 109 101 116 104 111 100 34 58 34 101 116 104 95 103 101 116 83 116 111 114 97 103 101 65 116 34 44 34 112 97 114 97 109 115 34 58 91 34 48 120 100 97 99 49 55 102 57 53 56 100 50 101 101 53 50 51 97 50 50 48 54 50 48 54 57 57 52 53 57 55 99 49 51 100 56 51 49 101 99 55 34 44 34 48 120 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 34 44 34 108 97 116 101 115 116 34 93 125] Sig:[] Provider:lava@1m545r4tw3ycywkfj5l43ec38evedlxdqrhs7a6 BlockHeight:280 RelayNum:56 RequestBlock:-2 DataReliability:<nil> QoSReport:latency:"1000000000000000000" availability:"1000000000000000000" sync:"0"  UnresponsiveProviders:[91 93]}`

`{ChainID:ETH1 ConnectionType: ApiUrl: SessionId:6304003046640637942 CuSum:1219 Data:[123 34 106 115 111 110 114 112 99 34 58 34 50 46 48 34 44 34 105 100 34 58 50 48 44 34 109 101 116 104 111 100 34 58 34 101 116 104 95 103 101 116 83 116 111 114 97 103 101 65 116 34 44 34 112 97 114 97 109 115 34 58 91 34 48 120 100 97 99 49 55 102 57 53 56 100 50 101 101 53 50 51 97 50 50 48 54 50 48 54 57 57 52 53 57 55 99 49 51 100 56 51 49 101 99 55 34 44 34 48 120 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 34 44 34 108 97 116 101 115 116 34 93 125] Sig:[] Provider:lava@1m545r4tw3ycywkfj5l43ec38evedlxdqrhs7a6 BlockHeight:280 RelayNum:56 RequestBlock:16233337 DataReliability:<nil> QoSReport:latency:"1000000000000000000" availability:"1000000000000000000" sync:"0"  UnresponsiveProviders:[91 93]}`

With this difference, the recovered address will be incorrect

Upon further investigation, we've seen that when we are saving latest request as session proof we are not doing copy but we are just pointing to the same data. Because in the code we change this requestBloock form the proof it get changed in the request it self

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Manual tests

1. Start chain
2. Init chain commands
3. Spam test_client non stop for few epoch. On the main branch after about 5 minutes you would see error logs
` lavad test_client "ETH1" "jsonrpc" --from user1`
