### PR TITLE
 PRT-167-Data-reliability-for-rest-tendermint-grpc-optional-params

### DIFF
--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
@@ -26,7 +26,15 @@ type GrpcMessage struct {
 // GetParams will be deprecated after we remove old client
 // Currently needed because of parser.RPCInput interface
 func (gm GrpcMessage) GetParams() interface{} {
-	return nil
+
+	msgStr := string(gm.Msg)
+
+	var parsedData interface{}
+	err := json.Unmarshal([]byte(msgStr), &parsedData)
+	if err != nil {
+		return nil
+	}
+	return parsedData
 }
 
 // GetResult will be deprecated after we remove old client

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/grpcMessage.go
@@ -26,13 +26,10 @@ type GrpcMessage struct {
 // GetParams will be deprecated after we remove old client
 // Currently needed because of parser.RPCInput interface
 func (gm GrpcMessage) GetParams() interface{} {
-
-	msgStr := string(gm.Msg)
-
 	var parsedData interface{}
-	err := json.Unmarshal([]byte(msgStr), &parsedData)
+	err := json.Unmarshal(gm.Msg, &parsedData)
 	if err != nil {
-		return nil
+		utils.LavaFormatError("GetParams Failed to unmarshal grpc message", err, utils.Attribute{Key: "message", Value: string(gm.Msg)})
 	}
 	return parsedData
 }

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -2,19 +2,41 @@ package rpcInterfaceMessages
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/lavanet/lava/protocol/parser"
 )
 
 type RestMessage struct {
-	Msg  []byte
-	Path string
+	Msg      []byte
+	Path     string
+	SpecPath string
 }
 
 // GetParams will be deprecated after we remove old client
 // Currently needed because of parser.RPCInput interface
 func (cp RestMessage) GetParams() interface{} {
-	return nil
+
+	var parsedMethod string
+	idx := strings.Index(cp.Path, "?")
+	if idx == -1 {
+		parsedMethod = cp.Path
+	} else {
+		parsedMethod = cp.Path[0:idx]
+	}
+
+	objectSpec := strings.Split(cp.SpecPath, "/")
+	objectPath := strings.Split(parsedMethod, "/")
+
+	var parameters []interface{}
+
+	for index, element := range objectSpec {
+		if strings.Contains(element, "{") {
+			parameters = append(parameters, objectPath[index])
+		}
+	}
+
+	return parameters
 }
 
 // GetResult will be deprecated after we remove old client

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -16,7 +16,6 @@ type RestMessage struct {
 // GetParams will be deprecated after we remove old client
 // Currently needed because of parser.RPCInput interface
 func (cp RestMessage) GetParams() interface{} {
-
 	var parsedMethod string
 	idx := strings.Index(cp.Path, "?")
 	if idx == -1 {

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
@@ -2,6 +2,8 @@ package rpcInterfaceMessages
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRestMessage(t *testing.T) {
@@ -14,9 +16,7 @@ func TestRestMessage(t *testing.T) {
 
 	// Test GetParams method
 	params := restMessage.GetParams()
-	if params == nil {
-		t.Errorf("Expected params, but got nil")
-	}
+	require.Nil(t, params)
 
 	// Test GetResult method
 	result := restMessage.GetResult()

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
@@ -9,9 +9,8 @@ import (
 func TestRestMessage(t *testing.T) {
 	// Test GetParams method
 	restMessage := RestMessage{
-		Path:     "eth_getTransactionByHash",
-		Msg:      []byte{1, 2, 3, 4, 5},
-		SpecPath: "eth_getTransactionByHash",
+		Path:     "blocks/latest",
+		SpecPath: "blocks/latest",
 	}
 
 	// Test GetParams method

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
@@ -7,14 +7,15 @@ import (
 func TestRestMessage(t *testing.T) {
 	// Test GetParams method
 	restMessage := RestMessage{
-		Path: "eth_getTransactionByHash",
-		Msg:  []byte{1, 2, 3, 4, 5},
+		Path:     "eth_getTransactionByHash",
+		Msg:      []byte{1, 2, 3, 4, 5},
+		SpecPath: "eth_getTransactionByHash",
 	}
 
 	// Test GetParams method
 	params := restMessage.GetParams()
-	if params != nil {
-		t.Errorf("Expected nil, but got %v", params)
+	if params == nil {
+		t.Errorf("Expected params, but got nil")
 	}
 
 	// Test GetResult method

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -153,8 +153,10 @@ func matchSpecApiByName(name string, serverApis map[string]spectypes.ServiceApi)
 			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: apiName})
 			continue
 		}
-		if re.Match([]byte(name)) {
-			return api, true
+		if re.MatchString(name) {
+			if re.FindStringIndex(name)[0] == 0 && re.FindStringIndex(name)[1] == len(name) {
+				return api, true
+			}
 		}
 	}
 	return spectypes.ServiceApi{}, false

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -148,15 +148,13 @@ func getServiceApis(spec spectypes.Spec, rpcInterface string) (retServerApis map
 func matchSpecApiByName(name string, serverApis map[string]spectypes.ServiceApi) (spectypes.ServiceApi, bool) {
 	// TODO: make it faster and better by not doing a regex instead using a better algorithm
 	for apiName, api := range serverApis {
-		re, err := regexp.Compile(apiName)
+		re, err := regexp.Compile("^" + apiName + "$")
 		if err != nil {
 			utils.LavaFormatError("regex Compile api", err, utils.Attribute{Key: "apiName", Value: apiName})
 			continue
 		}
 		if re.MatchString(name) {
-			if re.FindStringIndex(name)[0] == 0 && re.FindStringIndex(name)[1] == len(name) {
-				return api, true
-			}
+			return api, true
 		}
 	}
 	return spectypes.ServiceApi{}, false

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -25,7 +25,7 @@ func TestMatchSpecApiByName(t *testing.T) {
 		expectedOk  bool
 	}{
 		{
-			name: "test0",
+			name: "test1",
 			serverApis: map[string]spectypes.ServiceApi{
 				"/blocks/[^\\/\\s]+": {
 					Name: "/blocks/{height}",
@@ -56,7 +56,7 @@ func TestMatchSpecApiByName(t *testing.T) {
 			expectedOk:  true,
 		},
 		{
-			name: "test1",
+			name: "test2",
 			serverApis: map[string]spectypes.ServiceApi{
 				"/cosmos/base/tendermint/v1beta1/blocks/[^\\/\\s]+": {
 					Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
@@ -87,7 +87,7 @@ func TestMatchSpecApiByName(t *testing.T) {
 			expectedOk:  true,
 		},
 		{
-			name: "test2",
+			name: "test3",
 			serverApis: map[string]spectypes.ServiceApi{
 				"/cosmos/base/tendermint/v1beta1/blocks/latest": {
 					Name: "/cosmos/base/tendermint/v1beta1/blocks/latest",
@@ -117,36 +117,6 @@ func TestMatchSpecApiByName(t *testing.T) {
 			expectedApi: spectypes.ServiceApi{Name: "/cosmos/base/tendermint/v1beta1/blocks/latest"},
 			expectedOk:  true,
 		},
-		// {
-		// 	name: "test1",
-		// 	serverApis: map[string]spectypes.ServiceApi{
-		// 		"test1.*": {Name: "test1-api"},
-		// 		"test2.*": {Name: "test2-api"},
-		// 	},
-		// 	inputName:   "test1-match",
-		// 	expectedApi: spectypes.ServiceApi{Name: "test1-api"},
-		// 	expectedOk:  true,
-		// },
-		// {
-		// 	name: "test2",
-		// 	serverApis: map[string]spectypes.ServiceApi{
-		// 		"test1.*": {Name: "test1-api"},
-		// 		"test2.*": {Name: "test2-api"},
-		// 	},
-		// 	inputName:   "test2-match",
-		// 	expectedApi: spectypes.ServiceApi{Name: "test2-api"},
-		// 	expectedOk:  true,
-		// },
-		// {
-		// 	name: "test3",
-		// 	serverApis: map[string]spectypes.ServiceApi{
-		// 		"test1.*": {Name: "test1-api"},
-		// 		"test2.*": {Name: "test2-api"},
-		// 	},
-		// 	inputName:   "test3-match",
-		// 	expectedApi: spectypes.ServiceApi{},
-		// 	expectedOk:  false,
-		// },
 	}
 	for _, testCase := range testTable {
 		testCase := testCase

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -25,35 +25,128 @@ func TestMatchSpecApiByName(t *testing.T) {
 		expectedOk  bool
 	}{
 		{
+			name: "test0",
+			serverApis: map[string]spectypes.ServiceApi{
+				"/blocks/[^\\/\\s]+": {
+					Name: "/blocks/{height}",
+					BlockParsing: spectypes.BlockParser{
+						ParserArg:  []string{"0"},
+						ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
+					},
+					ComputeUnits: 10,
+					Enabled:      true,
+					ApiInterfaces: []spectypes.ApiInterface{
+						{Interface: "REST",
+							Type:     "GET",
+							Category: &spectypes.SpecCategory{Deterministic: true},
+						},
+					},
+					Parsing: spectypes.Parsing{
+						FunctionTag:      "",
+						FunctionTemplate: "",
+						ResultParsing: spectypes.BlockParser{
+							ParserArg:  []string{},
+							ParserFunc: spectypes.PARSER_FUNC_EMPTY,
+						},
+					},
+				},
+			},
+			inputName:   "/blocks/10",
+			expectedApi: spectypes.ServiceApi{Name: "/blocks/{height}"},
+			expectedOk:  true,
+		},
+		{
 			name: "test1",
 			serverApis: map[string]spectypes.ServiceApi{
-				"test1.*": {Name: "test1-api"},
-				"test2.*": {Name: "test2-api"},
+				"/cosmos/base/tendermint/v1beta1/blocks/[^\\/\\s]+": {
+					Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}",
+					BlockParsing: spectypes.BlockParser{
+						ParserArg:  []string{"0"},
+						ParserFunc: spectypes.PARSER_FUNC_PARSE_BY_ARG,
+					},
+					ComputeUnits: 10,
+					Enabled:      true,
+					ApiInterfaces: []spectypes.ApiInterface{
+						{Interface: "REST",
+							Type:     "GET",
+							Category: &spectypes.SpecCategory{Deterministic: true},
+						},
+					},
+					Parsing: spectypes.Parsing{
+						FunctionTag:      "getBlockByNumber",
+						FunctionTemplate: "/cosmos/base/tendermint/v1beta1/blocks/%d",
+						ResultParsing: spectypes.BlockParser{
+							ParserArg:  []string{"block_id", "hash"},
+							ParserFunc: spectypes.PARSER_FUNC_PARSE_CANONICAL,
+						},
+					},
+				},
 			},
-			inputName:   "test1-match",
-			expectedApi: spectypes.ServiceApi{Name: "test1-api"},
+			inputName:   "/cosmos/base/tendermint/v1beta1/blocks/10",
+			expectedApi: spectypes.ServiceApi{Name: "/cosmos/base/tendermint/v1beta1/blocks/{height}"},
 			expectedOk:  true,
 		},
 		{
 			name: "test2",
 			serverApis: map[string]spectypes.ServiceApi{
-				"test1.*": {Name: "test1-api"},
-				"test2.*": {Name: "test2-api"},
+				"/cosmos/base/tendermint/v1beta1/blocks/latest": {
+					Name: "/cosmos/base/tendermint/v1beta1/blocks/latest",
+					BlockParsing: spectypes.BlockParser{
+						ParserArg:  []string{"0"},
+						ParserFunc: spectypes.PARSER_FUNC_DEFAULT,
+					},
+					ComputeUnits: 10,
+					Enabled:      true,
+					ApiInterfaces: []spectypes.ApiInterface{
+						{Interface: "REST",
+							Type:     "GET",
+							Category: &spectypes.SpecCategory{Deterministic: true},
+						},
+					},
+					Parsing: spectypes.Parsing{
+						FunctionTag:      "getBlockByNumber",
+						FunctionTemplate: "/cosmos/base/tendermint/v1beta1/blocks/latest",
+						ResultParsing: spectypes.BlockParser{
+							ParserArg:  []string{"block", "header", "height"},
+							ParserFunc: spectypes.PARSER_FUNC_PARSE_CANONICAL,
+						},
+					},
+				},
 			},
-			inputName:   "test2-match",
-			expectedApi: spectypes.ServiceApi{Name: "test2-api"},
+			inputName:   "/cosmos/base/tendermint/v1beta1/blocks/latest",
+			expectedApi: spectypes.ServiceApi{Name: "/cosmos/base/tendermint/v1beta1/blocks/latest"},
 			expectedOk:  true,
 		},
-		{
-			name: "test3",
-			serverApis: map[string]spectypes.ServiceApi{
-				"test1.*": {Name: "test1-api"},
-				"test2.*": {Name: "test2-api"},
-			},
-			inputName:   "test3-match",
-			expectedApi: spectypes.ServiceApi{},
-			expectedOk:  false,
-		},
+		// {
+		// 	name: "test1",
+		// 	serverApis: map[string]spectypes.ServiceApi{
+		// 		"test1.*": {Name: "test1-api"},
+		// 		"test2.*": {Name: "test2-api"},
+		// 	},
+		// 	inputName:   "test1-match",
+		// 	expectedApi: spectypes.ServiceApi{Name: "test1-api"},
+		// 	expectedOk:  true,
+		// },
+		// {
+		// 	name: "test2",
+		// 	serverApis: map[string]spectypes.ServiceApi{
+		// 		"test1.*": {Name: "test1-api"},
+		// 		"test2.*": {Name: "test2-api"},
+		// 	},
+		// 	inputName:   "test2-match",
+		// 	expectedApi: spectypes.ServiceApi{Name: "test2-api"},
+		// 	expectedOk:  true,
+		// },
+		// {
+		// 	name: "test3",
+		// 	serverApis: map[string]spectypes.ServiceApi{
+		// 		"test1.*": {Name: "test1-api"},
+		// 		"test2.*": {Name: "test2-api"},
+		// 	},
+		// 	inputName:   "test3-match",
+		// 	expectedApi: spectypes.ServiceApi{},
+		// 	expectedOk:  false,
+		// },
 	}
 	for _, testCase := range testTable {
 		testCase := testCase

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -122,7 +122,7 @@ func (apip *GrpcChainParser) getSupportedApi(name string) (*spectypes.ServiceApi
 	defer apip.rwLock.RUnlock()
 
 	// Fetch server api by name
-	api, ok := matchSpecApiByName(name, apip.serverApis)
+	api, ok := apip.serverApis[name]
 
 	// Return an error if spec does not exist
 	if !ok {

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -78,12 +78,6 @@ func (apip *GrpcChainParser) ParseMsg(url string, data []byte, connectionType st
 		return nil, fmt.Errorf("could not find the interface %s in the service %s", connectionType, serviceApi.Name)
 	}
 
-	// Check if custom block parser exists in the api interface
-	// Use custom block parser only for URI calls
-	if apiInterface.GetOverwriteBlockParsing() != nil {
-		blockParser = *apiInterface.GetOverwriteBlockParsing()
-	}
-
 	// Construct grpcMessage
 	grpcMessage := rpcInterfaceMessages.GrpcMessage{
 		Msg:  data,

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -72,12 +72,6 @@ func (apip *RestChainParser) ParseMsg(url string, data []byte, connectionType st
 		return nil, fmt.Errorf("could not find the interface %s in the service %s", connectionType, serviceApi.Name)
 	}
 
-	// Check if custom block parser exists in the api interface
-	// Use custom block parser only for URI calls
-	if apiInterface.GetOverwriteBlockParsing() != nil {
-		blockParser = *apiInterface.GetOverwriteBlockParsing()
-	}
-
 	// Construct restMessage
 	restMessage := rpcInterfaceMessages.RestMessage{
 		Msg:  data,

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -80,18 +80,18 @@ func (apip *RestChainParser) ParseMsg(url string, data []byte, connectionType st
 
 	// Construct restMessage
 	restMessage := rpcInterfaceMessages.RestMessage{
-		Msg:      data,
-		Path:     url,
-		SpecPath: serviceApi.Name,
+		Msg:  data,
+		Path: url,
 	}
 	if connectionType == http.MethodGet {
 		// support for optional params, our listener puts them inside Msg data
 		restMessage = rpcInterfaceMessages.RestMessage{
-			Msg:      nil,
-			Path:     url + string(data),
-			SpecPath: serviceApi.Name,
+			Msg:  nil,
+			Path: url + string(data),
 		}
 	}
+	// add spec path to rest message so we can extract the requested block.
+	restMessage.SpecPath = serviceApi.Name
 
 	// Fetch requested block, it is used for data reliability
 	requestedBlock, err := parser.ParseBlockFromParams(restMessage, blockParser)

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lavanet/lava/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/lavanet/lava/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/lavanet/lava/protocol/lavasession"
+	"github.com/lavanet/lava/protocol/parser"
 	"github.com/lavanet/lava/utils"
 
 	pairingtypes "github.com/lavanet/lava/x/pairing/types"
@@ -63,26 +64,42 @@ func (apip *RestChainParser) ParseMsg(url string, data []byte, connectionType st
 		return nil, err
 	}
 
+	// Extract default block parser
+	blockParser := serviceApi.BlockParsing
+
 	apiInterface := GetApiInterfaceFromServiceApi(serviceApi, connectionType)
 	if apiInterface == nil {
 		return nil, fmt.Errorf("could not find the interface %s in the service %s", connectionType, serviceApi.Name)
 	}
 
+	// Check if custom block parser exists in the api interface
+	// Use custom block parser only for URI calls
+	if apiInterface.GetOverwriteBlockParsing() != nil {
+		blockParser = *apiInterface.GetOverwriteBlockParsing()
+	}
+
 	// Construct restMessage
 	restMessage := rpcInterfaceMessages.RestMessage{
-		Msg:  data,
-		Path: url,
+		Msg:      data,
+		Path:     url,
+		SpecPath: serviceApi.Name,
 	}
 	if connectionType == http.MethodGet {
 		// support for optional params, our listener puts them inside Msg data
 		restMessage = rpcInterfaceMessages.RestMessage{
-			Msg:  nil,
-			Path: url + string(data),
+			Msg:      nil,
+			Path:     url + string(data),
+			SpecPath: serviceApi.Name,
 		}
 	}
 
-	// TODO fix requested block
-	nodeMsg := apip.newChainMessage(serviceApi, apiInterface, spectypes.NOT_APPLICABLE, restMessage)
+	// Fetch requested block, it is used for data reliability
+	requestedBlock, err := parser.ParseBlockFromParams(restMessage, blockParser)
+	if err != nil {
+		return nil, utils.LavaFormatError("ParseBlockFromParams failed parsing block", err, utils.Attribute{Key: "chain", Value: apip.spec.Name}, utils.Attribute{Key: "blockParsing", Value: serviceApi.BlockParsing})
+	}
+
+	nodeMsg := apip.newChainMessage(serviceApi, apiInterface, requestedBlock, restMessage)
 	return nodeMsg, nil
 }
 

--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -111,8 +111,9 @@ func TestRestParseMessage(t *testing.T) {
 	assert.Equal(t, msg.GetServiceApi().Name, apip.serverApis["API1"].Name)
 
 	restMessage := rpcInterfaceMessages.RestMessage{
-		Msg:  []byte("test message"),
-		Path: "API1",
+		Msg:      []byte("test message"),
+		Path:     "API1",
+		SpecPath: "API1",
 	}
 
 	assert.Equal(t, restMessage, msg.GetRPCMessage())

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -308,11 +307,7 @@ func ParseDictionary(rpcInput RPCInput, input []string, dataSource int) ([]inter
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			val, err := convertInterfaceToString(val)
-			if err != nil {
-				return nil, err
-			}
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(blockInterfaceToString(val)), nil
 		}
 
 		// Else return an error
@@ -364,28 +359,16 @@ func ParseDictionaryOrOrdered(rpcInput RPCInput, input []string, dataSource int)
 
 		// Fetch value using prop index
 		block := unmarshalledDataTyped[propIndex]
-		block, err := convertInterfaceToString(block)
-		if err != nil {
-			return nil, err
-		}
-		return appendInterfaceToInterfaceArray(block), nil
+		return appendInterfaceToInterfaceArray(blockInterfaceToString(block)), nil
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			val, err := convertInterfaceToString(val)
-			if err != nil {
-				return nil, err
-			}
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(blockInterfaceToString(val)), nil
 		}
 
 		// If attribute with key index exists return value
 		if val, ok := unmarshalledDataTyped[inp]; ok {
-			val, err := convertInterfaceToString(val)
-			if err != nil {
-				return nil, err
-			}
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(blockInterfaceToString(val)), nil
 		}
 
 		// Else return not set error
@@ -423,15 +406,4 @@ func appendInterfaceToInterfaceArray(value interface{}) []interface{} {
 	retArr := make([]interface{}, 0)
 	retArr = append(retArr, value)
 	return retArr
-}
-
-func convertInterfaceToString(input interface{}) (string, error) {
-	switch inp := input.(type) {
-	case string:
-		return inp, nil
-	case float64:
-		return strconv.FormatFloat(inp, 'f', -1, 64), nil
-	default:
-		return "", utils.LavaFormatError("Failed to convert to string, unknown type", nil, utils.Attribute{Key: "input.(type)", Value: reflect.TypeOf(input)})
-	}
 }

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -307,7 +307,7 @@ func ParseDictionary(rpcInput RPCInput, input []string, dataSource int) ([]inter
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
 		}
 
 		// Else return an error

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -360,16 +360,16 @@ func ParseDictionaryOrOrdered(rpcInput RPCInput, input []string, dataSource int)
 		// Fetch value using prop index
 		block := unmarshalledDataTyped[propIndex]
 
-		return appendInterfaceToInterfaceArray(block), nil
+		return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", block)), nil
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
 		}
 
 		// If attribute with key index exists return value
 		if val, ok := unmarshalledDataTyped[inp]; ok {
-			return appendInterfaceToInterfaceArray(val), nil
+			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
 		}
 
 		// Else return not set error

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -307,7 +308,11 @@ func ParseDictionary(rpcInput RPCInput, input []string, dataSource int) ([]inter
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
+			val, err := convertInterfaceToString(val)
+			if err != nil {
+				return nil, err
+			}
+			return appendInterfaceToInterfaceArray(val), nil
 		}
 
 		// Else return an error
@@ -359,17 +364,28 @@ func ParseDictionaryOrOrdered(rpcInput RPCInput, input []string, dataSource int)
 
 		// Fetch value using prop index
 		block := unmarshalledDataTyped[propIndex]
-
-		return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", block)), nil
+		block, err := convertInterfaceToString(block)
+		if err != nil {
+			return nil, err
+		}
+		return appendInterfaceToInterfaceArray(block), nil
 	case map[string]interface{}:
 		// If attribute with key propName exists return value
 		if val, ok := unmarshalledDataTyped[propName]; ok {
-			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
+			val, err := convertInterfaceToString(val)
+			if err != nil {
+				return nil, err
+			}
+			return appendInterfaceToInterfaceArray(val), nil
 		}
 
 		// If attribute with key index exists return value
 		if val, ok := unmarshalledDataTyped[inp]; ok {
-			return appendInterfaceToInterfaceArray(fmt.Sprintf("%v", val)), nil
+			val, err := convertInterfaceToString(val)
+			if err != nil {
+				return nil, err
+			}
+			return appendInterfaceToInterfaceArray(val), nil
 		}
 
 		// Else return not set error
@@ -407,4 +423,15 @@ func appendInterfaceToInterfaceArray(value interface{}) []interface{} {
 	retArr := make([]interface{}, 0)
 	retArr = append(retArr, value)
 	return retArr
+}
+
+func convertInterfaceToString(input interface{}) (string, error) {
+	switch inp := input.(type) {
+	case string:
+		return inp, nil
+	case float64:
+		return fmt.Sprintf("%v", inp), nil
+	default:
+		return "", utils.LavaFormatError("Failed to convert to string, unknown type", nil, utils.Attribute{Key: "input.(type)", Value: reflect.TypeOf(input)})
+	}
 }

--- a/protocol/parser/parser.go
+++ b/protocol/parser/parser.go
@@ -430,7 +430,7 @@ func convertInterfaceToString(input interface{}) (string, error) {
 	case string:
 		return inp, nil
 	case float64:
-		return fmt.Sprintf("%v", inp), nil
+		return strconv.FormatFloat(inp, 'f', -1, 64), nil
 	default:
 		return "", utils.LavaFormatError("Failed to convert to string, unknown type", nil, utils.Attribute{Key: "input.(type)", Value: reflect.TypeOf(input)})
 	}

--- a/protocol/rpcprovider/rewardserver/reward_server.go
+++ b/protocol/rpcprovider/rewardserver/reward_server.go
@@ -73,7 +73,7 @@ type RewardsTxSender interface {
 func (rws *RewardServer) SendNewProof(ctx context.Context, proof *pairingtypes.RelaySession, epoch uint64, consumerAddr string, apiInterface string) (existingCU uint64, updatedWithProof bool) {
 	rws.lock.Lock() // assuming 99% of the time we will need to write the new entry so there's no use in doing the read lock first to check stuff
 	defer rws.lock.Unlock()
-	consumerRewardsKey := proof.SpecId + apiInterface + consumerAddr
+	consumerRewardsKey := getKeyForConsumerRewards(proof.SpecId, apiInterface, consumerAddr)
 	epochRewards, ok := rws.rewards[epoch]
 	if !ok {
 		proofs := map[uint64]*pairingtypes.RelaySession{proof.SessionId: proof}
@@ -104,7 +104,7 @@ func (rws *RewardServer) SendNewProof(ctx context.Context, proof *pairingtypes.R
 func (rws *RewardServer) SendNewDataReliabilityProof(ctx context.Context, dataReliability *pairingtypes.VRFData, epoch uint64, consumerAddr string, specId string, apiInterface string) (updatedWithProof bool) {
 	rws.lock.Lock() // assuming 99% of the time we will need to write the new entry so there's no use in doing the read lock first to check stuff
 	defer rws.lock.Unlock()
-	consumerRewardsKey := specId + apiInterface + consumerAddr
+	consumerRewardsKey := getKeyForConsumerRewards(specId, apiInterface, consumerAddr)
 	epochRewards, ok := rws.rewards[epoch]
 	if !ok {
 		consumerRewardsMap := map[string]*ConsumerRewards{(consumerRewardsKey): {epoch: epoch, consumer: consumerAddr, proofs: map[uint64]*pairingtypes.RelaySession{}, dataReliabilityProofs: []*pairingtypes.VRFData{dataReliability}}}
@@ -366,4 +366,8 @@ func BuildPaymentFromRelayPaymentEvent(event terderminttypes.Event, block int64)
 		ChainID:             chainID,
 	}
 	return payment, nil
+}
+
+func getKeyForConsumerRewards(specId string, apiInterface string, consumerAddress string) string {
+	return specId + apiInterface + consumerAddress
 }


### PR DESCRIPTION
The requested block has been added to the `newChainMessage`, replacing the prior usage of `spectypes.NOT_APPLICABLE` for both REST and gRPC interfaces.