### PR TITLE
Upgrade plan v0.8.1

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,8 @@ var Upgrades = []upgrades.Upgrade{
 	upgrades.Upgrade_0_6_1,
 	upgrades.Upgrade_0_7_0,
 	upgrades.Upgrade_0_7_1,
-	upgrades.Upgrade_0_8_0,
+	// upgrades.Upgrade_0_8_0,
+	upgrades.Upgrade_0_8_1,
 }
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals

--- a/app/upgrades/empty_upgrades.go
+++ b/app/upgrades/empty_upgrades.go
@@ -97,8 +97,20 @@ var Upgrade_0_7_1 = Upgrade{
 	StoreUpgrades:        store.StoreUpgrades{},
 }
 
-var Upgrade_0_8_0 = Upgrade{
-	UpgradeName:          "v0.8.0-RC1",
+//// Upgrade_0_8_0 canceled: module StoreKey "projects" renamed to "project" without store
+//// rename/delete/add; outcome not recoverable (due to cosmos-sdk v0.45.11 bug?).
+// var Upgrade_0_8_0 = Upgrade{
+// 	UpgradeName:          "v0.8.0-RC1",
+// 	CreateUpgradeHandler: defaultUpgradeHandler,
+// 	StoreUpgrades:        store.StoreUpgrades{},
+// }
+
+// Upgrade_0_8_1 fixes StoreKey "projects"->"project": delete old and add new
+var Upgrade_0_8_1 = Upgrade{
+	UpgradeName:          "v0.8.1",
 	CreateUpgradeHandler: defaultUpgradeHandler,
-	StoreUpgrades:        store.StoreUpgrades{},
+	StoreUpgrades: store.StoreUpgrades{
+		Deleted: []string{"projects"},
+		Added:   []string{"project"},
+	},
 }

--- a/app/upgrades/empty_upgrades.go
+++ b/app/upgrades/empty_upgrades.go
@@ -105,12 +105,15 @@ var Upgrade_0_7_1 = Upgrade{
 // 	StoreUpgrades:        store.StoreUpgrades{},
 // }
 
+// for Upgrade_0_8_1 the old StoreKey for Projects module
+const oldProjectsModuleStoreKey = "projects"
+
 // Upgrade_0_8_1 fixes StoreKey "projects"->"project": delete old and add new
 var Upgrade_0_8_1 = Upgrade{
 	UpgradeName:          "v0.8.1",
 	CreateUpgradeHandler: defaultUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
-		Deleted: []string{"projects"},
-		Added:   []string{"project"},
+		Deleted: []string{oldProjectsModuleStoreKey},
+		Added:   []string{projectsmoduletypes.StoreKey},
 	},
 }

--- a/app/upgrades/empty_upgrades.go
+++ b/app/upgrades/empty_upgrades.go
@@ -11,102 +11,94 @@ import (
 	subscriptionmoduletypes "github.com/lavanet/lava/x/subscription/types"
 )
 
+func defaultUpgradeHandler(
+	m *module.Manager,
+	c module.Configurator,
+	bapm BaseAppParamManager,
+	lk *keepers.LavaKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return m.RunMigrations(ctx, c, vm)
+	}
+}
+
+// Template for empty/simple upgrades:
+// (Note: in cosmos-sdk 0.45.11 "Renamed" did not work properly for attempt v0.8.1)
+//
+// var Upgrade_0_0_1 = Upgrade{
+// 	UpgradeName: "v0.0.1",                          // upgrade name
+// 	CreateUpgradeHandler: defaultUpgradeHandler,    // upgrade handler (default)
+//  	StoreUpgrades: store.StoreUpgrades{         // store upgrades
+// 		Added:   []string{newmoduletypes.StoreKey}, //   new module store to add
+// 		Deleted: []string{oldmoduletypes.StoreKey}, //   old module store to delete
+// 		Renamed: []store.StoreRename{               //   old/new module store to rename
+// 			{OldKey: oldmoduletypes.StoreKey, NewKey: newmoduletypes.StoreKey},
+// 		},
+// 	},
+// }
+
 var Upgrade_0_4_0 = Upgrade{
-	UpgradeName: "v0.4.0", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.4.0",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_4_3 = Upgrade{
-	UpgradeName: "v0.4.3", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.4.3",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_4_4 = Upgrade{
-	UpgradeName: "v0.4.4", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.4.4",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_4_5 = Upgrade{
-	UpgradeName: "v0.4.5", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.4.5",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_6_0 = Upgrade{
-	UpgradeName: "v0.6.0", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.6.0",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_6_0_RC3 = Upgrade{
-	UpgradeName: "v0.6.0-RC3", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_6_1 = Upgrade{
-	UpgradeName: "v0.6.1", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.6.1",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
+// Upgrade_0_7_0 adds three new modules: plan, subscription, projects
 var Upgrade_0_7_0 = Upgrade{
-	UpgradeName: "v0.7.0", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{Added: []string{plansmoduletypes.StoreKey, projectsmoduletypes.StoreKey, subscriptionmoduletypes.StoreKey}}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.7.0",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{
+			plansmoduletypes.StoreKey,
+			projectsmoduletypes.StoreKey,
+			subscriptionmoduletypes.StoreKey,
+		},
+	},
 }
 
 var Upgrade_0_7_1 = Upgrade{
-	UpgradeName: "v0.7.1", // upgrade name defined few lines above
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	}, // create CreateUpgradeHandler in upgrades.go below
-	StoreUpgrades: store.StoreUpgrades{}, // StoreUpgrades has 3 fields: Added/Renamed/Deleted any module that fits these description should be added in the way below
+	UpgradeName:          "v0.7.1",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
 var Upgrade_0_8_0 = Upgrade{
-	UpgradeName: "v0.8.0-RC1",
-	CreateUpgradeHandler: func(m *module.Manager, c module.Configurator, bapm BaseAppParamManager, lk *keepers.LavaKeepers) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			return m.RunMigrations(ctx, c, vm)
-		}
-	},
-	StoreUpgrades: store.StoreUpgrades{},
+	UpgradeName:          "v0.8.0-RC1",
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
 }

--- a/x/projects/keeper/msg_server_set_project_policy.go
+++ b/x/projects/keeper/msg_server_set_project_policy.go
@@ -20,7 +20,7 @@ func (k msgServer) SetProjectPolicy(goCtx context.Context, msg *types.MsgSetProj
 	}
 
 	// check if the admin key is valid
-	if !project.HasKeyType(adminKey, types.ProjectKey_ADMIN) || project.Subscription != adminKey {
+	if !project.IsAdminKey(adminKey) {
 		return nil, utils.LavaError(ctx, ctx.Logger(), "SetProjectPolicy_not_admin", map[string]string{"project": projectID}, "the requesting key is not admin key")
 	}
 

--- a/x/projects/keeper/project.go
+++ b/x/projects/keeper/project.go
@@ -56,7 +56,7 @@ func (k Keeper) AddKeysToProject(ctx sdk.Context, projectID string, adminKey str
 	}
 
 	// check if the admin key is valid
-	if !project.HasKeyType(adminKey, types.ProjectKey_ADMIN) && project.Subscription != adminKey {
+	if !project.IsAdminKey(adminKey) {
 		return utils.LavaError(ctx, ctx.Logger(), "AddProjectKeys_not_admin", map[string]string{"project": projectID}, "the requesting key is not admin key")
 	}
 

--- a/x/projects/types/project.go
+++ b/x/projects/types/project.go
@@ -61,6 +61,10 @@ func (project *Project) HasKeyType(projectKey string, keyTypeToCheck ProjectKey_
 	return project.GetKey(projectKey).IsKeyType(keyTypeToCheck)
 }
 
+func (project *Project) IsAdminKey(projectKey string) bool {
+	return project.HasKeyType(projectKey, ProjectKey_ADMIN) || project.Subscription == projectKey
+}
+
 func (project *Project) VerifyProject(chainID string) error {
 	if !project.Enabled {
 		return fmt.Errorf("the developers project is disabled")


### PR DESCRIPTION
**Upgrade plan from v0.7.1 to v0.8.1.**

In v0.8.1 the StoreKey of module Projects changed from "projects" to "project". The store upgrade handler deletes the old storage and adds the new one. (Note that as of cosmos-sdk 0.45.11 the "Renamed" method for store upgrade did not work properly).

Disable the attempt for v0.8.0 (which left out the above change), because it led to a corrupt store state, and could not be easily re-upgraded to a working state.

**How to test:**

1. Checkout/compile lavad-v0.7.1, install the `lavad` binary
2. Start the server with ignite:  `ignite chain server`
3. Run `scripts/init_chain_commands.sh`
4. Test the following commands:
```
curl http://127.0.0.1:3333/1/ --request POST --header "Content-Type: application/json" --data '{ "jsonrpc":"2.0", "method":"eth_blockNumber","params":[],"id":1}'
lavad query pairing get-pairing ETH1 lava@1fjntxw49cqjlkphm72u9fjrxmjpjh7zmgttgcp
```
5. Submit proposal for upgrade:
(note: adjust the "--upgrade-height 800" to use a block height not yet reached)
```
lavad tx gov submit-proposal software-upgrade v0.8.1 --title "v0.8.1" --upgrade-height 800 --upgrade-info '{"binaries":{"linux/amd64":"NONE"}}' --gas "auto" --from alice --description "lala1" --keyring-backend "test" --gas-prices "0.000000001ulava" --gas-adjustment "1.5" --deposit 10000000ulava --yes && lavad tx gov vote 5 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices "0.000000001ulava"
```
6. Wait until the chain reached the desired block height (800 in this example)
7. Kill all lavad:  `pkill lavad`
8. Checkout/compile lavad-v0.8.1, install the `lavad` binary
9. Start the server again: `lavad start`
10. Confirm that the "get-pairing" works:
```
lavad query pairing get-pairing ETH1 lava@1fjntxw49cqjlkphm72u9fjrxmjpjh7zmgttgcp
```
11. Re-run `scripts/init_chain_commands.sh`
12. Re-run the tests again:
```
curl http://127.0.0.1:3333/1/ --request POST --header "Content-Type: application/json" --data '{ "jsonrpc":"2.0", "method":"eth_blockNumber","params":[],"id":1}'
lavad query pairing get-pairing ETH1 lava@1fjntxw49cqjlkphm72u9fjrxmjpjh7zmgttgcp
```
13. Adjust the proposal id in the vote tx in scripts/init_subscription_commands.sh (should probably be 8, 9, 10 instead of 1, 2, 3)
14. Run `scripts/init_subscription_commands.sh`
15. Re-run the tests once more:
```
curl http://127.0.0.1:3333/1/ --request POST --header "Content-Type: application/json" --data '{ "jsonrpc":"2.0", "method":"eth_blockNumber","params":[],"id":1}'
lavad query pairing get-pairing ETH1 lava@1fjntxw49cqjlkphm72u9fjrxmjpjh7zmgttgcp
```
