### PR TITLE
PRT-466-prefer-to-use-http-over-ws-where-possible-from-main

### DIFF
--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/favicon"
 	"github.com/gofiber/websocket/v2"
+	"github.com/lavanet/lava/protocol/chainlib/chainproxy"
 	"github.com/lavanet/lava/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/lavanet/lava/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/lavanet/lava/protocol/common"
@@ -425,7 +426,8 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context) {
 type tendermintRpcChainProxy struct {
 	// embedding the jrpc chain proxy because the only diff is on parse message
 	JrpcChainProxy
-	httpNodeUrl common.NodeUrl
+	httpNodeUrl   common.NodeUrl
+	httpConnector *chainproxy.Connector
 }
 
 func NewtendermintRpcChainProxy(ctx context.Context, nConns uint, rpcProviderEndpoint *lavasession.RPCProviderEndpoint, averageBlockTime time.Duration) (ChainProxy, error) {
@@ -436,16 +438,25 @@ func NewtendermintRpcChainProxy(ctx context.Context, nConns uint, rpcProviderEnd
 	cp := &tendermintRpcChainProxy{
 		JrpcChainProxy: JrpcChainProxy{BaseChainProxy: BaseChainProxy{averageBlockTime: averageBlockTime, NodeUrl: websocketUrl}},
 		httpNodeUrl:    httpUrl,
+		httpConnector:  nil,
 	}
+	cp.addHttpConnector(ctx, nConns, httpUrl)
 	return cp, cp.start(ctx, nConns, websocketUrl)
 }
 
-func (cp *tendermintRpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *pairingtypes.RelayReply, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
-	rpc, err := cp.conn.GetRpc(ctx, true)
+func (cp *tendermintRpcChainProxy) addHttpConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) error {
+	conn, err := chainproxy.NewConnector(ctx, nConns, nodeUrl)
 	if err != nil {
-		return nil, "", nil, err
+		return err
 	}
-	defer cp.conn.ReturnRpc(rpc)
+	cp.httpConnector = conn
+	if cp.httpConnector == nil {
+		return errors.New("g_conn == nil")
+	}
+	return nil
+}
+
+func (cp *tendermintRpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *pairingtypes.RelayReply, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
 	rpcInputMessage := chainMessage.GetRPCMessage()
 	nodeMessage, ok := rpcInputMessage.(rpcInterfaceMessages.TendermintrpcMessage)
 	if !ok {
@@ -521,9 +532,17 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 // SendRPC sends Tendermint HTTP or WebSockets call
 func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpcInterfaceMessages.TendermintrpcMessage, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *pairingtypes.RelayReply, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
 	// Get rpc connection from the connection pool
-	rpc, err := cp.conn.GetRpc(ctx, true)
-	if err != nil {
-		return nil, "", nil, err
+	var rpc *rpcclient.Client
+	if ch != nil {
+		rpc, err = cp.conn.GetRpc(ctx, true)
+		if err != nil {
+			return nil, "", nil, err
+		}
+	} else {
+		rpc, err = cp.httpConnector.GetRpc(ctx, true)
+		if err != nil {
+			return nil, "", nil, err
+		}
 	}
 	// return the rpc connection to the pool after the function completes
 	defer cp.conn.ReturnRpc(rpc)


### PR DESCRIPTION
Added an HTTP connector to tendermintRpcChainProxy for all incoming relays, with the exception of the 'subscribe' process.