### PR TITLE
Return an error message from relay and not the placeholder

### DIFF
--- a/relayer/chainproxy/jsonRPC.go
+++ b/relayer/chainproxy/jsonRPC.go
@@ -455,9 +455,6 @@ func (nm *JrpcMessage) Send(ctx context.Context, ch chan interface{}) (relayRepl
 			return nil, "", nil, utils.LavaFormatError("Subscription failed", err, nil)
 		}
 	}
-	if replyMsg.Error != nil {
-		return reply, "", nil, utils.LavaFormatError(replyMsg.Error.Message, nil, nil)
-	}
 
 	return reply, subscriptionID, sub, err
 }

--- a/relayer/chainproxy/rpcclient/client.go
+++ b/relayer/chainproxy/rpcclient/client.go
@@ -309,11 +309,7 @@ func (c *Client) CallContext(ctx context.Context, id json.RawMessage, method str
 		return nil, err
 	}
 
-	if len(resp.Result) == 0 {
-		return nil, ErrNoResult
-	} else {
-		return resp, nil
-	}
+	return resp, nil
 }
 
 // BatchCall sends all given requests as a single batch and waits for the server
@@ -378,10 +374,7 @@ func (c *Client) BatchCallContext(ctx context.Context, b []BatchElem) error {
 			elem.Error = resp.Error
 			continue
 		}
-		if len(resp.Result) == 0 {
-			elem.Error = ErrNoResult
-			continue
-		}
+
 		elem.Error = json.Unmarshal(resp.Result, elem.Result)
 	}
 	return err

--- a/relayer/chainproxy/tendermintRPC.go
+++ b/relayer/chainproxy/tendermintRPC.go
@@ -433,9 +433,6 @@ func (nm *TendemintRpcMessage) Send(ctx context.Context, ch chan interface{}) (r
 			return nil, "", nil, utils.LavaFormatError("unknown subscriptionID type on tendermint subscribe", nil, nil)
 		}
 	}
-	if replyMsg.Error != nil {
-		return reply, "", nil, utils.LavaFormatError(replyMsg.Error.Message, nil, nil)
-	}
 
 	return reply, subscriptionID, sub, err
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Commit message follows the Contribution Guidelines
- [ ] Tests ran locally and added/modified if needed
- [ ] Docs have been added/updated, if applicable
- [ ] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
In the current implementation of our codebase, when the user sends the relay to the network using the portal and the provider and network return error message, error message will not be returned to the user but the placeholder **no result in JSON-RPC response**

These errors are not the provider's fault, so the provider should return whatever the network returns and get a reward for it

* **What is the new behavior (if this is a feature change)?**

DoD:
1. If the networks returns error message return it to the user
2. Make sure provider gets an reward for these relays

* **Please describe what manual tests you ran, if applicable**

1. Start local network 
2. Init chain commands
3. Send tendermint and json rpc call which has incorrect params
`curl -X POST -H "Content-Type: application/json"  http://127.0.0.1:3341/1 --data '{"jsonrpc":"2.0","method":"unconfirmed_txs","params":[],"id":1}'`

should return 

`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error","data":"error converting json params to arguments: expected 1 parameters ([limit]), got 0 ([])"}}`

and 

`curl -X POST -H "Content-Type: application/json"  http://127.0.0.1:3333/1 --data '{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":[],"id":1}'`

should return 

`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"missing value for required argument 0"}}`

4. Make sure that providers got an reward for these relays
