### PR TITLE
Enable snapshots

### DIFF
--- a/cmd/lavad/cmd/root.go
+++ b/cmd/lavad/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"path/filepath"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -16,6 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/snapshots"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
@@ -239,6 +241,17 @@ func (a appCreator) newApp(
 	if err != nil {
 		panic(err)
 	}
+	
+	// Add snapshots
+	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
+        snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
+        if err != nil {
+                panic(err)
+        }
+        snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
+        if err != nil {
+                panic(err)
+        }
 
 	return app.New(
 		logger,
@@ -258,6 +271,9 @@ func (a appCreator) newApp(
 		baseapp.SetInterBlockCache(cache),
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
+		baseapp.SetSnapshotStore(snapshotStore),
+	        baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
+	        baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
 	)
 }
 


### PR DESCRIPTION
Enable snapshots for testnet to enable validators to more quickly deploy nodes/run experiments