### PR TITLE
Prt 236 performance provider consumer using the connector go always pass 1 connector instead of a flag need to test how this impacts our parallel sessions

### DIFF
--- a/cmd/lavad/main.go
+++ b/cmd/lavad/main.go
@@ -199,7 +199,7 @@ func main() {
 	cmdPortalServer.Flags().String(performance.PprofAddressFlagName, "", "pprof server address, used for code profiling")
 	cmdPortalServer.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
 	cmdServer.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
-	cmdServer.Flags().Uint(chainproxy.ParallelConnectionsFlag, 10, "parallel connections")
+	cmdServer.Flags().Uint(chainproxy.ParallelConnectionsFlag, chainproxy.DefaultNumberOfParallelConnections, "parallel connections")
 
 	rootCmd.AddCommand(cmdServer)
 	rootCmd.AddCommand(cmdPortalServer)

--- a/cmd/lavad/main.go
+++ b/cmd/lavad/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ignite-hq/cli/ignite/pkg/cosmoscmd"
 	"github.com/lavanet/lava/app"
 	"github.com/lavanet/lava/relayer"
+	"github.com/lavanet/lava/relayer/chainproxy"
 	"github.com/lavanet/lava/relayer/performance"
 	"github.com/lavanet/lava/relayer/sentry"
 	"github.com/lavanet/lava/utils"
@@ -198,6 +199,8 @@ func main() {
 	cmdPortalServer.Flags().String(performance.PprofAddressFlagName, "", "pprof server address, used for code profiling")
 	cmdPortalServer.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
 	cmdServer.Flags().String(performance.CacheFlagName, "", "address for a cache server to improve performance")
+	cmdServer.Flags().Uint(chainproxy.ParallelConnectionsFlag, 10, "parallel connections")
+
 	rootCmd.AddCommand(cmdServer)
 	rootCmd.AddCommand(cmdPortalServer)
 	rootCmd.AddCommand(cmdTestClient)

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
+	github.com/golang/glog v1.0.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,8 @@ github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -778,6 +780,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=

--- a/relayer/chainproxy/connector.go
+++ b/relayer/chainproxy/connector.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strconv"
 	"sync"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 const DialTimeout = 500 * time.Millisecond
 const ParallelConnectionsFlag = "parallel-connections"
 const DefaultNumberOfParallelConnections = 10
+const MaximumNumberOfParallelConnectionsAttempts = 10
 
 type Connector struct {
 	lock        utils.LavaMutex
@@ -36,7 +38,15 @@ func NewConnector(ctx context.Context, nConns uint, addr string) *Connector {
 	for i := uint(0); i < nConns; i++ {
 		var rpcClient *rpcclient.Client
 		var err error
+		numberOfConnectionAttempts := 0
 		for {
+			numberOfConnectionAttempts += 1
+			if numberOfConnectionAttempts > MaximumNumberOfParallelConnectionsAttempts {
+				utils.LavaFormatFatal("Reached maximum number of parallel connections attempts, consider decreasing number of connections",
+					nil,
+					&map[string]string{"Number of parallel connections": strconv.FormatUint(uint64(nConns), 10)},
+				)
+			}
 			if ctx.Err() != nil {
 				connector.Close()
 				return nil
@@ -44,7 +54,12 @@ func NewConnector(ctx context.Context, nConns uint, addr string) *Connector {
 			nctx, cancel := context.WithTimeout(ctx, DialTimeout)
 			rpcClient, err = rpcclient.DialContext(nctx, addr)
 			if err != nil {
-				utils.LavaFormatError("Could not connect to the client, retrying", err, nil)
+				utils.LavaFormatWarning("Could not connect to the node, retrying",
+					err,
+					&map[string]string{
+						"Current Number Of Connections": strconv.FormatUint(uint64(i), 10),
+						"Number Of Attempts Remaining":  strconv.Itoa(numberOfConnectionAttempts),
+					})
 				cancel()
 				continue
 			}
@@ -53,7 +68,7 @@ func NewConnector(ctx context.Context, nConns uint, addr string) *Connector {
 		}
 		connector.freeClients = append(connector.freeClients, rpcClient)
 	}
-
+	utils.LavaFormatInfo("Number of parallel connections created: "+strconv.Itoa(len(connector.freeClients)), nil)
 	go connector.connectorLoop(ctx)
 	return connector
 }
@@ -132,7 +147,15 @@ func NewGRPCConnector(ctx context.Context, nConns uint, addr string) *GRPCConnec
 	for i := uint(0); i < nConns; i++ {
 		var grpcClient *grpc.ClientConn
 		var err error
+		numberOfConnectionAttempts := 0
 		for {
+			numberOfConnectionAttempts += 1
+			if numberOfConnectionAttempts > MaximumNumberOfParallelConnectionsAttempts {
+				utils.LavaFormatFatal("Reached maximum number of parallel connections attempts, consider decreasing number of connections",
+					nil,
+					&map[string]string{"Number of parallel connections": strconv.FormatUint(uint64(nConns), 10)},
+				)
+			}
 			if ctx.Err() != nil {
 				connector.Close()
 				return nil
@@ -140,7 +163,7 @@ func NewGRPCConnector(ctx context.Context, nConns uint, addr string) *GRPCConnec
 			nctx, cancel := context.WithTimeout(ctx, DialTimeout)
 			grpcClient, err = grpc.DialContext(nctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				utils.LavaFormatError("Could not connect to the client, retrying", err, nil)
+				utils.LavaFormatWarning("Could not connect to the client, retrying", err, nil)
 				cancel()
 				continue
 			}

--- a/relayer/chainproxy/connector.go
+++ b/relayer/chainproxy/connector.go
@@ -19,10 +19,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const DialTimeout = 500 * time.Millisecond
-const ParallelConnectionsFlag = "parallel-connections"
-const DefaultNumberOfParallelConnections = 10
-const MaximumNumberOfParallelConnectionsAttempts = 10
+const (
+	DialTimeout                                = 500 * time.Millisecond
+	ParallelConnectionsFlag                    = "parallel-connections"
+	DefaultNumberOfParallelConnections         = 10
+	MaximumNumberOfParallelConnectionsAttempts = 10
+)
 
 type Connector struct {
 	lock        utils.LavaMutex

--- a/relayer/chainproxy/connector.go
+++ b/relayer/chainproxy/connector.go
@@ -20,6 +20,7 @@ import (
 
 const DialTimeout = 500 * time.Millisecond
 const ParallelConnectionsFlag = "parallel-connections"
+const DefaultNumberOfParallelConnections = 10
 
 type Connector struct {
 	lock        utils.LavaMutex

--- a/relayer/chainproxy/connector.go
+++ b/relayer/chainproxy/connector.go
@@ -19,6 +19,7 @@ import (
 )
 
 const DialTimeout = 500 * time.Millisecond
+const ParallelConnectionsFlag = "parallel-connections"
 
 type Connector struct {
 	lock        utils.LavaMutex

--- a/relayer/server.go
+++ b/relayer/server.go
@@ -1218,7 +1218,12 @@ func Server(
 	if err != nil {
 		utils.LavaFormatFatal("provider failure to NewPortalLogs", err, &map[string]string{"apiInterface": apiInterface, "ChainID": chainID})
 	}
-	chainProxy, err := chainproxy.GetChainProxy(nodeUrl, 1, newSentry, pLogs)
+	numberOfNodeParallelConnections, err := flagSet.GetUint(chainproxy.ParallelConnectionsFlag)
+	if err != nil {
+		utils.LavaFormatFatal("error fetching chainproxy.ParallelConnectionsFlag", err, nil)
+	}
+
+	chainProxy, err := chainproxy.GetChainProxy(nodeUrl, numberOfNodeParallelConnections, newSentry, pLogs)
 	if err != nil {
 		utils.LavaFormatFatal("provider failure to GetChainProxy", err, &map[string]string{"apiInterface": apiInterface, "ChainID": chainID})
 	}

--- a/relayer/test_client.go
+++ b/relayer/test_client.go
@@ -46,7 +46,7 @@ func TestClient(
 
 	//
 	// Node
-	chainProxy, err := chainproxy.GetChainProxy("", 1, sentry, nil)
+	chainProxy, err := chainproxy.GetChainProxy("", 10, sentry, nil)
 	if err != nil {
 		log.Fatalln("error: GetChainProxy", err)
 	}

--- a/relayer/test_client.go
+++ b/relayer/test_client.go
@@ -46,7 +46,7 @@ func TestClient(
 
 	//
 	// Node
-	chainProxy, err := chainproxy.GetChainProxy("", 10, sentry, nil)
+	chainProxy, err := chainproxy.GetChainProxy("", chainproxy.DefaultNumberOfParallelConnections, sentry, nil)
 	if err != nil {
 		log.Fatalln("error: GetChainProxy", err)
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit message follows the Contribution Guidelines
- [x] Tests ran locally and added/modified if needed
- [x] Docs have been added/updated, if applicable
- [x] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)
Adding multiple connections from the provider process to the node to support more parallel requests. 

* **What is the current behavior?** (You can also link to an open issue here)
Currently its hardcoded to 1 connection always 

* **What is the new behavior (if this is a feature change)?**
added a flag to control how many connections in parallel will be open, default number of connections are 10. also added a protector from hanging for ever in connection attempts. 

* **Please describe what manual tests you ran, if applicable**
standard pairing test and stress test. performance increased X3 

* **Other information**:
