### PR TITLE
CNS 158 makefile abort on version mismatch with the actual code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vue/dist
 release/
 .idea/
 .vscode/
+.*.sw?
 .DS_Store
 notes.txt
 vue/src/store/generated/*


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit message follows the Contribution Guidelines
- [x] Tests ran locally and added/modified if needed
- [x] Docs have been added/updated, if applicable
- [x] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The Makefile is used to generate production versions. It uses a VERSION variable to indicate the version that the `lavad` executable will report. It can be set by the command line (e.g. VERSION=0.4.1 make) or detected from the current checked-out code (as the most recent tag). However, it did not verify that the VERSION (requested/detected) matches the current code, and that the current code is clean.

* **What is the new behavior (if this is a feature change)?**

The Makefile now checks that the VERSION matches that of the current code, and that there are no uncommited changes or untracked files.

* **Please describe what manual tests you ran, if applicable**

Run 'make' on with matching and matching versions, and on clean and dirty code trees.

* **Other information**:
