### PR TITLE
DOCS-34 Create enforce-pr-title.yml

### DIFF
--- a/.github/workflows/enforce-pr-title.yml
+++ b/.github/workflows/enforce-pr-title.yml
@@ -1,0 +1,12 @@
+name: Enforce Pull Request Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  enforce-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Pull Request Title includes Jira Issue Key
+        uses: ryanvade/enforce-pr-title-style-action@v1


### PR DESCRIPTION
Enforce title names to include the Jira ticket in the prefix, uses existing [automation] (https://github.com/marketplace/actions/enforce-pull-request-title-includes-jira-issue-key)