### PR TITLE
PRT-273 when we have 0 providers left in pairing un block all providers and retry

### DIFF
--- a/relayer/lavasession/consumer_session_manager.go
+++ b/relayer/lavasession/consumer_session_manager.go
@@ -93,15 +93,13 @@ func (csm *ConsumerSessionManager) shouldResetValidAddresses() (reset bool, numb
 }
 
 // reset the valid addresses list and increase numberOfResets
-func (csm *ConsumerSessionManager) resetValidAddresses(numberOfResets uint64) uint64 {
+func (csm *ConsumerSessionManager) resetValidAddresses() uint64 {
 	csm.lock.Lock() // lock write
 	defer csm.lock.Unlock()
 	if len(csm.validAddresses) == 0 { // re verify it didn't change while waiting for lock.
 		utils.LavaFormatWarning("Provider pairing list is empty, resetting state.", nil, nil)
 		csm.setValidAddressesToDefaultValue()
 		csm.numberOfResets += 1
-		numberOfResets = csm.numberOfResets // update numberOfResets with the new value
-		return numberOfResets
 	}
 	// if len(csm.validAddresses) != 0 meaning we had a reset (or an epoch change), so we need to return the numberOfResets which is currently in csm
 	return csm.numberOfResets
@@ -111,7 +109,7 @@ func (csm *ConsumerSessionManager) resetValidAddresses(numberOfResets uint64) ui
 func (csm *ConsumerSessionManager) validatePairingListNotEmpty() uint64 {
 	reset, numberOfResets := csm.shouldResetValidAddresses()
 	if reset {
-		numberOfResets = csm.resetValidAddresses(numberOfResets)
+		numberOfResets = csm.resetValidAddresses()
 	}
 	return numberOfResets
 }

--- a/relayer/lavasession/consumer_session_manager_test.go
+++ b/relayer/lavasession/consumer_session_manager_test.go
@@ -106,6 +106,35 @@ func TestPairingReset(t *testing.T) {
 	require.Equal(t, cs.LatestBlock, servicedBlockNumber)
 }
 
+func TestPairingResetWithFailures(t *testing.T) {
+	s := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.
+	defer s.Stop()           // stop the server when finished.
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList()
+	err := csm.UpdateAllProviders(ctx, firstEpochHeight, pairingList) // update the providers.
+	require.Nil(t, err)
+	for {
+		fmt.Printf("%v", len(csm.validAddresses))
+		cs, _, _, _, err := csm.GetSession(ctx, cuForFirstRequest, nil) // get a session
+		if err != nil {
+			if len(csm.validAddresses) == 0 { // wait for all pairings to be blocked.
+				break
+			}
+			require.True(t, false) // fail test.
+		}
+		err = csm.OnSessionFailure(cs, nil)
+
+	}
+	require.Equal(t, len(csm.validAddresses), 0)
+	cs, epoch, _, _, err := csm.GetSession(ctx, cuForFirstRequest, nil) // get a session
+	require.Nil(t, err)
+	require.Equal(t, len(csm.validAddresses), len(csm.pairingAddresses))
+	require.NotNil(t, cs)
+	require.Equal(t, epoch, csm.currentEpoch)
+	require.Equal(t, cs.LatestRelayCu, uint64(cuForFirstRequest))
+}
+
 // Test the basic functionality of the consumerSessionManager
 func TestSuccessAndFailureOfSessionWithUpdatePairingsInTheMiddle(t *testing.T) {
 	s := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.

--- a/relayer/lavasession/consumer_session_manager_test.go
+++ b/relayer/lavasession/consumer_session_manager_test.go
@@ -104,6 +104,7 @@ func TestPairingReset(t *testing.T) {
 	require.Equal(t, cs.LatestRelayCu, latestRelayCuAfterDone)
 	require.Equal(t, cs.RelayNum, relayNumberAfterFirstCall)
 	require.Equal(t, cs.LatestBlock, servicedBlockNumber)
+	require.Equal(t, csm.numberOfResets, uint64(0x1)) // verify we had one reset only
 }
 
 func TestPairingResetWithFailures(t *testing.T) {
@@ -133,6 +134,7 @@ func TestPairingResetWithFailures(t *testing.T) {
 	require.NotNil(t, cs)
 	require.Equal(t, epoch, csm.currentEpoch)
 	require.Equal(t, cs.LatestRelayCu, uint64(cuForFirstRequest))
+	require.Equal(t, csm.numberOfResets, uint64(0x1)) // verify we had one reset only
 }
 
 // Test the basic functionality of the consumerSessionManager

--- a/relayer/lavasession/consumer_session_manager_test.go
+++ b/relayer/lavasession/consumer_session_manager_test.go
@@ -83,6 +83,29 @@ func TestHappyFlow(t *testing.T) {
 	require.Equal(t, cs.LatestBlock, servicedBlockNumber)
 }
 
+func TestPairingReset(t *testing.T) {
+	s := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.
+	defer s.Stop()           // stop the server when finished.
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList()
+	err := csm.UpdateAllProviders(ctx, firstEpochHeight, pairingList) // update the providers.
+	require.Nil(t, err)
+	csm.validAddresses = []string{}                                     // set valid addresses to zero
+	cs, epoch, _, _, err := csm.GetSession(ctx, cuForFirstRequest, nil) // get a session
+	require.Nil(t, err)
+	require.Equal(t, len(csm.validAddresses), len(csm.pairingAddresses))
+	require.NotNil(t, cs)
+	require.Equal(t, epoch, csm.currentEpoch)
+	require.Equal(t, cs.LatestRelayCu, uint64(cuForFirstRequest))
+	err = csm.OnSessionDone(cs, firstEpochHeight, servicedBlockNumber, cuForFirstRequest, time.Duration(time.Millisecond), (servicedBlockNumber - 1), numberOfProviders, numberOfProviders)
+	require.Nil(t, err)
+	require.Equal(t, cs.CuSum, cuForFirstRequest)
+	require.Equal(t, cs.LatestRelayCu, latestRelayCuAfterDone)
+	require.Equal(t, cs.RelayNum, relayNumberAfterFirstCall)
+	require.Equal(t, cs.LatestBlock, servicedBlockNumber)
+}
+
 // Test the basic functionality of the consumerSessionManager
 func TestSuccessAndFailureOfSessionWithUpdatePairingsInTheMiddle(t *testing.T) {
 	s := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.

--- a/relayer/lavasession/consumer_session_manager_test.go
+++ b/relayer/lavasession/consumer_session_manager_test.go
@@ -18,6 +18,7 @@ import (
 const (
 	parallelGoRoutines                 = 40
 	numberOfProviders                  = 10
+	numberOfResetsToTest               = 10
 	numberOfAllowedSessionsPerConsumer = 10
 	firstEpochHeight                   = 20
 	secondEpochHeight                  = 40
@@ -135,6 +136,38 @@ func TestPairingResetWithFailures(t *testing.T) {
 	require.Equal(t, epoch, csm.currentEpoch)
 	require.Equal(t, cs.LatestRelayCu, uint64(cuForFirstRequest))
 	require.Equal(t, csm.numberOfResets, uint64(0x1)) // verify we had one reset only
+}
+
+func TestPairingResetWithMultipleFailures(t *testing.T) {
+	s := createGRPCServer(t) // create a grpcServer so we can connect to its endpoint and validate everything works.
+	defer s.Stop()           // stop the server when finished.
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	pairingList := createPairingList()
+	err := csm.UpdateAllProviders(ctx, firstEpochHeight, pairingList) // update the providers.
+	require.Nil(t, err)
+	for numberOfResets := 0; numberOfResets < numberOfResetsToTest; numberOfResets++ {
+		for {
+			fmt.Printf("%v", len(csm.validAddresses))
+			cs, _, _, _, err := csm.GetSession(ctx, cuForFirstRequest, nil) // get a session
+			if err != nil {
+				if len(csm.validAddresses) == 0 { // wait for all pairings to be blocked.
+					break
+				}
+				require.True(t, false) // fail test.
+			}
+			err = csm.OnSessionFailure(cs, nil)
+		}
+		require.Equal(t, len(csm.validAddresses), 0)
+		cs, epoch, _, _, err := csm.GetSession(ctx, cuForFirstRequest, nil) // get a session
+		require.Nil(t, err)
+		require.Equal(t, len(csm.validAddresses), len(csm.pairingAddresses))
+		require.NotNil(t, cs)
+		require.Equal(t, epoch, csm.currentEpoch)
+		require.Equal(t, cs.LatestRelayCu, uint64(cuForFirstRequest))
+		require.Equal(t, csm.numberOfResets, uint64(numberOfResets+1)) // verify we had one reset only
+	}
+
 }
 
 // Test the basic functionality of the consumerSessionManager

--- a/relayer/lavasession/consumer_types.go
+++ b/relayer/lavasession/consumer_types.go
@@ -149,10 +149,11 @@ func (cswp *ConsumerSessionsWithProvider) connectRawClientWithTimeout(ctx contex
 	return &c, nil
 }
 
-func (cswp *ConsumerSessionsWithProvider) getConsumerSessionInstanceFromEndpoint(endpoint *Endpoint, maximumBlockedSessionsMultiplier uint64) (singleConsumerSession *SingleConsumerSession, pairingEpoch uint64, err error) {
+func (cswp *ConsumerSessionsWithProvider) getConsumerSessionInstanceFromEndpoint(endpoint *Endpoint, numberOfResets uint64) (singleConsumerSession *SingleConsumerSession, pairingEpoch uint64, err error) {
 	// TODO: validate that the endpoint even belongs to the ConsumerSessionsWithProvider and is enabled.
 
-	maximumBlockedSessionsAllowed := MaxAllowedBlockListedSessionPerProvider * (maximumBlockedSessionsMultiplier + 1) // +1 as we start from 0
+	// Multiply numberOfReset +1 by MaxAllowedBlockListedSessionPerProvider as every reset needs to allow more blocked sessions allowed.
+	maximumBlockedSessionsAllowed := MaxAllowedBlockListedSessionPerProvider * (numberOfResets + 1) // +1 as we start from 0
 	cswp.Lock.Lock()
 	defer cswp.Lock.Unlock()
 

--- a/relayer/lavasession/consumer_types.go
+++ b/relayer/lavasession/consumer_types.go
@@ -149,14 +149,15 @@ func (cswp *ConsumerSessionsWithProvider) connectRawClientWithTimeout(ctx contex
 	return &c, nil
 }
 
-func (cswp *ConsumerSessionsWithProvider) getConsumerSessionInstanceFromEndpoint(endpoint *Endpoint) (singleConsumerSession *SingleConsumerSession, pairingEpoch uint64, err error) {
+func (cswp *ConsumerSessionsWithProvider) getConsumerSessionInstanceFromEndpoint(endpoint *Endpoint, maximumBlockedSessionsMultiplier uint64) (singleConsumerSession *SingleConsumerSession, pairingEpoch uint64, err error) {
 	// TODO: validate that the endpoint even belongs to the ConsumerSessionsWithProvider and is enabled.
 
+	maximumBlockedSessionsAllowed := MaxAllowedBlockListedSessionPerProvider * (maximumBlockedSessionsMultiplier + 1) // +1 as we start from 0
 	cswp.Lock.Lock()
 	defer cswp.Lock.Unlock()
 
 	// try to lock an existing session, if can't create a new one
-	numberOfBlockedSessions := 0
+	var numberOfBlockedSessions uint64 = 0
 	for sessionID, session := range cswp.Sessions {
 		if sessionID == DataReliabilitySessionId {
 			continue // we cant use the data reliability session. which is located at key DataReliabilitySessionId
@@ -165,7 +166,7 @@ func (cswp *ConsumerSessionsWithProvider) getConsumerSessionInstanceFromEndpoint
 			// skip sessions that don't belong to the active connection
 			continue
 		}
-		if numberOfBlockedSessions >= MaxAllowedBlockListedSessionPerProvider {
+		if numberOfBlockedSessions >= maximumBlockedSessionsAllowed {
 			return nil, 0, MaximumNumberOfBlockListedSessionsError
 		}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit message follows the Contribution Guidelines
- [x] Tests ran locally and added/modified if needed
- [x] Docs have been added/updated, if applicable
- [x] If applicable - JIRA ticket ID was added

* **What kind of change does this PR introduce?** (Bug fix, feature, unit tests, docs update, ...)
Adding support for multiple no pairings resets. (after no pairings are available we try to go over the pairing list again)

* **What is the current behavior?** (You can also link to an open issue here)
currently, we reach a point where there is an issue and we ban the provider for the remaining of the epoch, this can result in many idle epochs waiting for an epoch to change to get a different pairing list. 

* **What is the new behavior (if this is a feature change)?**
after the entire provider list is blocked, we reset them and try again, instead of waiting for the remaining of the epoch. 

* **Please describe what manual tests you ran, if applicable**
added unit tests to stress test the system 

* **Other information**:
