### PR TITLE
Cns 266 remove core.block and use instead blockhash that is saved in storage

### DIFF
--- a/cookbook/spec_add_arbitrum.json
+++ b/cookbook/spec_add_arbitrum.json
@@ -1305,6 +1305,14 @@
                 "blocks_in_finalization_proof": 3,
                 "average_block_time": "500",
                 "allowed_block_lag_for_qos_sync": "20",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "rpc_modules",

--- a/cookbook/spec_add_cosmoshub.json
+++ b/cookbook/spec_add_cosmoshub.json
@@ -5797,6 +5797,14 @@
                 "blocks_in_finalization_proof": 1,
                 "average_block_time": "6500",
                 "allowed_block_lag_for_qos_sync": "10",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "abci_info",

--- a/cookbook/spec_add_fantom.json
+++ b/cookbook/spec_add_fantom.json
@@ -1613,6 +1613,14 @@
                 "blocks_in_finalization_proof": 1,
                 "average_block_time": "1500",
                 "allowed_block_lag_for_qos_sync": "5",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "web3_clientVersion",

--- a/cookbook/spec_add_juno.json
+++ b/cookbook/spec_add_juno.json
@@ -6565,6 +6565,14 @@
                 "blocks_in_finalization_proof": 1,
                 "average_block_time": "6500",
                 "allowed_block_lag_for_qos_sync": "2",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "abci_info",

--- a/cookbook/spec_add_osmosis.json
+++ b/cookbook/spec_add_osmosis.json
@@ -9565,6 +9565,14 @@
                 "blocks_in_finalization_proof": 1,
                 "average_block_time": "6500",
                 "allowed_block_lag_for_qos_sync": "3",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "abci_info",

--- a/cookbook/spec_add_polygon.json
+++ b/cookbook/spec_add_polygon.json
@@ -1401,6 +1401,14 @@
                 "blocks_in_finalization_proof": 3,
                 "average_block_time": "2000",
                 "allowed_block_lag_for_qos_sync": "30",
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "1000"
+                },
+                "min_stake_client": {
+                    "denom": "ulava",
+                    "amount": "100"
+                },
                 "apis": [
                     {
                         "name": "rpc_modules",

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -30145,33 +30145,10 @@ paths:
                   properties:
                     index:
                       type: string
-                    clientsPayments:
+                    providerPaymentStorageKeys:
                       type: array
                       items:
-                        type: object
-                        properties:
-                          index:
-                            type: string
-                          uniquePaymentStorageClientProvider:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                index:
-                                  type: string
-                                block:
-                                  type: string
-                                  format: uint64
-                                usedCU:
-                                  type: string
-                                  format: uint64
-                          epoch:
-                            type: string
-                            format: uint64
-                          unresponsiveness_complaints:
-                            type: array
-                            items:
-                              type: string
+                        type: string
               pagination:
                 type: object
                 properties:
@@ -30291,33 +30268,10 @@ paths:
                 properties:
                   index:
                     type: string
-                  clientsPayments:
+                  providerPaymentStorageKeys:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        index:
-                          type: string
-                        uniquePaymentStorageClientProvider:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              index:
-                                type: string
-                              block:
-                                type: string
-                                format: uint64
-                              usedCU:
-                                type: string
-                                format: uint64
-                        epoch:
-                          type: string
-                          format: uint64
-                        unresponsiveness_complaints:
-                          type: array
-                          items:
-                            type: string
+                      type: string
         default:
           description: An unexpected error response.
           schema:
@@ -30519,23 +30473,14 @@ paths:
                   properties:
                     index:
                       type: string
-                    uniquePaymentStorageClientProvider:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          index:
-                            type: string
-                          block:
-                            type: string
-                            format: uint64
-                          usedCU:
-                            type: string
-                            format: uint64
                     epoch:
                       type: string
                       format: uint64
                     unresponsiveness_complaints:
+                      type: array
+                      items:
+                        type: string
+                    uniquePaymentStorageClientProviderKeys:
                       type: array
                       items:
                         type: string
@@ -30658,23 +30603,14 @@ paths:
                 properties:
                   index:
                     type: string
-                  uniquePaymentStorageClientProvider:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        index:
-                          type: string
-                        block:
-                          type: string
-                          format: uint64
-                        usedCU:
-                          type: string
-                          format: uint64
                   epoch:
                     type: string
                     format: uint64
                   unresponsiveness_complaints:
+                    type: array
+                    items:
+                      type: string
+                  uniquePaymentStorageClientProviderKeys:
                     type: array
                     items:
                       type: string
@@ -31237,10 +31173,19 @@ paths:
           schema:
             type: object
             properties:
-              chainNames:
+              chainInfoList:
                 type: array
                 items:
-                  type: string
+                  type: object
+                  properties:
+                    chainName:
+                      type: string
+                    chainID:
+                      type: string
+                    enabledApiInterfaces:
+                      type: array
+                      items:
+                        type: string
         default:
           description: An unexpected error response.
           schema:
@@ -31354,16 +31299,17 @@ paths:
                                   - PARSE_CANONICAL
                                   - PARSE_DICTIONARY
                                   - PARSE_DICTIONARY_OR_ORDERED
+                                  - PARSE_DICTIONARY_OR_DEFAULT
                                   - DEFAULT
                                 default: EMPTY
                                 title: >-
                                   - PARSE_BY_ARG: means parameters are ordered
-                                  and flat expected areguments are: [param
-                                  index] (example: PARAMS:
-                                  [<#BlockNum>,"banana"])
-                                   - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                                   - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                                  and flat expected arguments are: [param index]
+                                  (example: PARAMS: [<#BlockNum>,"banana"])
+                                   - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                   - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                                    - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                   - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                                    - DEFAULT: means parameters are non related to block, and should fetch latest block
                           compute_units:
                             type: string
@@ -31394,6 +31340,34 @@ paths:
                                     stateful:
                                       type: integer
                                       format: int64
+                                overwrite_block_parsing:
+                                  type: object
+                                  properties:
+                                    parser_arg:
+                                      type: array
+                                      items:
+                                        type: string
+                                    parser_func:
+                                      type: string
+                                      enum:
+                                        - EMPTY
+                                        - PARSE_BY_ARG
+                                        - PARSE_CANONICAL
+                                        - PARSE_DICTIONARY
+                                        - PARSE_DICTIONARY_OR_ORDERED
+                                        - PARSE_DICTIONARY_OR_DEFAULT
+                                        - DEFAULT
+                                      default: EMPTY
+                                      title: >-
+                                        - PARSE_BY_ARG: means parameters are
+                                        ordered and flat expected arguments are:
+                                        [param index] (example: PARAMS:
+                                        [<#BlockNum>,"banana"])
+                                         - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                         - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                                         - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                         - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                                         - DEFAULT: means parameters are non related to block, and should fetch latest block
                           reserved:
                             type: object
                             properties:
@@ -31428,16 +31402,18 @@ paths:
                                       - PARSE_CANONICAL
                                       - PARSE_DICTIONARY
                                       - PARSE_DICTIONARY_OR_ORDERED
+                                      - PARSE_DICTIONARY_OR_DEFAULT
                                       - DEFAULT
                                     default: EMPTY
                                     title: >-
                                       - PARSE_BY_ARG: means parameters are
-                                      ordered and flat expected areguments are:
+                                      ordered and flat expected arguments are:
                                       [param index] (example: PARAMS:
                                       [<#BlockNum>,"banana"])
-                                       - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                                       - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                                       - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                       - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                                        - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                       - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                                        - DEFAULT: means parameters are non related to block, and should fetch latest block
                     enabled:
                       type: boolean
@@ -31640,15 +31616,17 @@ paths:
                                 - PARSE_CANONICAL
                                 - PARSE_DICTIONARY
                                 - PARSE_DICTIONARY_OR_ORDERED
+                                - PARSE_DICTIONARY_OR_DEFAULT
                                 - DEFAULT
                               default: EMPTY
                               title: >-
                                 - PARSE_BY_ARG: means parameters are ordered and
-                                flat expected areguments are: [param index]
+                                flat expected arguments are: [param index]
                                 (example: PARAMS: [<#BlockNum>,"banana"])
-                                 - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                                 - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                                 - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                 - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                                  - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                 - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                                  - DEFAULT: means parameters are non related to block, and should fetch latest block
                         compute_units:
                           type: string
@@ -31679,6 +31657,34 @@ paths:
                                   stateful:
                                     type: integer
                                     format: int64
+                              overwrite_block_parsing:
+                                type: object
+                                properties:
+                                  parser_arg:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parser_func:
+                                    type: string
+                                    enum:
+                                      - EMPTY
+                                      - PARSE_BY_ARG
+                                      - PARSE_CANONICAL
+                                      - PARSE_DICTIONARY
+                                      - PARSE_DICTIONARY_OR_ORDERED
+                                      - PARSE_DICTIONARY_OR_DEFAULT
+                                      - DEFAULT
+                                    default: EMPTY
+                                    title: >-
+                                      - PARSE_BY_ARG: means parameters are
+                                      ordered and flat expected arguments are:
+                                      [param index] (example: PARAMS:
+                                      [<#BlockNum>,"banana"])
+                                       - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                       - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                                       - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                       - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                                       - DEFAULT: means parameters are non related to block, and should fetch latest block
                         reserved:
                           type: object
                           properties:
@@ -31713,16 +31719,18 @@ paths:
                                     - PARSE_CANONICAL
                                     - PARSE_DICTIONARY
                                     - PARSE_DICTIONARY_OR_ORDERED
+                                    - PARSE_DICTIONARY_OR_DEFAULT
                                     - DEFAULT
                                   default: EMPTY
                                   title: >-
                                     - PARSE_BY_ARG: means parameters are ordered
-                                    and flat expected areguments are: [param
+                                    and flat expected arguments are: [param
                                     index] (example: PARAMS:
                                     [<#BlockNum>,"banana"])
-                                     - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                                     - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                                     - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                     - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                                      - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                     - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                                      - DEFAULT: means parameters are non related to block, and should fetch latest block
                   enabled:
                     type: boolean
@@ -53550,33 +53558,10 @@ definitions:
     properties:
       index:
         type: string
-      clientsPayments:
+      providerPaymentStorageKeys:
         type: array
         items:
-          type: object
-          properties:
-            index:
-              type: string
-            uniquePaymentStorageClientProvider:
-              type: array
-              items:
-                type: object
-                properties:
-                  index:
-                    type: string
-                  block:
-                    type: string
-                    format: uint64
-                  usedCU:
-                    type: string
-                    format: uint64
-            epoch:
-              type: string
-              format: uint64
-            unresponsiveness_complaints:
-              type: array
-              items:
-                type: string
+          type: string
   lavanet.lava.pairing.MsgRelayPaymentResponse:
     type: object
   lavanet.lava.pairing.MsgStakeClientResponse:
@@ -53621,23 +53606,14 @@ definitions:
     properties:
       index:
         type: string
-      uniquePaymentStorageClientProvider:
-        type: array
-        items:
-          type: object
-          properties:
-            index:
-              type: string
-            block:
-              type: string
-              format: uint64
-            usedCU:
-              type: string
-              format: uint64
       epoch:
         type: string
         format: uint64
       unresponsiveness_complaints:
+        type: array
+        items:
+          type: string
+      uniquePaymentStorageClientProviderKeys:
         type: array
         items:
           type: string
@@ -53651,33 +53627,10 @@ definitions:
           properties:
             index:
               type: string
-            clientsPayments:
+            providerPaymentStorageKeys:
               type: array
               items:
-                type: object
-                properties:
-                  index:
-                    type: string
-                  uniquePaymentStorageClientProvider:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        index:
-                          type: string
-                        block:
-                          type: string
-                          format: uint64
-                        usedCU:
-                          type: string
-                          format: uint64
-                  epoch:
-                    type: string
-                    format: uint64
-                  unresponsiveness_complaints:
-                    type: array
-                    items:
-                      type: string
+                type: string
       pagination:
         type: object
         properties:
@@ -53713,23 +53666,14 @@ definitions:
           properties:
             index:
               type: string
-            uniquePaymentStorageClientProvider:
-              type: array
-              items:
-                type: object
-                properties:
-                  index:
-                    type: string
-                  block:
-                    type: string
-                    format: uint64
-                  usedCU:
-                    type: string
-                    format: uint64
             epoch:
               type: string
               format: uint64
             unresponsiveness_complaints:
+              type: array
+              items:
+                type: string
+            uniquePaymentStorageClientProviderKeys:
               type: array
               items:
                 type: string
@@ -53858,33 +53802,10 @@ definitions:
         properties:
           index:
             type: string
-          clientsPayments:
+          providerPaymentStorageKeys:
             type: array
             items:
-              type: object
-              properties:
-                index:
-                  type: string
-                uniquePaymentStorageClientProvider:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      index:
-                        type: string
-                      block:
-                        type: string
-                        format: uint64
-                      usedCU:
-                        type: string
-                        format: uint64
-                epoch:
-                  type: string
-                  format: uint64
-                unresponsiveness_complaints:
-                  type: array
-                  items:
-                    type: string
+              type: string
   lavanet.lava.pairing.QueryGetPairingResponse:
     type: object
     properties:
@@ -53954,23 +53875,14 @@ definitions:
         properties:
           index:
             type: string
-          uniquePaymentStorageClientProvider:
-            type: array
-            items:
-              type: object
-              properties:
-                index:
-                  type: string
-                block:
-                  type: string
-                  format: uint64
-                usedCU:
-                  type: string
-                  format: uint64
           epoch:
             type: string
             format: uint64
           unresponsiveness_complaints:
+            type: array
+            items:
+              type: string
+          uniquePaymentStorageClientProviderKeys:
             type: array
             items:
               type: string
@@ -54212,6 +54124,33 @@ definitions:
           stateful:
             type: integer
             format: int64
+      overwrite_block_parsing:
+        type: object
+        properties:
+          parser_arg:
+            type: array
+            items:
+              type: string
+          parser_func:
+            type: string
+            enum:
+              - EMPTY
+              - PARSE_BY_ARG
+              - PARSE_CANONICAL
+              - PARSE_DICTIONARY
+              - PARSE_DICTIONARY_OR_ORDERED
+              - PARSE_DICTIONARY_OR_DEFAULT
+              - DEFAULT
+            default: EMPTY
+            title: >-
+              - PARSE_BY_ARG: means parameters are ordered and flat expected
+              arguments are: [param index] (example: PARAMS:
+              [<#BlockNum>,"banana"])
+               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+               - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+               - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+               - DEFAULT: means parameters are non related to block, and should fetch latest block
   lavanet.lava.spec.BlockParser:
     type: object
     properties:
@@ -54227,15 +54166,16 @@ definitions:
           - PARSE_CANONICAL
           - PARSE_DICTIONARY
           - PARSE_DICTIONARY_OR_ORDERED
+          - PARSE_DICTIONARY_OR_DEFAULT
           - DEFAULT
         default: EMPTY
         title: >-
           - PARSE_BY_ARG: means parameters are ordered and flat expected
-          areguments are: [param index] (example: PARAMS:
-          [<#BlockNum>,"banana"])
-           - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-           - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+          arguments are: [param index] (example: PARAMS: [<#BlockNum>,"banana"])
+           - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+           - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
            - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+           - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
            - DEFAULT: means parameters are non related to block, and should fetch latest block
   lavanet.lava.spec.PARSER_FUNC:
     type: string
@@ -54245,14 +54185,16 @@ definitions:
       - PARSE_CANONICAL
       - PARSE_DICTIONARY
       - PARSE_DICTIONARY_OR_ORDERED
+      - PARSE_DICTIONARY_OR_DEFAULT
       - DEFAULT
     default: EMPTY
     title: >-
-      - PARSE_BY_ARG: means parameters are ordered and flat expected areguments
+      - PARSE_BY_ARG: means parameters are ordered and flat expected arguments
       are: [param index] (example: PARAMS: [<#BlockNum>,"banana"])
-       - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-       - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+       - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+       - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
        - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+       - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
        - DEFAULT: means parameters are non related to block, and should fetch latest block
   lavanet.lava.spec.Params:
     type: object
@@ -54286,15 +54228,17 @@ definitions:
               - PARSE_CANONICAL
               - PARSE_DICTIONARY
               - PARSE_DICTIONARY_OR_ORDERED
+              - PARSE_DICTIONARY_OR_DEFAULT
               - DEFAULT
             default: EMPTY
             title: >-
               - PARSE_BY_ARG: means parameters are ordered and flat expected
-              areguments are: [param index] (example: PARAMS:
+              arguments are: [param index] (example: PARAMS:
               [<#BlockNum>,"banana"])
-               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+               - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                - DEFAULT: means parameters are non related to block, and should fetch latest block
   lavanet.lava.spec.QueryAllSpecResponse:
     type: object
@@ -54330,15 +54274,17 @@ definitions:
                           - PARSE_CANONICAL
                           - PARSE_DICTIONARY
                           - PARSE_DICTIONARY_OR_ORDERED
+                          - PARSE_DICTIONARY_OR_DEFAULT
                           - DEFAULT
                         default: EMPTY
                         title: >-
                           - PARSE_BY_ARG: means parameters are ordered and flat
-                          expected areguments are: [param index] (example:
+                          expected arguments are: [param index] (example:
                           PARAMS: [<#BlockNum>,"banana"])
-                           - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                           - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                           - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                           - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                            - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                           - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                            - DEFAULT: means parameters are non related to block, and should fetch latest block
                   compute_units:
                     type: string
@@ -54369,6 +54315,33 @@ definitions:
                             stateful:
                               type: integer
                               format: int64
+                        overwrite_block_parsing:
+                          type: object
+                          properties:
+                            parser_arg:
+                              type: array
+                              items:
+                                type: string
+                            parser_func:
+                              type: string
+                              enum:
+                                - EMPTY
+                                - PARSE_BY_ARG
+                                - PARSE_CANONICAL
+                                - PARSE_DICTIONARY
+                                - PARSE_DICTIONARY_OR_ORDERED
+                                - PARSE_DICTIONARY_OR_DEFAULT
+                                - DEFAULT
+                              default: EMPTY
+                              title: >-
+                                - PARSE_BY_ARG: means parameters are ordered and
+                                flat expected arguments are: [param index]
+                                (example: PARAMS: [<#BlockNum>,"banana"])
+                                 - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                                 - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                                 - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                                 - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                                 - DEFAULT: means parameters are non related to block, and should fetch latest block
                   reserved:
                     type: object
                     properties:
@@ -54403,15 +54376,17 @@ definitions:
                               - PARSE_CANONICAL
                               - PARSE_DICTIONARY
                               - PARSE_DICTIONARY_OR_ORDERED
+                              - PARSE_DICTIONARY_OR_DEFAULT
                               - DEFAULT
                             default: EMPTY
                             title: >-
                               - PARSE_BY_ARG: means parameters are ordered and
-                              flat expected areguments are: [param index]
+                              flat expected arguments are: [param index]
                               (example: PARAMS: [<#BlockNum>,"banana"])
-                               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                                - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                               - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                                - DEFAULT: means parameters are non related to block, and should fetch latest block
             enabled:
               type: boolean
@@ -54528,15 +54503,17 @@ definitions:
                         - PARSE_CANONICAL
                         - PARSE_DICTIONARY
                         - PARSE_DICTIONARY_OR_ORDERED
+                        - PARSE_DICTIONARY_OR_DEFAULT
                         - DEFAULT
                       default: EMPTY
                       title: >-
                         - PARSE_BY_ARG: means parameters are ordered and flat
-                        expected areguments are: [param index] (example: PARAMS:
+                        expected arguments are: [param index] (example: PARAMS:
                         [<#BlockNum>,"banana"])
-                         - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                         - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                         - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                         - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                          - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                         - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                          - DEFAULT: means parameters are non related to block, and should fetch latest block
                 compute_units:
                   type: string
@@ -54567,6 +54544,33 @@ definitions:
                           stateful:
                             type: integer
                             format: int64
+                      overwrite_block_parsing:
+                        type: object
+                        properties:
+                          parser_arg:
+                            type: array
+                            items:
+                              type: string
+                          parser_func:
+                            type: string
+                            enum:
+                              - EMPTY
+                              - PARSE_BY_ARG
+                              - PARSE_CANONICAL
+                              - PARSE_DICTIONARY
+                              - PARSE_DICTIONARY_OR_ORDERED
+                              - PARSE_DICTIONARY_OR_DEFAULT
+                              - DEFAULT
+                            default: EMPTY
+                            title: >-
+                              - PARSE_BY_ARG: means parameters are ordered and
+                              flat expected arguments are: [param index]
+                              (example: PARAMS: [<#BlockNum>,"banana"])
+                               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                               - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                               - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                               - DEFAULT: means parameters are non related to block, and should fetch latest block
                 reserved:
                   type: object
                   properties:
@@ -54601,15 +54605,17 @@ definitions:
                             - PARSE_CANONICAL
                             - PARSE_DICTIONARY
                             - PARSE_DICTIONARY_OR_ORDERED
+                            - PARSE_DICTIONARY_OR_DEFAULT
                             - DEFAULT
                           default: EMPTY
                           title: >-
                             - PARSE_BY_ARG: means parameters are ordered and
-                            flat expected areguments are: [param index]
-                            (example: PARAMS: [<#BlockNum>,"banana"])
-                             - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                             - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                            flat expected arguments are: [param index] (example:
+                            PARAMS: [<#BlockNum>,"banana"])
+                             - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                             - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                              - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                             - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                              - DEFAULT: means parameters are non related to block, and should fetch latest block
           enabled:
             type: boolean
@@ -54686,10 +54692,19 @@ definitions:
   lavanet.lava.spec.QueryShowAllChainsResponse:
     type: object
     properties:
-      chainNames:
+      chainInfoList:
         type: array
         items:
-          type: string
+          type: object
+          properties:
+            chainName:
+              type: string
+            chainID:
+              type: string
+            enabledApiInterfaces:
+              type: array
+              items:
+                type: string
   lavanet.lava.spec.QueryShowChainInfoResponse:
     type: object
     properties:
@@ -54730,15 +54745,17 @@ definitions:
               - PARSE_CANONICAL
               - PARSE_DICTIONARY
               - PARSE_DICTIONARY_OR_ORDERED
+              - PARSE_DICTIONARY_OR_DEFAULT
               - DEFAULT
             default: EMPTY
             title: >-
               - PARSE_BY_ARG: means parameters are ordered and flat expected
-              areguments are: [param index] (example: PARAMS:
+              arguments are: [param index] (example: PARAMS:
               [<#BlockNum>,"banana"])
-               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+               - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+               - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+               - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                - DEFAULT: means parameters are non related to block, and should fetch latest block
       compute_units:
         type: string
@@ -54769,6 +54786,33 @@ definitions:
                 stateful:
                   type: integer
                   format: int64
+            overwrite_block_parsing:
+              type: object
+              properties:
+                parser_arg:
+                  type: array
+                  items:
+                    type: string
+                parser_func:
+                  type: string
+                  enum:
+                    - EMPTY
+                    - PARSE_BY_ARG
+                    - PARSE_CANONICAL
+                    - PARSE_DICTIONARY
+                    - PARSE_DICTIONARY_OR_ORDERED
+                    - PARSE_DICTIONARY_OR_DEFAULT
+                    - DEFAULT
+                  default: EMPTY
+                  title: >-
+                    - PARSE_BY_ARG: means parameters are ordered and flat
+                    expected arguments are: [param index] (example: PARAMS:
+                    [<#BlockNum>,"banana"])
+                     - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                     - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                     - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                     - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                     - DEFAULT: means parameters are non related to block, and should fetch latest block
       reserved:
         type: object
         properties:
@@ -54803,15 +54847,17 @@ definitions:
                   - PARSE_CANONICAL
                   - PARSE_DICTIONARY
                   - PARSE_DICTIONARY_OR_ORDERED
+                  - PARSE_DICTIONARY_OR_DEFAULT
                   - DEFAULT
                 default: EMPTY
                 title: >-
                   - PARSE_BY_ARG: means parameters are ordered and flat expected
-                  areguments are: [param index] (example: PARAMS:
+                  arguments are: [param index] (example: PARAMS:
                   [<#BlockNum>,"banana"])
-                   - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                   - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                   - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                   - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                    - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                   - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                    - DEFAULT: means parameters are non related to block, and should fetch latest block
   lavanet.lava.spec.Spec:
     type: object
@@ -54842,15 +54888,17 @@ definitions:
                     - PARSE_CANONICAL
                     - PARSE_DICTIONARY
                     - PARSE_DICTIONARY_OR_ORDERED
+                    - PARSE_DICTIONARY_OR_DEFAULT
                     - DEFAULT
                   default: EMPTY
                   title: >-
                     - PARSE_BY_ARG: means parameters are ordered and flat
-                    expected areguments are: [param index] (example: PARAMS:
+                    expected arguments are: [param index] (example: PARAMS:
                     [<#BlockNum>,"banana"])
-                     - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                     - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                     - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                     - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                      - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                     - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                      - DEFAULT: means parameters are non related to block, and should fetch latest block
             compute_units:
               type: string
@@ -54881,6 +54929,33 @@ definitions:
                       stateful:
                         type: integer
                         format: int64
+                  overwrite_block_parsing:
+                    type: object
+                    properties:
+                      parser_arg:
+                        type: array
+                        items:
+                          type: string
+                      parser_func:
+                        type: string
+                        enum:
+                          - EMPTY
+                          - PARSE_BY_ARG
+                          - PARSE_CANONICAL
+                          - PARSE_DICTIONARY
+                          - PARSE_DICTIONARY_OR_ORDERED
+                          - PARSE_DICTIONARY_OR_DEFAULT
+                          - DEFAULT
+                        default: EMPTY
+                        title: >-
+                          - PARSE_BY_ARG: means parameters are ordered and flat
+                          expected arguments are: [param index] (example:
+                          PARAMS: [<#BlockNum>,"banana"])
+                           - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                           - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
+                           - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                           - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
+                           - DEFAULT: means parameters are non related to block, and should fetch latest block
             reserved:
               type: object
               properties:
@@ -54915,15 +54990,17 @@ definitions:
                         - PARSE_CANONICAL
                         - PARSE_DICTIONARY
                         - PARSE_DICTIONARY_OR_ORDERED
+                        - PARSE_DICTIONARY_OR_DEFAULT
                         - DEFAULT
                       default: EMPTY
                       title: >-
                         - PARSE_BY_ARG: means parameters are ordered and flat
-                        expected areguments are: [param index] (example: PARAMS:
+                        expected arguments are: [param index] (example: PARAMS:
                         [<#BlockNum>,"banana"])
-                         - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected areguments are: [param index to object,propname in object] (example: PARAMS: ["banana",{propname:<#BlockNum>}])
-                         - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {propname:<#BlockNum>,prop2:"banana"})
+                         - PARSE_CANONICAL: means parameters are ordered and one of them has named properties, expected arguments are: [param index to object,prop_name in object] (example: PARAMS: ["banana",{prop_name:<#BlockNum>}])
+                         - PARSE_DICTIONARY: means parameters are named, expected arguments are [prop_name,separator] (example: PARAMS: {prop_name:<#BlockNum>,prop2:"banana"})
                          - PARSE_DICTIONARY_OR_ORDERED: means parameters are named expected arguments are [prop_name,separator,parameter order if not found]
+                         - PARSE_DICTIONARY_OR_DEFAULT: means parameters are named, expected arguments are [prop_name,separator,default value] (example: PARAMS: {prop_name:<#BlockNum>} or /prop_name=blockNum)
                          - DEFAULT: means parameters are non related to block, and should fetch latest block
       enabled:
         type: boolean
@@ -55001,6 +55078,17 @@ definitions:
       interface:
         type: string
       supportedApis:
+        type: array
+        items:
+          type: string
+  lavanet.lava.spec.showAllChainsInfoStruct:
+    type: object
+    properties:
+      chainName:
+        type: string
+      chainID:
+        type: string
+      enabledApiInterfaces:
         type: array
         items:
           type: string

--- a/testutil/keeper/keepers_init.go
+++ b/testutil/keeper/keepers_init.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -31,6 +32,8 @@ import (
 )
 
 const BLOCK_TIME = 30 * time.Second
+
+const BLOCK_HEADER_LEN = 32
 
 type Keepers struct {
 	Epochstorage  epochstoragekeeper.Keeper
@@ -147,6 +150,10 @@ func AdvanceBlock(ctx context.Context, ks *Keepers, customBlockTime ...time.Dura
 
 	block := uint64(unwrapedCtx.BlockHeight() + 1)
 	unwrapedCtx = unwrapedCtx.WithBlockHeight(int64(block))
+
+	headerHash := make([]byte, BLOCK_HEADER_LEN)
+	rand.Read(headerHash)
+	unwrapedCtx = unwrapedCtx.WithHeaderHash(headerHash)
 	if len(customBlockTime) > 0 {
 		NewBlock(sdk.WrapSDKContext(unwrapedCtx), ks, customBlockTime...)
 	} else {

--- a/x/epochstorage/keeper/stake_storage.go
+++ b/x/epochstorage/keeper/stake_storage.go
@@ -470,13 +470,13 @@ func (k Keeper) GetStakeEntryForAllProvidersEpoch(ctx sdk.Context, chainID strin
 	return &stakeStorage.StakeEntries, nil
 }
 
-func (k Keeper) GetEpochStakeEntries(ctx sdk.Context, block uint64, storageType string, chainID string) (entries []types.StakeEntry, found bool) {
+func (k Keeper) GetEpochStakeEntries(ctx sdk.Context, block uint64, storageType string, chainID string) (entries []types.StakeEntry, found bool, epochHash []byte) {
 	key := k.StakeStorageKey(storageType, block, chainID)
 	stakeStorage, found := k.GetStakeStorage(ctx, key)
 	if !found {
-		return nil, false
+		return nil, false, nil
 	}
-	return stakeStorage.StakeEntries, true
+	return stakeStorage.StakeEntries, true, stakeStorage.EpochBlockHash
 }
 
 // append to epoch stake entries ONLY if it doesn't exist

--- a/x/pairing/keeper/grpc_query_static_providers_list.go
+++ b/x/pairing/keeper/grpc_query_static_providers_list.go
@@ -28,7 +28,7 @@ func (k Keeper) StaticProvidersList(goCtx context.Context, req *types.QueryStati
 	}
 
 	epoch := k.epochStorageKeeper.GetEpochStart(ctx)
-	stakes, found := k.epochStorageKeeper.GetEpochStakeEntries(ctx, epoch, epochstoragetypes.ProviderKey, req.GetChainID())
+	stakes, found, _ := k.epochStorageKeeper.GetEpochStakeEntries(ctx, epoch, epochstoragetypes.ProviderKey, req.GetChainID())
 
 	if !found {
 		return &types.QueryStaticProvidersListResponse{}, nil

--- a/x/pairing/keeper/msg_server_stake_unstake_gov_test.go
+++ b/x/pairing/keeper/msg_server_stake_unstake_gov_test.go
@@ -86,9 +86,9 @@ func TestStakeGovEpochBlocksDecrease(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			// check if the provider/client are staked
-			_, foundProvider := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ProviderKey, ts.spec.GetIndex())
+			_, foundProvider, _ := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ProviderKey, ts.spec.GetIndex())
 			require.Equal(t, tt.shouldBeStaked, foundProvider)
-			_, foundClient := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ClientKey, ts.spec.GetIndex())
+			_, foundClient, _ := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ClientKey, ts.spec.GetIndex())
 			require.Equal(t, tt.shouldBeStaked, foundClient)
 		})
 	}
@@ -173,9 +173,9 @@ func TestStakeGovEpochBlocksIncrease(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			// check if the provider/client are staked
-			_, found := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ProviderKey, ts.spec.GetIndex())
+			_, found, _ := ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ProviderKey, ts.spec.GetIndex())
 			require.Equal(t, tt.shouldBeStaked, found)
-			_, found = ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ClientKey, ts.spec.GetIndex())
+			_, found, _ = ts.keepers.Epochstorage.GetEpochStakeEntries(sdk.UnwrapSDKContext(ts.ctx), tt.epoch, epochstoragetypes.ClientKey, ts.spec.GetIndex())
 			require.Equal(t, tt.shouldBeStaked, found)
 		})
 	}

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -38,6 +38,7 @@ func TestPairingUniqueness(t *testing.T) {
 
 	ctx = testkeeper.AdvanceEpoch(ctx, keepers)
 
+	// test that 2 different clients get different pairings
 	providers1, err := keepers.Pairing.GetPairingForClient(sdk.UnwrapSDKContext(ctx), spec.Index, consumer1.Addr)
 	require.Nil(t, err)
 
@@ -61,6 +62,17 @@ func TestPairingUniqueness(t *testing.T) {
 	}
 
 	require.True(t, diffrent)
+
+	ctx = testkeeper.AdvanceEpoch(ctx, keepers)
+
+	// test that in different epoch we get different pairings for consumer1
+	providers11, err := keepers.Pairing.GetPairingForClient(sdk.UnwrapSDKContext(ctx), spec.Index, consumer1.Addr)
+	require.Nil(t, err)
+
+	require.Equal(t, len(providers1), len(providers11))
+	for i := range providers1 {
+		require.NotEqual(t, providers1[i].Address, providers11[i].Address)
+	}
 
 }
 

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -81,6 +81,7 @@ func TestPairingUniqueness(t *testing.T) {
 
 	//test that get pairing gives the same results for the whole epoch
 	epochBlocks := keepers.Epochstorage.EpochBlocksRaw(sdk.UnwrapSDKContext(ctx))
+	foundIndexMap := map[string]int{}
 	for i := uint64(0); i < epochBlocks-1; i++ {
 		ctx = testkeeper.AdvanceBlock(ctx, keepers)
 
@@ -92,8 +93,13 @@ func TestPairingUniqueness(t *testing.T) {
 
 			providerAddr, err := sdk.AccAddressFromBech32(providers11[i].Address)
 			require.Nil(t, err)
-			valid, _, _, _ := keepers.Pairing.ValidatePairingForClient(sdk.UnwrapSDKContext(ctx), spec.Index, consumer1.Addr, providerAddr, uint64(sdk.UnwrapSDKContext(ctx).BlockHeight()))
+			valid, _, foundIndex, _ := keepers.Pairing.ValidatePairingForClient(sdk.UnwrapSDKContext(ctx), spec.Index, consumer1.Addr, providerAddr, uint64(sdk.UnwrapSDKContext(ctx).BlockHeight()))
 			require.True(t, valid)
+			if _, ok := foundIndexMap[providers11[i].Address]; !ok {
+				foundIndexMap[providers11[i].Address] = foundIndex
+			} else {
+				require.Equal(t, foundIndexMap[providers11[i].Address], foundIndex)
+			}
 		}
 
 	}

--- a/x/pairing/types/expected_keepers.go
+++ b/x/pairing/types/expected_keepers.go
@@ -37,7 +37,7 @@ type EpochstorageKeeper interface {
 	GetStakeEntryByAddressCurrent(ctx sdk.Context, storageType string, chainID string, address sdk.AccAddress) (value epochstoragetypes.StakeEntry, found bool, index uint64)
 	UnstakeEntryByAddress(ctx sdk.Context, storageType string, address sdk.AccAddress) (value epochstoragetypes.StakeEntry, found bool, index uint64)
 	GetStakeStorageCurrent(ctx sdk.Context, storageType string, chainID string) (epochstoragetypes.StakeStorage, bool)
-	GetEpochStakeEntries(ctx sdk.Context, block uint64, storageType string, chainID string) (entries []epochstoragetypes.StakeEntry, found bool)
+	GetEpochStakeEntries(ctx sdk.Context, block uint64, storageType string, chainID string) (entries []epochstoragetypes.StakeEntry, found bool, epochHash []byte)
 	GetStakeEntryByAddressFromStorage(ctx sdk.Context, stakeStorage epochstoragetypes.StakeStorage, address sdk.AccAddress) (value epochstoragetypes.StakeEntry, found bool, index uint64)
 	GetNextEpoch(ctx sdk.Context, block uint64) (nextEpoch uint64, erro error)
 	GetStakeEntryForClientEpoch(ctx sdk.Context, chainID string, selectedClient sdk.AccAddress, epoch uint64) (entry *epochstoragetypes.StakeEntry, err error)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Commit message follows the Contribution Guidelines
- [ ] Tests ran locally and added/modified if needed
- [ ] Docs have been added/updated, if applicable
- [ ] If applicable - JIRA ticket ID was added

this is a bug fix, removing core.block from pairing as it is not determinitic


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Please describe what manual tests you ran, if applicable**


* **Other information**:
