### PR TITLE
CNS-175 continued: improve subscription tests and CLI

### DIFF
--- a/testutil/keeper/keepers_init.go
+++ b/testutil/keeper/keepers_init.go
@@ -197,7 +197,7 @@ func InitAllKeepers(t testing.TB) (*Servers, *Keepers, context.Context) {
 	core.SetEnvironment(&core.Environment{BlockStore: &ks.BlockStore})
 
 	ks.Epochstorage.SetEpochDetails(ctx, *epochstoragetypes.DefaultGenesis().EpochDetails)
-	NewBlock(sdk.WrapSDKContext(ctx), &ks)
+	ctx = sdk.UnwrapSDKContext(AdvanceBlock(sdk.WrapSDKContext(ctx), &ks))
 	return &ss, &ks, sdk.WrapSDKContext(ctx)
 }
 
@@ -215,6 +215,10 @@ func AdvanceBlock(ctx context.Context, ks *Keepers, customBlockTime ...time.Dura
 	} else {
 		NewBlock(sdk.WrapSDKContext(unwrapedCtx), ks)
 	}
+
+	b := ks.BlockStore.LoadBlock(int64(block))
+	unwrapedCtx = unwrapedCtx.WithBlockTime(b.Header.Time)
+
 	return sdk.WrapSDKContext(unwrapedCtx)
 }
 

--- a/x/subscription/client/cli/query_current_subscription.go
+++ b/x/subscription/client/cli/query_current_subscription.go
@@ -1,27 +1,26 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/spf13/cobra"
 )
 
-var _ = strconv.Itoa(0)
-
 func CmdCurrentSubscription() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "current-subscription [consumer]",
 		Short: "Query the current subscription of a consumer to a service plan",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			reqConsumer := args[0]
-
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
+			}
+
+			reqConsumer := clientCtx.GetFromAddress().String()
+			if len(args) == 1 {
+				reqConsumer = args[0]
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)

--- a/x/subscription/client/cli/tx_subscribe.go
+++ b/x/subscription/client/cli/tx_subscribe.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -11,28 +9,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var _ = strconv.Itoa(0)
-
 func CmdSubscribe() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "subscribe [consumer] [index] [is-yearly]",
+		Use:   "subscribe [index] [consumer] [is-yearly]",
 		Short: "Subscribe to a service plan",
