### PR TITLE
PRT-221 consumer requested a smaller relay num than expected trying to overwrite past usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/gogoproto v1.4.3
 	github.com/fullstorydev/grpcurl v1.8.5
+	github.com/gogo/status v1.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/ignite-hq/cli v0.22.1-0.20220610070456-1b33c09fceb7
 	github.com/jhump/protoreflect v1.14.0
@@ -45,6 +46,7 @@ require (
 	github.com/creachadair/taskgroup v0.3.2 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -642,9 +642,13 @@ github.com/gofiber/websocket/v2 v2.0.22/go.mod h1:/F8SLCxN9kEfBvwGW0FBQ4/+yF18GA
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/gateway v1.1.0 h1:u0SuhL9+Il+UbjM9VIE3ntfRujKbvVpFvNB4HbjeVQ0=
 github.com/gogo/gateway v1.1.0/go.mod h1:S7rR8FRQyG3QFESeSv4l2WnsyzlCLG0CzBbUUo/mbic=
+github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
+github.com/gogo/googleapis v1.4.0 h1:zgVt4UpGxcqVOw97aRGxT4svlcmdK35fynLNctY32zI=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
+github.com/gogo/status v1.1.0 h1:+eIkrewn5q6b30y+g/BJINVVdi2xH7je5MPJ3ZPK3JA=
+github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
@@ -1928,6 +1932,7 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
+google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1979,6 +1984,7 @@ google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSgaFAGyInDXeWzUhvYH57G/5GKMn70=
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/relayer/chainproxy/chainproxy.go
+++ b/relayer/chainproxy/chainproxy.go
@@ -25,6 +25,7 @@ const (
 	TimePerCU                 = uint64(100 * time.Millisecond)
 	ContextUserValueKeyDappID = "dappID"
 	MinimumTimePerRelayDelay  = time.Second
+	AverageWorldLatency       = 100 * time.Millisecond
 )
 
 type NodeMessage interface {
@@ -150,7 +151,7 @@ func SendRelay(
 		relayRequest.Sig = sig
 		c := *consumerSession.Endpoint.Client
 
-		connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second) // getTimePerCu(consumerSession.LatestRelayCu)+100*time.Millisecond
+		connectCtx, cancel := context.WithTimeout(ctx, getTimePerCu(consumerSession.LatestRelayCu)+AverageWorldLatency)
 		defer cancel()
 
 		var replyServer pairingtypes.Relayer_RelaySubscribeClient

--- a/relayer/chainproxy/chainproxy.go
+++ b/relayer/chainproxy/chainproxy.go
@@ -25,7 +25,7 @@ const (
 	TimePerCU                 = uint64(100 * time.Millisecond)
 	ContextUserValueKeyDappID = "dappID"
 	MinimumTimePerRelayDelay  = time.Second
-	AverageWorldLatency       = 100 * time.Millisecond
+	AverageWorldLatency       = 200 * time.Millisecond
 )
 
 type NodeMessage interface {

--- a/relayer/chainproxy/jsonRPC.go
+++ b/relayer/chainproxy/jsonRPC.go
@@ -366,7 +366,15 @@ func (cp *JrpcChainProxy) PortalStart(ctx context.Context, privKey *btcec.Privat
 			c.Status(fiber.StatusInternalServerError)
 			return c.SendString(fmt.Sprintf(`{"error": {"code":-32000,"message":"%s"}}`, errMasking))
 		}
-		cp.portalLogs.LogRequestAndResponse("jsonrpc http", false, "POST", c.Request().URI().String(), string(c.Body()), string(reply.Data), msgSeed, nil)
+		cp.portalLogs.LogRequestAndResponse("jsonrpc http",
+			false,
+			"POST",
+			c.Request().URI().String(),
+			string(c.Body()),
+			string(reply.Data),
+			msgSeed,
+			nil,
+		)
 		return c.SendString(string(reply.Data))
 	})
 

--- a/relayer/lavasession/consumer_session_manager.go
+++ b/relayer/lavasession/consumer_session_manager.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/gogo/status"
 	"github.com/lavanet/lava/utils"
+	"google.golang.org/grpc/codes"
 )
 
 type ConsumerSessionManager struct {
@@ -183,6 +185,7 @@ func (csm *ConsumerSessionManager) getValidProviderAddress(ignoredProvidersList 
 	validAddressesLength := len(csm.validAddresses)
 	totalValidLength := validAddressesLength - ignoredProvidersListLength
 	if totalValidLength <= 0 {
+		utils.LavaFormatDebug("Pairing list empty", &map[string]string{"Provider list": fmt.Sprintf("%v", csm.validAddresses), "IgnoredProviderList": fmt.Sprintf("%v", ignoredProvidersList)})
 		err = PairingListEmptyError
 		return
 	}
@@ -298,6 +301,8 @@ func (csm *ConsumerSessionManager) OnSessionUnUsed(consumerSession *SingleConsum
 // Report session failure, mark it as blocked from future usages, report if timeout happened.
 func (csm *ConsumerSessionManager) OnSessionFailure(consumerSession *SingleConsumerSession, errorReceived error) error {
 	// consumerSession must be locked when getting here.
+	code := status.Code(errorReceived)
+
 	if err := csm.verifyLock(consumerSession); err != nil {
 		return sdkerrors.Wrapf(err, "OnSessionFailure, consumerSession.lock must be locked before accessing this method, additional info:")
 	}
@@ -311,8 +316,9 @@ func (csm *ConsumerSessionManager) OnSessionFailure(consumerSession *SingleConsu
 	consumerSession.QoSInfo.TotalRelays++
 	consumerSession.ConsecutiveNumberOfFailures += 1 // increase number of failures for this session
 
-	// if this session failed more than MaximumNumberOfFailuresAllowedPerConsumerSession times we block list it.
-	if consumerSession.ConsecutiveNumberOfFailures > MaximumNumberOfFailuresAllowedPerConsumerSession || SessionOutOfSyncError.Is(errorReceived) {
+	// if this session failed more than MaximumNumberOfFailuresAllowedPerConsumerSession times or session went out of sync we block it.
+	if consumerSession.ConsecutiveNumberOfFailures > MaximumNumberOfFailuresAllowedPerConsumerSession || code == codes.Code(SessionOutOfSyncError.ABCICode()) {
+		utils.LavaFormatDebug("Blocking consumer session", &map[string]string{"id": strconv.FormatInt(consumerSession.SessionId, 10)})
 		consumerSession.BlockListed = true // block this session from future usages
 	}
 	cuToDecrease := consumerSession.LatestRelayCu

--- a/relayer/lavasession/errors.go
+++ b/relayer/lavasession/errors.go
@@ -31,4 +31,5 @@ var ( // Provider Side Errors
 	InvalidEpochError           = sdkerrors.New("InvalidEpoch Error", 881, "Requested Epoch Is Too Old")
 	NewSessionWithRelayNumError = sdkerrors.New("NewSessionWithRelayNum Error", 882, "Requested Session With Relay Number Is Invalid")
 	ConsumerIsBlockListed       = sdkerrors.New("ConsumerIsBlockListed Error", 883, "This Consumer Is Blocked.")
+	SessionSyncLossError        = sdkerrors.New("SessionSyncLossError Error", 884, "Consumer and provider lost synchronization on session")
 )

--- a/relayer/lavasession/errors.go
+++ b/relayer/lavasession/errors.go
@@ -31,5 +31,4 @@ var ( // Provider Side Errors
 	InvalidEpochError           = sdkerrors.New("InvalidEpoch Error", 881, "Requested Epoch Is Too Old")
 	NewSessionWithRelayNumError = sdkerrors.New("NewSessionWithRelayNum Error", 882, "Requested Session With Relay Number Is Invalid")
 	ConsumerIsBlockListed       = sdkerrors.New("ConsumerIsBlockListed Error", 883, "This Consumer Is Blocked.")
-	SessionSyncLossError        = sdkerrors.New("SessionSyncLossError Error", 884, "Consumer and provider lost synchronization on session")
 )

--- a/relayer/sentry/sentry.go
+++ b/relayer/sentry/sentry.go
@@ -982,7 +982,10 @@ func (s *Sentry) SendRelay(
 	reply, replyServer, request, latency, fromCache, err := cb_send_relay(consumerSession)
 	// error using this provider
 	if err != nil {
-		return nil, nil, 0, fromCache, utils.LavaFormatError("failed sending relay", lavasession.SendRelayError, &map[string]string{"ErrMsg": err.Error()})
+		// Lava format error overrides the error status code.
+		// so in this case we just want to return the error as it is
+		utils.LavaFormatError("failed sending relay", err, nil)
+		return nil, nil, 0, fromCache, err
 	}
 
 	if s.GetSpecDataReliabilityEnabled() && reply != nil && !fromCache {

--- a/relayer/sentry/sentry.go
+++ b/relayer/sentry/sentry.go
@@ -151,7 +151,7 @@ type Sentry struct {
 	// every entry in providerHashesConsensus is conflicted with the other entries
 	providerHashesConsensus          []ProviderHashesConsensus
 	prevEpochProviderHashesConsensus []ProviderHashesConsensus
-	providerDataContainersMu         utils.LavaMutex
+	providerDataContainersMu         sync.RWMutex
 
 	consumerSessionManager *lavasession.ConsumerSessionManager
 }
@@ -1406,6 +1406,8 @@ func (s *Sentry) GetVrfPkAndMaxCuForUser(ctx context.Context, address string, ch
 }
 
 func (s *Sentry) ExpectedBlockHeight() (int64, int) {
+	s.providerDataContainersMu.RLock()
+	defer s.providerDataContainersMu.RUnlock()
 	averageBlockTime_ms := s.serverSpec.AverageBlockTime
 	listExpectedBlockHeights := []int64{}
 

--- a/relayer/server.go
+++ b/relayer/server.go
@@ -796,7 +796,6 @@ func (s *relayServer) Relay(ctx context.Context, request *pairingtypes.RelayRequ
 		utils.LavaFormatDebug("Provider Finished Relay Successfully", &map[string]string{
 			"request.SessionId":   strconv.FormatUint(request.SessionId, 10),
 			"request.relayNumber": strconv.FormatUint(request.RelayNum, 10),
-			"providerSession":     strconv.FormatUint(relaySession.atomicReadRelayNum(), 10),
 		})
 	}
 	return reply, s.handleRelayErrorStatus(err)

--- a/relayer/server.go
+++ b/relayer/server.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/status"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -43,6 +44,7 @@ import (
 	"github.com/spf13/pflag"
 	tenderbytes "github.com/tendermint/tendermint/libs/bytes"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -92,6 +94,10 @@ type RelaySession struct {
 	Proof              *pairingtypes.RelayRequest // saves last relay request of a session as proof
 	RelayNum           uint64
 	PairingEpoch       uint64
+}
+
+func (rs *RelaySession) atomicReadRelayNum() uint64 {
+	return atomic.LoadUint64(&rs.RelayNum)
 }
 
 type subscription struct {
@@ -424,16 +430,18 @@ func updateSessionCu(sess *RelaySession, userSessions *UserSessions, serviceApi 
 
 	if relayNum+1 != request.RelayNum {
 		utils.LavaFormatError("consumer requested incorrect relaynum, expected it to increment by 1", nil, &map[string]string{
-			"expected": strconv.FormatUint(relayNum+1, 10),
-			"received": strconv.FormatUint(request.RelayNum, 10),
+			"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+			"expected":          strconv.FormatUint(relayNum+1, 10),
+			"received":          strconv.FormatUint(request.RelayNum, 10),
 		})
 	}
 
 	// Check that relaynum gets incremented by user
 	if relayNum+1 > request.RelayNum {
-		return utils.LavaFormatError("consumer requested a smaller relay num than expected, trying to overwrite past usage", nil, &map[string]string{
-			"expected": strconv.FormatUint(relayNum+1, 10),
-			"received": strconv.FormatUint(request.RelayNum, 10),
+		return utils.LavaFormatError("consumer requested a smaller relay num than expected, trying to overwrite past usage", lavasession.SessionOutOfSyncError, &map[string]string{
+			"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+			"expected":          strconv.FormatUint(relayNum+1, 10),
+			"received":          strconv.FormatUint(request.RelayNum, 10),
 		})
 	}
 
@@ -441,20 +449,22 @@ func updateSessionCu(sess *RelaySession, userSessions *UserSessions, serviceApi 
 	sess.RelayNum++
 	sess.Lock.Unlock()
 
-	utils.LavaFormatInfo("updateSessionCu", &map[string]string{
-		"serviceApi.Name":   serviceApi.Name,
-		"request.SessionId": strconv.FormatUint(request.SessionId, 10),
-	})
+	// utils.LavaFormatDebug("updateSessionCu", &map[string]string{
+	// 	"serviceApi.Name":   serviceApi.Name,
+	// 	"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+	// })
 	//
 	// TODO: do we worry about overflow here?
 	if cuSum >= request.CuSum {
-		return utils.LavaFormatError("bad CU sum", nil, &map[string]string{
-			"cuSum":         strconv.FormatUint(cuSum, 10),
-			"request.CuSum": strconv.FormatUint(request.CuSum, 10),
+		return utils.LavaFormatError("bad CU sum", lavasession.SessionOutOfSyncError, &map[string]string{
+			"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+			"cuSum":             strconv.FormatUint(cuSum, 10),
+			"request.CuSum":     strconv.FormatUint(request.CuSum, 10),
 		})
 	}
 	if cuSum+serviceApi.ComputeUnits != request.CuSum {
-		return utils.LavaFormatError("bad CU sum", nil, &map[string]string{
+		return utils.LavaFormatError("bad CU sum", lavasession.SessionOutOfSyncError, &map[string]string{
+			"request.SessionId":       strconv.FormatUint(request.SessionId, 10),
 			"cuSum":                   strconv.FormatUint(cuSum, 10),
 			"request.CuSum":           strconv.FormatUint(request.CuSum, 10),
 			"serviceApi.ComputeUnits": strconv.FormatUint(serviceApi.ComputeUnits, 10),
@@ -467,6 +477,7 @@ func updateSessionCu(sess *RelaySession, userSessions *UserSessions, serviceApi 
 	if epochData.UsedComputeUnits+serviceApi.ComputeUnits > epochData.MaxComputeUnits {
 		userSessions.Lock.Unlock()
 		return utils.LavaFormatError("client cu overflow", nil, &map[string]string{
+			"request.SessionId":          strconv.FormatUint(request.SessionId, 10),
 			"epochData.MaxComputeUnits":  strconv.FormatUint(epochData.MaxComputeUnits, 10),
 			"epochData.UsedComputeUnits": strconv.FormatUint(epochData.UsedComputeUnits, 10),
 			"serviceApi.ComputeUnits":    strconv.FormatUint(request.CuSum, 10),
@@ -576,8 +587,7 @@ func (s *relayServer) initRelay(ctx context.Context, request *pairingtypes.Relay
 	var authorisedUserResponse *pairingtypes.QueryVerifyPairingResponse
 	authorisedUserResponse, nodeMsg, err = authorizeAndParseMessage(ctx, userAddr, request, uint64(request.BlockHeight))
 	if err != nil {
-		utils.LavaFormatError("failed authorizing user request", nil, nil)
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, utils.LavaFormatError("failed authorizing user request", err, nil)
 	}
 	var relaySession *RelaySession
 	var userSessions *UserSessions
@@ -750,13 +760,25 @@ func (s *relayServer) onRelayFailure(userSessions *UserSessions, relaySession *R
 	return retError
 }
 
+func (s *relayServer) handleRelayErrorStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	if lavasession.SessionOutOfSyncError.Is(err) {
+		err = status.Error(codes.Code(lavasession.SessionOutOfSyncError.ABCICode()), err.Error())
+	}
+	return err
+}
+
 func (s *relayServer) Relay(ctx context.Context, request *pairingtypes.RelayRequest) (*pairingtypes.RelayReply, error) {
-	utils.LavaFormatInfo("Provider got relay request", &map[string]string{
-		"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+	utils.LavaFormatDebug("Provider got relay request", &map[string]string{
+		"request.SessionId":   strconv.FormatUint(request.SessionId, 10),
+		"request.relayNumber": strconv.FormatUint(request.RelayNum, 10),
+		"request.cu":          strconv.FormatUint(request.CuSum, 10),
 	})
 	userAddr, nodeMsg, userSessions, relaySession, err := s.initRelay(ctx, request)
 	if err != nil {
-		return nil, err
+		return nil, s.handleRelayErrorStatus(err)
 	}
 
 	reply, err := s.TryRelay(ctx, request, userAddr, nodeMsg)
@@ -764,10 +786,20 @@ func (s *relayServer) Relay(ctx context.Context, request *pairingtypes.RelayRequ
 		// failed to send relay. we need to adjust session state. cuSum and relayNumber.
 		relayFailureError := s.onRelayFailure(userSessions, relaySession, nodeMsg)
 		if relayFailureError != nil {
-			err = sdkerrors.Wrapf(relayFailureError, "Relay Error: "+err.Error())
+			err = sdkerrors.Wrapf(relayFailureError, "On relay failure: "+err.Error())
 		}
+		utils.LavaFormatError("TryRelay Failed", err, &map[string]string{
+			"request.SessionId": strconv.FormatUint(request.SessionId, 10),
+			"request.userAddr":  userAddr.String(),
+		})
+	} else {
+		utils.LavaFormatDebug("Provider Finished Relay Successfully", &map[string]string{
+			"request.SessionId":   strconv.FormatUint(request.SessionId, 10),
+			"request.relayNumber": strconv.FormatUint(request.RelayNum, 10),
+			"providerSession":     strconv.FormatUint(relaySession.atomicReadRelayNum(), 10),
+		})
 	}
-	return reply, err
+	return reply, s.handleRelayErrorStatus(err)
 }
 
 func (s *relayServer) TryRelay(ctx context.Context, request *pairingtypes.RelayRequest, userAddr sdk.AccAddress, nodeMsg chainproxy.NodeMessage) (*pairingtypes.RelayReply, error) {

--- a/scripts/pre_setups/init_gth_only.sh
+++ b/scripts/pre_setups/init_gth_only.sh
@@ -1,0 +1,24 @@
+#!/bin/bash 
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+. "${__dir}"/../vars/variables.sh
+# Making sure old screens are not running
+killall screen
+screen -wipe
+LOGS_DIR=${__dir}/../../testutil/debugging/logs
+GASPRICE="0.000000001ulava"
+lavad tx gov submit-proposal spec-add ./cookbook/spec_add_goerli.json  -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+sleep 4
+lavad tx pairing stake-client "GTH1"   200000ulava 1 -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+#Goerli providers
+lavad tx pairing stake-provider "GTH1" 2010ulava "127.0.0.1:2121,jsonrpc,1" 1 -y --from servicer1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx pairing stake-provider "GTH1" 2000ulava "127.0.0.1:2122,jsonrpc,1" 1 -y --from servicer2 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+sleep_until_next_epoch
+
+screen -d -m -S gth_providers bash -c "source ~/.bashrc; lavad server 127.0.0.1 2121 $GTH_RPC_WS GTH1 jsonrpc $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer1 2>&1 | tee $LOGS_DIR/GTH1_2121.log" && sleep 0.25
+screen -S gth_providers -X screen -t win1 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2122 $GTH_RPC_WS GTH1 jsonrpc $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer2 2>&1 | tee $LOGS_DIR/GTH1_2122.log"
+
+screen -d -m -S portals bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3339 GTH1 jsonrpc $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug --from user1 2>&1 | tee $LOGS_DIR/PORTAL_3339.log"

--- a/scripts/pre_setups/init_lava_grpc.sh
+++ b/scripts/pre_setups/init_lava_grpc.sh
@@ -21,19 +21,19 @@ lavad tx pairing stake-provider "LAV1" 2050ulava "127.0.0.1:2263,tendermintrpc,1
 sleep_until_next_epoch
 
 # Lava providers
-screen -d -m -S lav1_providers bash -c "source ~/.bashrc; lavad server 127.0.0.1 2271 $LAVA_REST LAV1 rest --from servicer1 2>&1 | tee $LOGS_DIR/LAV1_2271.log"; sleep 0.3
-screen -S lav1_providers -X screen -t win1 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2272 $LAVA_REST LAV1 rest --from servicer2 2>&1 | tee $LOGS_DIR/LAV1_2272.log"
-screen -S lav1_providers -X screen -t win2 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2273 $LAVA_REST LAV1 rest --from servicer3 2>&1 | tee $LOGS_DIR/LAV1_2273.log"
-screen -S lav1_providers -X screen -t win3 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2261 $LAVA_RPC LAV1 tendermintrpc --from servicer1 2>&1 | tee $LOGS_DIR/LAV1_2261.log"
-screen -S lav1_providers -X screen -t win4 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2262 $LAVA_RPC LAV1 tendermintrpc --from servicer2 2>&1 | tee $LOGS_DIR/LAV1_2262.log"
-screen -S lav1_providers -X screen -t win5 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2263 $LAVA_RPC LAV1 tendermintrpc --from servicer3 2>&1 | tee $LOGS_DIR/LAV1_2263.log"
-screen -S lav1_providers -X screen -t win6 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2281 $LAVA_GRPC LAV1 grpc --from servicer1 2>&1 | tee $LOGS_DIR/LAV1_2281.log"
-screen -S lav1_providers -X screen -t win7 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2282 $LAVA_GRPC LAV1 grpc --from servicer2 2>&1 | tee $LOGS_DIR/LAV1_2282.log"
-screen -S lav1_providers -X screen -t win8 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2283 $LAVA_GRPC LAV1 grpc --from servicer3 2>&1 | tee $LOGS_DIR/LAV1_2283.log"
+screen -d -m -S lav1_providers bash -c "source ~/.bashrc; lavad server 127.0.0.1 2271 $LAVA_REST LAV1 rest --from servicer1 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2271.log"; sleep 0.3
+screen -S lav1_providers -X screen -t win1 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2272 $LAVA_REST LAV1 rest --from servicer2 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2272.log"
+screen -S lav1_providers -X screen -t win2 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2273 $LAVA_REST LAV1 rest --from servicer3 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2273.log"
+screen -S lav1_providers -X screen -t win3 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2261 $LAVA_RPC LAV1 tendermintrpc --from servicer1$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2261.log"
+screen -S lav1_providers -X screen -t win4 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2262 $LAVA_RPC LAV1 tendermintrpc --from servicer2$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2262.log"
+screen -S lav1_providers -X screen -t win5 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2263 $LAVA_RPC LAV1 tendermintrpc --from servicer3$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2263.log"
+screen -S lav1_providers -X screen -t win6 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2281 $LAVA_GRPC LAV1 grpc --from servicer1 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2281.log"
+screen -S lav1_providers -X screen -t win7 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2282 $LAVA_GRPC LAV1 grpc --from servicer2 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2282.log"
+screen -S lav1_providers -X screen -t win8 -X bash -c "source ~/.bashrc; lavad server 127.0.0.1 2283 $LAVA_GRPC LAV1 grpc --from servicer3 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_2283.log"
 
-screen -d -m -S portals bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3340 LAV1 rest --from user4"; sleep 0.3
-screen -S portals -X screen -t win17 -X bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3341 LAV1 tendermintrpc --from user4"
-screen -S portals -X screen -t win17 -X bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3342 LAV1 grpc --from user4 2>&1 | tee $LOGS_DIR/LAV1_grpc_portal.log"
+screen -d -m -S portals bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3340 LAV1 rest --from user4 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug | tee $LOGS_DIR/LAV1_tendermint_portal.log"; sleep 0.3
+screen -S portals -X screen -t win17 -X bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3341 LAV1 tendermintrpc --from user4 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug | tee $LOGS_DIR/LAV1_tendermint_portal.log"
+screen -S portals -X screen -t win17 -X bash -c "source ~/.bashrc; lavad portal_server 127.0.0.1 3342 LAV1 grpc --from user4 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug 2>&1 | tee $LOGS_DIR/LAV1_grpc_portal.log"
 
 # Lava Over Lava ETH
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [V] Commit message follows the Contribution Guidelines
- [V] Tests ran locally and added/modified if needed
- [V] Docs have been added/updated, if applicable
- [V] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)
Bug fix for session sync loss, added status error code between provider and consumer processes, to analyze if the session sync was lost, increased the consumer context timeout to wait a few MS longer than the provider to prevent context cancel races resulting in fewer session sync losses. 

* **What is the current behavior?** (You can also link to an open issue here)
https://lavanet.atlassian.net/browse/PRT-221?atlOrigin=eyJpIjoiZDY1MTgxOTgxNzQwNGMyZWIxNzZmOGZkOTM1YWIyMjEiLCJwIjoiaiJ9

* **What is the new behavior (if this is a feature change)?**


* **Please describe what manual tests you ran, if applicable**
stress testing the system using: 
yes '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | ./versus -vv --concurrency=100 --stop-after=100000 http://127.0.0.1:3339/1/

* **Other information**:
