### PR TITLE
DO-485 Improve release pipeline - pin ubuntu base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release:
     name: 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     environment: default
     defaults:


### PR DESCRIPTION
The ubuntu-latest image was upgraded from v20 to v22, which caused our pipeline to fail when building.