### PR TITLE
PRT-206 add lava txs to e2e lava over lava txs validate they happened on chain

### DIFF
--- a/scripts/init_e2e.sh
+++ b/scripts/init_e2e.sh
@@ -1,10 +1,7 @@
 #!/bin/bash 
 __dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $__dir/useful_commands.sh
-. ${__dir}/vars/variables.sh
-# Making sure old screens are not running
-killall screen
-screen -wipe
+
 GASPRICE="0.000000001ulava"
 lavad tx gov submit-proposal spec-add ./cookbook/spec_add_ethereum.json,./cookbook/spec_add_lava.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE

--- a/scripts/init_e2e.sh
+++ b/scripts/init_e2e.sh
@@ -23,7 +23,6 @@ lavad tx pairing stake-provider "LAV1" 2050ulava "127.0.0.1:2265,tendermintrpc,1
 
 lavad tx pairing stake-client "ETH1" 200000ulava 1 -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 lavad tx pairing stake-client "LAV1" 200000ulava 1 -y --from user2 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-lavad tx pairing stake-client "LAV1" 200000ulava 1 -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 
 # we need to wait for the next epoch for the stake to take action.
 sleep_until_next_epoch

--- a/scripts/init_e2e_lava_over_lava.sh
+++ b/scripts/init_e2e_lava_over_lava.sh
@@ -1,0 +1,21 @@
+#!/bin/bash 
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $__dir/useful_commands.sh
+
+GASPRICE="0.000000001ulava"
+NODE="http://127.0.0.1:3340/1"
+lavad tx gov submit-proposal spec-add ./cookbook/spec_add_goerli.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+sleep 4
+
+# Goerli providers
+lavad tx pairing stake-provider "GTH1" 2010ulava "127.0.0.1:2121,jsonrpc,1" 1 -y --from servicer1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+lavad tx pairing stake-provider "GTH1" 2000ulava "127.0.0.1:2122,jsonrpc,1" 1 -y --from servicer2 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+lavad tx pairing stake-provider "GTH1" 2050ulava "127.0.0.1:2123,jsonrpc,1" 1 -y --from servicer3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+lavad tx pairing stake-provider "GTH1" 2020ulava "127.0.0.1:2124,jsonrpc,1" 1 -y --from servicer4 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+lavad tx pairing stake-provider "GTH1" 2030ulava "127.0.0.1:2125,jsonrpc,1" 1 -y --from servicer5 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+
+lavad tx pairing stake-client "GTH1" 200000ulava 1 -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE --node $NODE
+
+# we need to wait for the next epoch for the stake to take action.
+sleep_until_next_epoch

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -118,7 +118,7 @@ func (lt *lavaTest) stakeLava() {
 
 func (lt *lavaTest) checkStakeLava(specCount int, providerCount int, clientCount int, successMessage string) {
 	// providerCount and clientCount refers to number and providers and client for each spec
-	// number of providers and clients should be the same for all specs for for simplicity's sake
+	// number of providers and clients should be the same for all specs for simplicity's sake
 	specQueryClient := specTypes.NewQueryClient(lt.grpcConn)
 
 	// query all specs

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -243,7 +243,7 @@ func (lt *lavaTest) finishTestSuccessfully() {
 	lt.testFinishedProperly = true
 	for processName, cmd := range lt.commands { // kill all the project commands
 		if processName == "2_jsonProxy" {
-			cmd.Process.Signal(os.Interrupt) //call interrupt on jsonproxy to properly free the port
+			cmd.Process.Signal(os.Interrupt) // git call interrupt on jsonproxy to properly free the port
 		} else {
 			cmd.Process.Kill()
 		}

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -101,7 +101,7 @@ func (lt *lavaTest) checkLava(timeout time.Duration) {
 }
 
 func (lt *lavaTest) stakeLava() {
-	stakeCommand := "./scripts/init.sh"
+	stakeCommand := "./scripts/init_e2e.sh"
 	lt.logs["1_stakeLava"] = new(bytes.Buffer)
 	cmd := exec.Cmd{
 		Path:   stakeCommand,
@@ -599,32 +599,21 @@ func getRequest(url string) ([]byte, error) {
 }
 
 // This would submit a proposal, vote then stake providers and clients for that network over lava
-func (lt *lavaTest) lavaOverLava(rpcURL string) {
-	utils.LavaFormatInfo("Starting Lava Over Lava", nil)
-	lavaOverLavaCommands := []string{
-		lt.lavadPath + " tx gov submit-proposal spec-add ./cookbook/spec_add_goerli.json -y --from alice --gas-adjustment 1.5 --gas auto --gas-prices 0.000000001ulava --node " + rpcURL,
-		lt.lavadPath + " tx gov vote 2 yes -y --from alice --gas-adjustment 1.5 --gas auto --gas-prices 0.000000001ulava --node " + rpcURL,
-		lt.lavadPath + " tx pairing stake-provider GTH1 2010ulava 127.0.0.1:2121,jsonrpc,1 1 -y --from servicer1 --gas-adjustment 1.5 --gas auto --gas-prices 0.000000001ulava --node " + rpcURL,
-		lt.lavadPath + " tx pairing stake-client GTH1 200000ulava 1 -y --from user1 --gas-adjustment 1.5 --gas auto --gas-prices 0.000000001ulava --node " + rpcURL,
-	}
-
+func (lt *lavaTest) lavaOverLava() {
+	utils.LavaFormatInfo("Starting Lava over Lva Tests", nil)
+	stakeCommand := "./scripts/init_e2e_lava_over_lava.sh"
 	lt.logs["9_lavaOverLava"] = new(bytes.Buffer)
-	for idx, providerCommand := range lavaOverLavaCommands {
-		cmd := exec.Cmd{
-			Path:   lt.lavadPath,
-			Args:   strings.Split(providerCommand, " "),
-			Stdout: lt.logs["9_lavaOverLava"],
-			Stderr: lt.logs["9_lavaOverLava"],
-		}
-		err := cmd.Start()
-		if err != nil {
-			panic(utils.LavaFormatError("LavaOverLava command didnt complete idx:"+strconv.Itoa(idx), err, nil))
-		}
-		cmd.Wait()
-		if idx == 1 {
-			time.Sleep(time.Second * 5)
-		}
+	cmd := exec.Cmd{
+		Path:   stakeCommand,
+		Args:   strings.Split(stakeCommand, " "),
+		Stdout: lt.logs["9_lavaOverLava"],
+		Stderr: lt.logs["9_lavaOverLava"],
 	}
+	err := cmd.Start()
+	if err != nil {
+		panic("Staking Failed " + err.Error())
+	}
+	cmd.Wait()
 }
 
 func (lt *lavaTest) saveLogs() {
@@ -776,7 +765,7 @@ func runE2E() {
 
 	lt.checkPayments(time.Minute * 10)
 
-	lt.lavaOverLava("http://127.0.0.1:3340/1")
+	lt.lavaOverLava()
 
 	lt.finishTestSuccessfully()
 }


### PR DESCRIPTION
This PR does the following.
- Create proposal, vote and add providers and clients for a new network.
- Check if the txs are reflected onchain.
- Change the kill style for the proxy routine to interrupt so it properly gives up the port.
- Only print the errors from cmd.Wait() if the test is not done successfully. The current one prints out signal is killed errors because finishTestSuccessfully() kills them first before realizing the test is done because of the cmd.Wait().