-		Args:  cobra.ExactArgs(3),
+		Args:  cobra.RangeArgs(1, 3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			argConsumer := args[0]
-			argIndex := args[1]
-			argIsYearly, err := cast.ToBoolE(args[2])
-			if err != nil {
-				return err
-			}
-
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
+			creator := clientCtx.GetFromAddress().String()
+			argIndex := args[0]
+
+			argConsumer := creator
+			if len(args) >= 2 {
+				argConsumer = args[1]
+			}
+
+			argIsYearly := false
+			if len(args) == 3 {
+				argIsYearly, err = cast.ToBoolE(args[2])
+				if err != nil {
+					return err
+				}
+			}
+
 			msg := types.NewMsgSubscribe(
-				clientCtx.GetFromAddress().String(),
+				creator,
 				argConsumer,
 				argIndex,
 				argIsYearly,

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -218,7 +218,10 @@ func (k Keeper) CreateSubscription(
 	}()
 
 	price := plan.GetPrice()
-	expiry := time.Now().UTC()
+
+	// use current block's timestamp for subscription start-time
+	timestamp := ctx.BlockTime()
+	expiry := timestamp
 
 	duration := int(plan.GetDuration())
 	for i := 0; i < duration; i++ {
@@ -227,7 +230,7 @@ func (k Keeper) CreateSubscription(
 
 	if isYearly && duration < 12 {
 		// extend the duration to 1 year, and price pro-rata
-		expiry = nextYear(time.Now().UTC())
+		expiry = nextYear(timestamp)
 		price.Amount = price.Amount.MulRaw(12).QuoRaw(int64(duration))
 
 		// adjust cost if discount given

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -109,6 +109,22 @@ func nextMonth(date time.Time) time.Time {
 		return endOfMonth(next)
 	}
 
+	// If we are reaching end of January, stll need to "manually" select end of
+	// next month, otherwise will overrun into March.
+
+	if date.Month() == 1 && date.Day() >= 29 {
+		next = time.Date(
+			date.Year(),
+			time.February,
+			1,
+			date.Hour(),
+			date.Minute(),
+			date.Second(),
+			date.Nanosecond(),
+			time.UTC)
+		return endOfMonth(next)
+	}
+
 	return next
 }
 

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -3,12 +3,15 @@ package keeper_test
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/relayer/sigs"
 	"github.com/lavanet/lava/testutil/common"
 	keepertest "github.com/lavanet/lava/testutil/keeper"
 	"github.com/lavanet/lava/testutil/nullify"
+	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
+	projectstypes "github.com/lavanet/lava/x/projects/types"
 	"github.com/lavanet/lava/x/subscription/keeper"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/stretchr/testify/require"
@@ -146,13 +149,13 @@ func TestCreateSubscription(t *testing. T) {
 			consumers: []int{2},
 			success:   false,
 		},
-//		{
-//			name:      "invalid plan",
-//			index:     "",
-//			creator:   0,
-//			consumers: []int{2},
-//			success:   false,
-//		},
+		{
+			name:      "invalid plan",
+			index:     "",
+			creator:   0,
+			consumers: []int{2},
+			success:   false,
+		},
 		{
 			name:      "unknown plan",
 			index:     "no-such-plan",
@@ -211,4 +214,123 @@ func TestSubscriptionDefaultProject(t *testing. T) {
 	// with the subscription address as its developer key
 	_, err = keepers.Projects.GetProjectIDForDeveloper(ctx, creator, block)
 	require.Nil(t, err)
+}
+
+func TestExpiryTime(t *testing. T) {
+	_, keepers, _ctx := keepertest.InitAllKeepers(t)
+	ctx := sdk.UnwrapSDKContext(_ctx)
+
+	keeper := keepers.Subscription
+	plansKeeper := keepers.Plans
+	projsKeeper := keepers.Projects
+
+	plan := common.CreateMockPlan()
+	plan.Duration = 1 // month
+	plansKeeper.AddPlan(ctx, plan)
+
+	template := []struct {
+		now    [3]int // year, month, day
+		res    [3]int // year, month, day
+		yearly bool
+	}{
+		// monthly
+		{ [3]int{2000, 3, 1}, [3]int{2000, 4, 1}, false },
+		{ [3]int{2000, 3, 30}, [3]int{2000, 4, 30}, false },
+		{ [3]int{2000, 3, 31}, [3]int{2000, 4, 30}, false },
+		{ [3]int{2000, 2, 1}, [3]int{2000, 3, 1}, false },
+		{ [3]int{2000, 2, 28}, [3]int{2000, 3, 28}, false },
+		{ [3]int{2001, 2, 28}, [3]int{2001, 3, 31}, false },
+		{ [3]int{2000, 2, 29}, [3]int{2000, 3, 31}, false },
+		{ [3]int{2000, 1, 28}, [3]int{2000, 2, 28}, false },
+		{ [3]int{2001, 1, 28}, [3]int{2001, 2, 28}, false },
+		{ [3]int{2000, 1, 29}, [3]int{2000, 2, 29}, false },
+		{ [3]int{2001, 1, 29}, [3]int{2001, 2, 28}, false },
+		{ [3]int{2000, 1, 30}, [3]int{2000, 2, 29}, false },
+		{ [3]int{2001, 1, 30}, [3]int{2001, 2, 28}, false },
+		{ [3]int{2000, 1, 31}, [3]int{2000, 2, 29}, false },
+		{ [3]int{2001, 1, 31}, [3]int{2001, 2, 28}, false },
+		{ [3]int{2001, 12, 31}, [3]int{2002, 1, 31}, false },
+		// yearly
+		{ [3]int{2000, 3, 1}, [3]int{2001, 3, 1}, true },
+		{ [3]int{2000, 2, 28}, [3]int{2001, 2, 28}, true },
+		{ [3]int{2000, 2, 29}, [3]int{2001, 2, 28}, true },
+		{ [3]int{2001, 2, 28}, [3]int{2002, 2, 28}, true },
+		{ [3]int{2003, 2, 28}, [3]int{2004, 2, 29}, true },
+	}
+
+	for _, tt := range template {
+		now := time.Date(tt.now[0], time.Month(tt.now[1]), tt.now[2], 12, 0, 0, 0, time.UTC)
+		res := time.Date(tt.res[0], time.Month(tt.res[1]), tt.res[2], 12, 0, 0, 0, time.UTC)
+
+		t.Run(now.Format("2006-01-02"), func(t *testing.T) {
+			// TODO: need new creator because Projects doesn't really delete projects
+			creator := common.CreateNewAccount(_ctx, *keepers, 10000).Addr.String()
+
+			delta := now.Sub(ctx.BlockTime())
+			_ctx = keepertest.AdvanceBlock(_ctx, keepers, delta)
+			ctx = sdk.UnwrapSDKContext(_ctx)
+
+			err := keeper.CreateSubscription(ctx, creator, creator, plan.Index, tt.yearly)
+			require.Nil(t, err)
+
+			sub, found := keeper.GetSubscription(ctx, creator)
+			require.True(t, found)
+			require.Equal(t, res, time.Unix(int64(sub.ExpiryTime), 0).UTC())
+
+			keeper.RemoveSubscription(ctx, creator)
+			// TODO: remove when RemoveSubscriptions properly removes projects
+			projsKeeper.DeleteProject(ctx, projectstypes.ProjectIndex(creator, "default"))
+		})
+	}
+}
+
+func TestYearlyPrice(t *testing. T) {
+	_, keepers, _ctx := keepertest.InitAllKeepers(t)
+	ctx := sdk.UnwrapSDKContext(_ctx)
+
+	keeper := keepers.Subscription
+	plansKeeper := keepers.Plans
+	projsKeeper := keepers.Projects
+
+	plan := common.CreateMockPlan()
+
+	template := []struct {
+		name     string
+		duration uint64
+		discount uint64
+		price    int64
+		cost     int64
+	}{
+		{ "yearly from 1 month", 1, 0, 100, 1200 },
+		{ "yearly from 2 months", 2, 0, 100, 600 },
+		{ "yearly from 4 months", 4, 0, 100, 300 },
+		{ "yearly from 1 month with discount", 1, 25, 100, 900 },
+		{ "yearly from 1 months with discount", 2, 25, 100, 450 },
+	}
+
+	for _, tt := range template {
+		t.Run(tt.name, func(t *testing.T) {
+			// NOTE: need new creator because Projects doesn't really delete projects
+			address := common.CreateNewAccount(_ctx, *keepers, 10000).Addr
+			creator := address.String()
+
+			plan.Duration = tt.duration
+			plan.AnnualDiscountPercentage = tt.discount
+			plan.Price = sdk.NewCoin("ulava", sdk.NewInt(tt.price))
+			plansKeeper.AddPlan(ctx, plan)
+
+			err := keeper.CreateSubscription(ctx, creator, creator, plan.Index, true)
+			require.Nil(t, err)
+
+			_, found := keeper.GetSubscription(ctx, creator)
+			require.True(t, found)
+
+			balance := keepers.BankKeeper.GetBalance(ctx, address, epochstoragetypes.TokenDenom)
+			require.Equal(t, balance.Amount.Int64(), int64(10000 - tt.cost))
+
+			keeper.RemoveSubscription(ctx, creator)
+			// TODO: remove when RemoveSubscriptions properly removes projects
+			projsKeeper.DeleteProject(ctx, projectstypes.ProjectIndex(creator, "default"))
+		})
+	}
 }


### PR DESCRIPTION
1. Fix bug in subscription nextMonth() on Jan 30,31 (spilled over to March)
2. Add unit tests for calculation of ExpiryTime (regular and yearly plans)
3. Add unit tests for calculation of plan cost (yearly with/without discount)
4. Improve CLI for (tx) subscribe and (query) current-subscription
    make the "consumer" and "is_yearly" args options
    (defaults are "creator" and "false" respectively).