### PR TITLE
CNS-131: added events for unstaking

### DIFF
--- a/x/conflict/keeper/vote.go
+++ b/x/conflict/keeper/vote.go
@@ -165,6 +165,8 @@ func (k Keeper) HandleAndCloseVote(ctx sdk.Context, conflictVote types.ConflictV
 						utils.LavaError(ctx, logger, "slash_failed_vote", map[string]string{"error": err.Error()}, "slashing failed at vote conflict")
 					}
 
+					details := map[string]string{"fraud voter address": vote.Address, "fraud voter chainID": conflictVote.ChainID}
+					utils.LogLavaEvent(ctx, logger, types.ConflictUnstakeFraudVoterEventName, details, " unstaking fraud voter.")
 					err = k.pairingKeeper.UnstakeEntry(ctx, true, conflictVote.ChainID, vote.Address)
 					if err != nil {
 						utils.LavaError(ctx, logger, "unstake_fraud_failed", map[string]string{"error": err.Error()}, "unstaking fraud voter failed")

--- a/x/conflict/keeper/vote.go
+++ b/x/conflict/keeper/vote.go
@@ -165,9 +165,7 @@ func (k Keeper) HandleAndCloseVote(ctx sdk.Context, conflictVote types.ConflictV
 						utils.LavaError(ctx, logger, "slash_failed_vote", map[string]string{"error": err.Error()}, "slashing failed at vote conflict")
 					}
 
-					details := map[string]string{"fraud voter address": vote.Address, "fraud voter chainID": conflictVote.ChainID}
-					utils.LogLavaEvent(ctx, logger, types.ConflictUnstakeFraudVoterEventName, details, " unstaking fraud voter.")
-					err = k.pairingKeeper.UnstakeEntry(ctx, true, conflictVote.ChainID, vote.Address)
+					err = k.pairingKeeper.UnstakeEntry(ctx, true, conflictVote.ChainID, vote.Address, " unstaking fraud voter.")
 					if err != nil {
 						utils.LavaError(ctx, logger, "unstake_fraud_failed", map[string]string{"error": err.Error()}, "unstaking fraud voter failed")
 						continue

--- a/x/conflict/keeper/vote.go
+++ b/x/conflict/keeper/vote.go
@@ -165,7 +165,7 @@ func (k Keeper) HandleAndCloseVote(ctx sdk.Context, conflictVote types.ConflictV
 						utils.LavaError(ctx, logger, "slash_failed_vote", map[string]string{"error": err.Error()}, "slashing failed at vote conflict")
 					}
 
-					err = k.pairingKeeper.UnstakeEntry(ctx, true, conflictVote.ChainID, vote.Address, " unstaking fraud voter.")
+					err = k.pairingKeeper.UnstakeEntry(ctx, true, conflictVote.ChainID, vote.Address, types.UnstakeDescriptionFraudVote)
 					if err != nil {
 						utils.LavaError(ctx, logger, "unstake_fraud_failed", map[string]string{"error": err.Error()}, "unstaking fraud voter failed")
 						continue

--- a/x/conflict/types/expected_keepers.go
+++ b/x/conflict/types/expected_keepers.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PairingKeeper interface {
-	UnstakeEntry(ctx sdk.Context, provider bool, chainID string, creator string) error
+	UnstakeEntry(ctx sdk.Context, provider bool, chainID string, creator string, unstakeDescription string) error
 	CreditStakeEntry(ctx sdk.Context, chainID string, lookUpAddress sdk.AccAddress, creditAmount sdk.Coin, isProvider bool) (bool, error)
 	VerifyPairingData(ctx sdk.Context, chainID string, clientAddress sdk.AccAddress, block uint64) (clientStakeEntryRet *epochstoragetypes.StakeEntry, errorRet error)
 	JailEntry(ctx sdk.Context, account sdk.AccAddress, isProvider bool, chainID string, jailStartBlock uint64, jailBlocks uint64, bail sdk.Coin) error

--- a/x/conflict/types/types.go
+++ b/x/conflict/types/types.go
@@ -31,6 +31,11 @@ const (
 	ConflictUnstakeFraudVoterEventName = "conflict_unstake_fraud_voter"
 )
 
+// unstake description
+const (
+	UnstakeDescriptionFraudVote = "fraud provider found in conflict detection"
+)
+
 func CommitVoteData(nonce int64, dataHash []byte) []byte {
 	commitData := make([]byte, 8) // nonce bytes
 	binary.LittleEndian.PutUint64(commitData, uint64(nonce))

--- a/x/conflict/types/types.go
+++ b/x/conflict/types/types.go
@@ -28,6 +28,7 @@ const (
 	ConflictVoteUnresolvedEventName    = "conflict_detection_vote_unresolved"
 	ConflictVoteGotCommitEventName     = "conflict_vote_got_commit"
 	ConflictVoteGotRevealEventName     = "conflict_vote_got_reveal"
+	ConflictUnstakeFraudVoterEventName = "conflict_unstake_fraud_voter"
 )
 
 func CommitVoteData(nonce int64, dataHash []byte) []byte {

--- a/x/pairing/keeper/msg_server_unstake_client.go
+++ b/x/pairing/keeper/msg_server_unstake_client.go
@@ -9,6 +9,6 @@ import (
 
 func (k msgServer) UnstakeClient(goCtx context.Context, msg *types.MsgUnstakeClient) (*types.MsgUnstakeClientResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err := k.Keeper.UnstakeEntry(ctx, false, msg.ChainID, msg.Creator, " Appending new client unstake entry (removing stake entry).")
+	err := k.Keeper.UnstakeEntry(ctx, false, msg.ChainID, msg.Creator, types.UnstakeDescriptionClientUnstake)
 	return &types.MsgUnstakeClientResponse{}, err
 }

--- a/x/pairing/keeper/msg_server_unstake_client.go
+++ b/x/pairing/keeper/msg_server_unstake_client.go
@@ -9,6 +9,6 @@ import (
 
 func (k msgServer) UnstakeClient(goCtx context.Context, msg *types.MsgUnstakeClient) (*types.MsgUnstakeClientResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err := k.Keeper.UnstakeEntry(ctx, false, msg.ChainID, msg.Creator)
+	err := k.Keeper.UnstakeEntry(ctx, false, msg.ChainID, msg.Creator, " Appending new client unstake entry (removing stake entry).")
 	return &types.MsgUnstakeClientResponse{}, err
 }

--- a/x/pairing/keeper/msg_server_unstake_provider.go
+++ b/x/pairing/keeper/msg_server_unstake_provider.go
@@ -10,6 +10,6 @@ import (
 func (k msgServer) UnstakeProvider(goCtx context.Context, msg *types.MsgUnstakeProvider) (*types.MsgUnstakeProviderResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	err := k.Keeper.UnstakeEntry(ctx, true, msg.ChainID, msg.Creator, " Appending new provider unstake entry (removing stake entry).")
+	err := k.Keeper.UnstakeEntry(ctx, true, msg.ChainID, msg.Creator, types.UnstakeDescriptionProviderUnstake)
 	return &types.MsgUnstakeProviderResponse{}, err
 }

--- a/x/pairing/keeper/msg_server_unstake_provider.go
+++ b/x/pairing/keeper/msg_server_unstake_provider.go
@@ -9,6 +9,7 @@ import (
 
 func (k msgServer) UnstakeProvider(goCtx context.Context, msg *types.MsgUnstakeProvider) (*types.MsgUnstakeProviderResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err := k.Keeper.UnstakeEntry(ctx, true, msg.ChainID, msg.Creator)
+
+	err := k.Keeper.UnstakeEntry(ctx, true, msg.ChainID, msg.Creator, " Appending new provider unstake entry (removing stake entry).")
 	return &types.MsgUnstakeProviderResponse{}, err
 }

--- a/x/pairing/keeper/stakeModify.go
+++ b/x/pairing/keeper/stakeModify.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/lavanet/lava/utils"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	"github.com/lavanet/lava/x/pairing/types"
 )
@@ -29,7 +30,8 @@ func (k Keeper) BurnClientStake(ctx sdk.Context, chainID string, clientAddressTo
 
 		if clientEntry.Stake.IsLT(k.MinStakeClient(ctx)) {
 			// if user doesn't have enough stake to stay staked, we will unstake him now
-			logger.Info("unstaking client", clientEntry.Address, "insufficient funds to stay staked", clientEntry.Stake)
+			details := map[string]string{"stake_entry": clientEntry.String()}
+			utils.LogLavaEvent(ctx, logger, types.ConsumerInsufficientFundsToStayStakedEventName, details, " insufficient funds to stay staked.")
 			// err := k.UnstakeUser(ctx, chainID, specStakeStorage.StakeStorage.StakedUsers[idx].Index, types.BlockNum{Num: 0})
 			err := k.UnstakeEntry(ctx, false, chainID, clientEntry.Address)
 			if err != nil {

--- a/x/pairing/keeper/stakeModify.go
+++ b/x/pairing/keeper/stakeModify.go
@@ -29,7 +29,7 @@ func (k Keeper) BurnClientStake(ctx sdk.Context, chainID string, clientAddressTo
 		if clientEntry.Stake.IsLT(k.MinStakeClient(ctx)) {
 			// if user doesn't have enough stake to stay staked, we will unstake him now
 			// err := k.UnstakeUser(ctx, chainID, specStakeStorage.StakeStorage.StakedUsers[idx].Index, types.BlockNum{Num: 0})
-			err := k.UnstakeEntry(ctx, false, chainID, clientEntry.Address, " insufficient funds to stay staked.")
+			err := k.UnstakeEntry(ctx, false, chainID, clientEntry.Address, types.UnstakeDescriptionInsufficientFunds)
 			if err != nil {
 				return true, fmt.Errorf("error unstaking user after burn: %v , error: %s", clientEntry, err)
 			}

--- a/x/pairing/keeper/stakeModify.go
+++ b/x/pairing/keeper/stakeModify.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/lavanet/lava/utils"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	"github.com/lavanet/lava/x/pairing/types"
 )
@@ -13,7 +12,6 @@ func (k Keeper) BurnClientStake(ctx sdk.Context, chainID string, clientAddressTo
 	if burnAmount.Denom != epochstoragetypes.TokenDenom {
 		return false, fmt.Errorf("burn coin isn't right denom: %s", burnAmount.Denom)
 	}
-	logger := k.Logger(ctx)
 	// find the user in the stake list
 	clientEntry, found, indexFound := k.epochStorageKeeper.GetStakeEntryByAddressCurrent(ctx, epochstoragetypes.ClientKey, chainID, clientAddressToBurn)
 	if found {
@@ -30,10 +28,8 @@ func (k Keeper) BurnClientStake(ctx sdk.Context, chainID string, clientAddressTo
 
 		if clientEntry.Stake.IsLT(k.MinStakeClient(ctx)) {
 			// if user doesn't have enough stake to stay staked, we will unstake him now
-			details := map[string]string{"stake_entry": clientEntry.String()}
-			utils.LogLavaEvent(ctx, logger, types.ConsumerInsufficientFundsToStayStakedEventName, details, " insufficient funds to stay staked.")
 			// err := k.UnstakeUser(ctx, chainID, specStakeStorage.StakeStorage.StakedUsers[idx].Index, types.BlockNum{Num: 0})
-			err := k.UnstakeEntry(ctx, false, chainID, clientEntry.Address)
+			err := k.UnstakeEntry(ctx, false, chainID, clientEntry.Address, " insufficient funds to stay staked.")
 			if err != nil {
 				return true, fmt.Errorf("error unstaking user after burn: %v , error: %s", clientEntry, err)
 			}

--- a/x/pairing/keeper/unstaking.go
+++ b/x/pairing/keeper/unstaking.go
@@ -52,7 +52,13 @@ func (k Keeper) UnstakeEntry(ctx sdk.Context, provider bool, chainID string, cre
 	if existingEntry.Deadline < holdBlocks {
 		existingEntry.Deadline = holdBlocks
 	}
-	details := map[string]string{"stake_entry": existingEntry.String()}
+	details := map[string]string{
+		"address":     existingEntry.GetAddress(),
+		"chainID":     existingEntry.GetChain(),
+		"geolocation": strconv.FormatUint(existingEntry.GetGeolocation(), 10),
+		"moniker":     existingEntry.GetMoniker(),
+		"stake":       existingEntry.GetStake().Amount.String(),
+	}
 	utils.LogLavaEvent(ctx, logger, types.UnstakeCommitNewEventName(provider), details, unstakeDescription)
 	return k.epochStorageKeeper.AppendUnstakeEntry(ctx, stake_type, existingEntry)
 }

--- a/x/pairing/keeper/unstaking.go
+++ b/x/pairing/keeper/unstaking.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lavanet/lava/x/pairing/types"
 )
 
-func (k Keeper) UnstakeEntry(ctx sdk.Context, provider bool, chainID string, creator string) error {
+func (k Keeper) UnstakeEntry(ctx sdk.Context, provider bool, chainID string, creator string, unstakeDescription string) error {
 	logger := k.Logger(ctx)
 	var stake_type string
 	if provider {
@@ -53,7 +53,7 @@ func (k Keeper) UnstakeEntry(ctx sdk.Context, provider bool, chainID string, cre
 		existingEntry.Deadline = holdBlocks
 	}
 	details := map[string]string{"stake_entry": existingEntry.String()}
-	utils.LogLavaEvent(ctx, logger, types.UnstakeCommitNewEventName(provider), details, " Appending new unstake entry (removing stake entry).")
+	utils.LogLavaEvent(ctx, logger, types.UnstakeCommitNewEventName(provider), details, unstakeDescription)
 	return k.epochStorageKeeper.AppendUnstakeEntry(ctx, stake_type, existingEntry)
 }
 
@@ -62,12 +62,6 @@ func (k Keeper) CheckUnstakingForCommit(ctx sdk.Context) error {
 	unstakingEntriesToCredit := k.epochStorageKeeper.PopUnstakeEntries(ctx, epochstoragetypes.ProviderKey, uint64(ctx.BlockHeight()))
 
 	if unstakingEntriesToCredit != nil {
-		details := map[string]string{"unstake_entities_type": epochstoragetypes.ProviderKey}
-		for i, unstakeEntry := range unstakingEntriesToCredit {
-			details["unstake_entry_"+strconv.Itoa(i)] = unstakeEntry.String()
-		}
-		utils.LogLavaEvent(ctx, k.Logger(ctx), types.UnstakeCommitNewEventName(true), details, " Crediting "+epochstoragetypes.ProviderKey+" unstake entries.")
-
 		err := k.creditUnstakingEntries(ctx, true, unstakingEntriesToCredit) // true for providers
 		if err != nil {
 			panic(err.Error())
@@ -76,12 +70,6 @@ func (k Keeper) CheckUnstakingForCommit(ctx sdk.Context) error {
 	// no providers entries to handle, check clients
 	unstakingEntriesToCredit = k.epochStorageKeeper.PopUnstakeEntries(ctx, epochstoragetypes.ClientKey, uint64(ctx.BlockHeight()))
 	if unstakingEntriesToCredit != nil {
-		details := map[string]string{"unstake_entities_type": epochstoragetypes.ClientKey}
-		for i, unstakeEntry := range unstakingEntriesToCredit {
-			details["unstake_entry_"+strconv.Itoa(i)] = unstakeEntry.String()
-		}
-		utils.LogLavaEvent(ctx, k.Logger(ctx), types.UnstakeCommitNewEventName(false), details, " Crediting "+epochstoragetypes.ClientKey+" unstake entries.")
-
 		err := k.creditUnstakingEntries(ctx, false, unstakingEntriesToCredit) // false for clients
 		if err != nil {
 			panic(err.Error())

--- a/x/pairing/types/types.go
+++ b/x/pairing/types/types.go
@@ -14,6 +14,13 @@ const (
 	ProviderJailedEventName                        = "provider_jailed"
 )
 
+// unstake description strings
+const (
+	UnstakeDescriptionClientUnstake     = "Client unstaked entry"
+	UnstakeDescriptionProviderUnstake   = "Provider unstaked entry"
+	UnstakeDescriptionInsufficientFunds = "client stake is below the minimum stake required"
+)
+
 func StakeNewEventName(isProvider bool) string {
 	if isProvider {
 		return ProviderStakeEventName

--- a/x/pairing/types/types.go
+++ b/x/pairing/types/types.go
@@ -8,9 +8,10 @@ const (
 	ProviderUnstakeEventName     = "provider_unstake_commit"
 	ConsumerUnstakeEventName     = "consumer_unstake_commit"
 
-	RelayPaymentEventName                      = "relay_payment"
-	UnresponsiveProviderUnstakeFailedEventName = "unresponsive_provider"
-	ProviderJailedEventName                    = "provider_jailed"
+	ConsumerInsufficientFundsToStayStakedEventName = "consumer_insufficient_funds_to_stay_staked"
+	RelayPaymentEventName                          = "relay_payment"
+	UnresponsiveProviderUnstakeFailedEventName     = "unresponsive_provider"
+	ProviderJailedEventName                        = "provider_jailed"
 )
 
 func StakeNewEventName(isProvider bool) string {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ v ] Commit message follows the Contribution Guidelines
- [ v ] Tests ran locally and added/modified if needed
- [ v ] Docs have been added/updated, if applicable
- [ v ] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)
feature - Add events messages for unstaking

* **What is the current behavior?** (You can also link to an open issue here)
The only unstake-related event is when the unstaker's money is returned to him. There are no events when the unstake is done or for when the unstake is automatic due to unresponsive provider / vote fraud

* **What is the new behavior (if this is a feature change)?**
All unstake-related scenarios have events

* **Please describe what manual tests you ran, if applicable**
There was no need to create a new test since I didn't change any functionality, only added "log" events. I've ran all the existing tests and they all passed.

* **Other information**:
