### PR TITLE
CNS-382 fixation update prefix

### DIFF
--- a/common/fixation_entry.go
+++ b/common/fixation_entry.go
@@ -418,8 +418,8 @@ func (fs *FixationStore) GetAllEntryVersions(ctx sdk.Context, index string, stal
 	return fs.getEntryVersionsFilter(ctx, index, 0, filter)
 }
 
-func (fs *FixationStore) createStoreKey(index string) string {
-	return types.EntryPrefix + fs.prefix + index
+func (fs *FixationStore) createEntryStoreKey(index string) string {
+	return fs.prefix + types.EntryPrefix + index
 }
 
 func (fs *FixationStore) AdvanceBlock(ctx sdk.Context) {

--- a/common/fixation_entry.go
+++ b/common/fixation_entry.go
@@ -80,16 +80,16 @@ type FixationStore struct {
 	tstore   TimerStore
 }
 
-func (fs *FixationStore) getStore(ctx sdk.Context, index string) *prefix.Store {
+func (fs *FixationStore) getEntryStore(ctx sdk.Context, index string) *prefix.Store {
 	store := prefix.NewStore(
 		ctx.KVStore(fs.storeKey),
-		types.KeyPrefix(fs.createStoreKey(index)))
+		types.KeyPrefix(fs.createEntryStoreKey(index)))
 	return &store
 }
 
 // getEntry returns an existing entry in the store
 func (fs *FixationStore) getEntry(ctx sdk.Context, safeIndex string, block uint64) (entry types.Entry) {
-	store := fs.getStore(ctx, safeIndex)
+	store := fs.getEntryStore(ctx, safeIndex)
 	byteKey := types.EncodeKey(block)
 	b := store.Get(byteKey)
 	if b == nil {
@@ -101,7 +101,7 @@ func (fs *FixationStore) getEntry(ctx sdk.Context, safeIndex string, block uint6
 
 // setEntry modifies an existing entry in the store
 func (fs *FixationStore) setEntry(ctx sdk.Context, entry types.Entry) {
-	store := fs.getStore(ctx, entry.Index)
+	store := fs.getEntryStore(ctx, entry.Index)
 	byteKey := types.EncodeKey(entry.Block)
 	marshaledEntry := fs.cdc.MustMarshal(&entry)
 	store.Set(byteKey, marshaledEntry)
@@ -164,7 +164,7 @@ func (fs *FixationStore) AppendEntry(
 
 func (fs *FixationStore) deleteStaleEntries(ctx sdk.Context, safeIndex string) {
 	types.AssertSanitizedIndex(safeIndex, fs.prefix)
-	store := fs.getStore(ctx, safeIndex)
+	store := fs.getEntryStore(ctx, safeIndex)
 
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
 	defer iterator.Close()
@@ -251,7 +251,7 @@ func (fs *FixationStore) ModifyEntry(ctx sdk.Context, index string, block uint64
 // nearest-smaller block version for the given block arg.
 func (fs *FixationStore) getUnmarshaledEntryForBlock(ctx sdk.Context, safeIndex string, block uint64) (types.Entry, bool) {
 	types.AssertSanitizedIndex(safeIndex, fs.prefix)
-	store := fs.getStore(ctx, safeIndex)
+	store := fs.getEntryStore(ctx, safeIndex)
 
 	// init a reverse iterator
 	iterator := sdk.KVStoreReversePrefixIterator(store, []byte{})
@@ -350,8 +350,72 @@ func (fs *FixationStore) PutEntry(ctx sdk.Context, index string, block uint64) {
 
 // removeEntry removes an entry from the store
 func (fs *FixationStore) removeEntry(ctx sdk.Context, index string, block uint64) {
-	store := fs.getStore(ctx, index)
+	store := fs.getEntryStore(ctx, index)
 	store.Delete(types.EncodeKey(block))
+}
+
+func (fs *FixationStore) getEntryVersionsFilter(ctx sdk.Context, index string, block uint64, filter func(*types.Entry) bool) (blocks []uint64) {
+	safeIndex, err := types.SanitizeIndex(index)
+	if err != nil {
+		details := map[string]string{"index": index}
+		utils.LavaError(ctx, ctx.Logger(), "getEntryVersionsFilter", details, "invalid non-ascii entry")
+		return nil
+	}
+
+	store := fs.getEntryStore(ctx, safeIndex)
+
+	iterator := sdk.KVStoreReversePrefixIterator(store, []byte{})
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var entry types.Entry
+		fs.cdc.MustUnmarshal(iterator.Value(), &entry)
+
+		if filter(&entry) {
+			blocks = append(blocks, entry.Block)
+		}
+
+		if entry.Block <= block {
+			break
+		}
+	}
+
+	// reverse the result slice to return the block in ascending order
+	length := len(blocks)
+	for i := 0; i < length/2; i++ {
+		blocks[i], blocks[length-i-1] = blocks[length-i-1], blocks[i]
+	}
+
+	return blocks
+}
+
+// GetEntryVersionsRange returns a list of versions from nearest-smaller block
+// and onward, and not more than delta blocks further (skip stale entries).
+func (fs *FixationStore) GetEntryVersionsRange(ctx sdk.Context, index string, block, delta uint64) (blocks []uint64) {
+	filter := func(entry *types.Entry) bool {
+		if entry.IsStale(ctx) {
+			return false
+		}
+		if entry.Block > block+delta {
+			return false
+		}
+		return true
+	}
+
+	return fs.getEntryVersionsFilter(ctx, index, block, filter)
+}
+
+// GetAllEntryVersions returns a list of all versions (blocks) of an entry.
+// If stale == true, then the output will include stale versions (for testing).
+func (fs *FixationStore) GetAllEntryVersions(ctx sdk.Context, index string, stale bool) (blocks []uint64) {
+	filter := func(entry *types.Entry) bool {
+		if !stale && entry.IsStale(ctx) {
+			return false
+		}
+		return true
+	}
+
+	return fs.getEntryVersionsFilter(ctx, index, 0, filter)
 }
 
 func (fs *FixationStore) createStoreKey(index string) string {

--- a/common/fixation_entry_index.go
+++ b/common/fixation_entry_index.go
@@ -4,7 +4,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/common/types"
-	"github.com/lavanet/lava/utils"
 )
 
 // FixationStore manages lists of entries with versions in the store.
@@ -31,20 +30,20 @@ func (fs FixationStore) setEntryIndex(ctx sdk.Context, safeIndex string) {
 	types.AssertSanitizedIndex(safeIndex, fs.prefix)
 	store := fs.getEntryIndexStore(ctx)
 	appendedValue := []byte(safeIndex) // convert the index value to a byte array
-	store.Set(types.KeyPrefix(fs.createEntryIndexKey(safeIndex)), appendedValue)
+	store.Set(types.KeyPrefix(safeIndex), appendedValue)
 }
 
 // removeEntryIndex removes an Entry index from the store
 func (fs FixationStore) removeEntryIndex(ctx sdk.Context, safeIndex string) {
 	types.AssertSanitizedIndex(safeIndex, fs.prefix)
 	store := fs.getEntryIndexStore(ctx)
-	store.Delete(types.KeyPrefix(fs.createEntryIndexKey(safeIndex)))
+	store.Delete(types.KeyPrefix(safeIndex))
 }
 
 // GetAllEntryIndexWithPrefix returns all Entry indices with a given prefix
 func (fs FixationStore) GetAllEntryIndicesWithPrefix(ctx sdk.Context, prefix string) []string {
 	store := fs.getEntryIndexStore(ctx)
-	entryPrefix := types.KeyPrefix(fs.createEntryIndexKey(prefix))
+	entryPrefix := types.KeyPrefix(prefix)
 	iterator := sdk.KVStorePrefixIterator(store, entryPrefix)
 	defer iterator.Close()
 
@@ -64,74 +63,6 @@ func (fs FixationStore) GetAllEntryIndices(ctx sdk.Context) []string {
 	return fs.GetAllEntryIndicesWithPrefix(ctx, "")
 }
 
-func (fs *FixationStore) getEntryVersionsFilter(ctx sdk.Context, index string, block uint64, filter func(*types.Entry) bool) (blocks []uint64) {
-	safeIndex, err := types.SanitizeIndex(index)
-	if err != nil {
-		details := map[string]string{"index": index}
-		utils.LavaError(ctx, ctx.Logger(), "getEntryVersionsFilter", details, "invalid non-ascii entry")
-		return nil
-	}
-
-	store := fs.getStore(ctx, safeIndex)
-
-	iterator := sdk.KVStoreReversePrefixIterator(store, []byte{})
-	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		var entry types.Entry
-		fs.cdc.MustUnmarshal(iterator.Value(), &entry)
-
-		if filter(&entry) {
-			blocks = append(blocks, entry.Block)
-		}
-
-		if entry.Block <= block {
-			break
-		}
-	}
-
-	// reverse the result slice to return the block in ascending order
-	length := len(blocks)
-	for i := 0; i < length/2; i++ {
-		blocks[i], blocks[length-i-1] = blocks[length-i-1], blocks[i]
-	}
-
-	return blocks
-}
-
-// GetEntryVersionsRange returns a list of versions from nearest-smaller block
-// and onward, and not more than delta blocks further (skip stale entries).
-func (fs *FixationStore) GetEntryVersionsRange(ctx sdk.Context, index string, block, delta uint64) (blocks []uint64) {
-	filter := func(entry *types.Entry) bool {
-		if entry.IsStale(ctx) {
-			return false
-		}
-		if entry.Block > block+delta {
-			return false
-		}
-		return true
-	}
-
-	return fs.getEntryVersionsFilter(ctx, index, block, filter)
-}
-
-// GetAllEntryVersions returns a list of all versions (blocks) of an entry.
-// If stale == true, then the output will include stale versions (for testing).
-func (fs *FixationStore) GetAllEntryVersions(ctx sdk.Context, index string, stale bool) (blocks []uint64) {
-	filter := func(entry *types.Entry) bool {
-		if !stale && entry.IsStale(ctx) {
-			return false
-		}
-		return true
-	}
-
-	return fs.getEntryVersionsFilter(ctx, index, 0, filter)
-}
-
 func (fs FixationStore) createEntryIndexStoreKey() string {
 	return types.EntryIndexPrefix + fs.prefix
-}
-
-func (fs FixationStore) createEntryIndexKey(safeIndex string) string {
-	return types.EntryIndexPrefix + fs.prefix + safeIndex
 }

--- a/common/fixation_entry_index.go
+++ b/common/fixation_entry_index.go
@@ -64,5 +64,5 @@ func (fs FixationStore) GetAllEntryIndices(ctx sdk.Context) []string {
 }
 
 func (fs FixationStore) createEntryIndexStoreKey() string {
-	return types.EntryIndexPrefix + fs.prefix
+	return fs.prefix + types.EntryIndexPrefix
 }

--- a/common/fixation_migrate.go
+++ b/common/fixation_migrate.go
@@ -19,6 +19,7 @@ var fixationMigrators = map[int]func(sdk.Context, *FixationStore) error{
 	2: fixationMigrate2to3,
 }
 
+// MigrateVerrsion performs pending internal version migration(s), if any.
 func (fs *FixationStore) MigrateVersion(ctx sdk.Context) (err error) {
 	from := fs.getVersion(ctx)
 	to := types.FixationVersion()
@@ -41,9 +42,10 @@ func (fs *FixationStore) MigrateVersion(ctx sdk.Context) (err error) {
 	return nil
 }
 
-// MigratePrefix replaces objects' prefixes from `oldPrefix` to the current `fs.prefix`
-// NOTE: it first tries to perform fs.MigrateVersion() with the old prefix.
-func (fs *FixationStore) MigratePrefix(ctx sdk.Context, oldPrefix string) (err error) {
+// MigrateVersionAndPrefix performs pending internal version migration(s),
+// if any, and then replaces the old prefix with a new (current) one. (For
+// the version migration(s) it uses the old prefix).
+func (fs *FixationStore) MigrateVersionAndPrefix(ctx sdk.Context, oldPrefix string) (err error) {
 	newPrefix := fs.prefix
 
 	// first check if version upgrade is due - must use old prefix

--- a/common/fixation_migrate_test.go
+++ b/common/fixation_migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/common/types"
 	"github.com/stretchr/testify/require"
@@ -86,5 +87,112 @@ func TestMigrate1to2(t *testing.T) {
 		} else {
 			require.Equal(t, uint64(math.MaxUint64), entry.StaleAt, what)
 		}
+	}
+}
+
+type mockEntry2to3 struct {
+	index string
+	block uint64
+	head  bool
+}
+
+// V2_setEntryIndex stores an Entry index in the store
+func (fs FixationStore) V2_setEntryIndex(ctx sdk.Context, safeIndex string) {
+	storePrefix := types.EntryIndexPrefix + fs.prefix
+	store := prefix.NewStore(ctx.KVStore(fs.storeKey), types.KeyPrefix(storePrefix))
+	appendedValue := []byte(safeIndex) // convert the index value to a byte array
+	store.Set(types.KeyPrefix(storePrefix+safeIndex), appendedValue)
+}
+
+// V2_setEntry modifies an existing entry in the store
+func (fs *FixationStore) V2_setEntry(ctx sdk.Context, entry types.Entry) {
+	storePrefix := types.EntryPrefix + fs.prefix + entry.Index
+	store := prefix.NewStore(ctx.KVStore(fs.storeKey), types.KeyPrefix(storePrefix))
+	byteKey := types.EncodeKey(entry.Block)
+	marshaledEntry := fs.cdc.MustMarshal(&entry)
+	store.Set(byteKey, marshaledEntry)
+}
+
+func countWithPrefix(store *prefix.Store, prefix string) int {
+	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefix(prefix))
+	defer iterator.Close()
+
+	count := 0
+	for ; iterator.Valid(); iterator.Next() {
+		count += 1
+	}
+	return count
+}
+
+func TestMigrate2to3(t *testing.T) {
+	var err error
+
+	ctx, cdc := initCtx(t)
+	fs := NewFixationStore(mockStoreKey, cdc, mockPrefix)
+	coin := sdk.Coin{Denom: "utest", Amount: sdk.NewInt(1)}
+
+	templates := []mockEntry2to3{
+		// entry_1 has 3 valid versions
+		{"entry_1", 100, false},
+		{"entry_1", 200, false},
+		{"entry_1", 300, true},
+		// entry_2 has 2 valid versions, one stale-at
+		{"entry_2", 100, false},
+		{"entry_2", 200, false},
+		{"entry_2", 300, true},
+		// entry_3 has 2 valid versions, head with extra refcount
+		{"entry_3", 100, false},
+		{"entry_3", 200, false},
+		{"entry_3", 300, true},
+	}
+
+	// set version to v2
+	fs.setVersion(ctx, 2)
+
+	// create v2 entries
+	numEntries, numHeads := 0, 0
+	for _, tt := range templates {
+		what := fmt.Sprintf("before: index: %s, block: %d", tt.index, tt.block)
+		safeIndex, err := types.SanitizeIndex(tt.index)
+		require.Nil(t, err, what)
+		if tt.head {
+			fs.V2_setEntryIndex(ctx, safeIndex)
+			numHeads += 1
+		}
+		entry := types.Entry{
+			Index:    safeIndex,
+			Block:    tt.block,
+			StaleAt:  math.MaxUint64,
+			Data:     fs.cdc.MustMarshal(&coin),
+			Refcount: 1,
+		}
+		fs.V2_setEntry(ctx, entry)
+		numEntries += 1
+	}
+
+	// verify entry count before migration
+	store_V2 := prefix.NewStore(ctx.KVStore(fs.storeKey), []byte{})
+	require.Equal(t, 1+numHeads+numEntries, countWithPrefix(&store_V2, ""))
+	require.Equal(t, numHeads+numEntries, countWithPrefix(&store_V2, "Entry"))
+
+	// perform migration version 2 to version 3
+	err = fs.MigrateVersion(ctx)
+	require.Nil(t, err, "migration version 2 to version 3")
+
+	// verify version upgrade
+	require.Equal(t, uint64(3), fs.getVersion(ctx))
+
+	// verify entry count before migration
+	store_V3 := prefix.NewStore(ctx.KVStore(fs.storeKey), []byte{})
+	require.Equal(t, 1+numHeads+numEntries, countWithPrefix(&store_V3, ""))
+	require.Equal(t, 1+numHeads+numEntries, countWithPrefix(&store_V3, mockPrefix))
+
+	// verify entries after migration
+	for _, tt := range templates {
+		what := fmt.Sprintf("after: index: %s, block: %d", tt.index, tt.block)
+		safeIndex, err := types.SanitizeIndex(tt.index)
+		require.Nil(t, err, what)
+		_, found := fs.getUnmarshaledEntryForBlock(ctx, safeIndex, tt.block)
+		require.True(t, found, what)
 	}
 }

--- a/common/types/fixationEntry.go
+++ b/common/types/fixationEntry.go
@@ -5,7 +5,7 @@ import (
 )
 
 func FixationVersion() uint64 {
-	return 2
+	return 3
 }
 
 // IsStale tests whether an entry is stale, i.e. has refcount zero _and_

--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -10,8 +10,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -242,7 +242,7 @@ func NewGRPCConnector(ctx context.Context, nConns uint, nodeUrl common.NodeUrl) 
 		cacert := nodeUrl.AuthConfig.GetCaCertificateParams()
 		if cacert != "" {
 			utils.LavaFormatDebug("Loading ca certificate from local path", utils.Attribute{Key: "cacert", Value: cacert})
-			caCert, err := ioutil.ReadFile(cacert)
+			caCert, err := os.ReadFile(cacert)
 			if err == nil {
 				caCertPool := x509.NewCertPool()
 				caCertPool.AppendCertsFromPEM(caCert)

--- a/x/plans/keeper/migrations.go
+++ b/x/plans/keeper/migrations.go
@@ -18,7 +18,8 @@ func NewMigrator(keeper Keeper) Migrator {
 }
 
 // Migrate2to3 implements store migration from v1 to v2:
-// Trigger the version upgrade of the planFS fixation store
+// - Trigger the version upgrade of the planFS fixation store
+// - Update plan policy
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	if err := m.keeper.plansFS.MigrateVersion(ctx); err != nil {
 		return fmt.Errorf("%w: plans fixation-store", err)
@@ -55,6 +56,24 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 
 			m.keeper.plansFS.ModifyEntry(ctx, planIndex, block, &plan_v3)
 		}
+	}
+
+	return nil
+}
+
+// Migrate3to4 implements store migration from v3 to v4:
+// - Trigger the version upgrade of the planFS fixation store
+// - Replace the store prefix from module-name ("plan") to "plan-fs"
+func (m Migrator) Migrate3to4(ctx sdk.Context) error {
+	const V4_PlanFixationStorePrefix = "plan"
+
+	// Note: MigratePrefix() already calls MigrateVersion() and thus will perform
+	// FixationStore version migration if needed, using the old prefix first.
+	// (This is required because otherwise the usual fixation-store MigrateVersion
+	// would wrongly use the new prefix).
+
+	if err := m.keeper.plansFS.MigratePrefix(ctx, V4_PlanFixationStorePrefix); err != nil {
+		return fmt.Errorf("%w: plans fixation-store", err)
 	}
 
 	return nil

--- a/x/plans/keeper/migrations.go
+++ b/x/plans/keeper/migrations.go
@@ -67,12 +67,10 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	const V4_PlanFixationStorePrefix = "plan"
 
-	// Note: MigratePrefix() already calls MigrateVersion() and thus will perform
-	// FixationStore version migration if needed, using the old prefix first.
-	// (This is required because otherwise the usual fixation-store MigrateVersion
-	// would wrongly use the new prefix).
+	// MigrateVersionAndPrefix() will take care of calling MigrateVersion()
+	// with the old prefix first, before changing to the new (current) prefix.
 
-	if err := m.keeper.plansFS.MigratePrefix(ctx, V4_PlanFixationStorePrefix); err != nil {
+	if err := m.keeper.plansFS.MigrateVersionAndPrefix(ctx, V4_PlanFixationStorePrefix); err != nil {
 		return fmt.Errorf("%w: plans fixation-store", err)
 	}
 

--- a/x/plans/module.go
+++ b/x/plans/module.go
@@ -140,6 +140,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err := cfg.RegisterMigration(types.ModuleName, 2, migrator.Migrate2to3); err != nil {
 		panic(fmt.Errorf("%s: failed to register migration to v3: %w", types.ModuleName, err))
 	}
+	// register v3 -> v4 migration
+	if err := cfg.RegisterMigration(types.ModuleName, 3, migrator.Migrate3to4); err != nil {
+		panic(fmt.Errorf("%s: failed to register migration to v4: %w", types.ModuleName, err))
+	}
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -164,7 +168,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 3 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/x/plans/types/keys.go
+++ b/x/plans/types/keys.go
@@ -19,7 +19,7 @@ const (
 	// Proposals router keys
 	ProposalsRouterKey = "planproposals"
 
-	PlanFixationStorePrefix = ModuleName
+	PlanFixationStorePrefix = "plan-fs"
 )
 
 func KeyPrefix(p string) []byte {

--- a/x/projects/keeper/migrations.go
+++ b/x/projects/keeper/migrations.go
@@ -16,14 +16,22 @@ func NewMigrator(keeper Keeper) Migrator {
 	return Migrator{keeper: keeper}
 }
 
-// Migrate2to3 implements store migration from v2 to v3:
-// Trigger version upgrade of the projectsFS, develooperKeysFS fixation stores
-func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+func (m Migrator) migrateFixationsVersion(ctx sdk.Context) error {
 	if err := m.keeper.projectsFS.MigrateVersion(ctx); err != nil {
 		return fmt.Errorf("%w: projects fixation-store", err)
 	}
 	if err := m.keeper.developerKeysFS.MigrateVersion(ctx); err != nil {
 		return fmt.Errorf("%w: developerKeys fixation-store", err)
+	}
+	return nil
+}
+
+// Migrate2to3 implements store migration from v2 to v3:
+// - Trigger version upgrade of the projectsFS, develooperKeysFS fixation stores
+// - Update keys contents
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	if err := m.migrateFixationsVersion(ctx); err != nil {
+		return err
 	}
 
 	projectIndices := m.keeper.projectsFS.GetAllEntryIndices(ctx)
@@ -100,5 +108,14 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// Migrate3to4 implements store migration from v3 to v4:
+// - Trigger version upgrade of the projectsFS, develooperKeysFS fixation-stores
+func (m Migrator) Migrate3to4(ctx sdk.Context) error {
+	if err := m.migrateFixationsVersion(ctx); err != nil {
+		return err
+	}
 	return nil
 }

--- a/x/projects/module.go
+++ b/x/projects/module.go
@@ -141,6 +141,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err := cfg.RegisterMigration(types.ModuleName, 2, migrator.Migrate2to3); err != nil {
 		panic(fmt.Errorf("%s: failed to register migration to v3: %w", types.ModuleName, err))
 	}
+	// register v3 -> v4 migration
+	if err := cfg.RegisterMigration(types.ModuleName, 3, migrator.Migrate3to4); err != nil {
+		panic(fmt.Errorf("%s: failed to register migration to v4: %w", types.ModuleName, err))
+	}
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -165,7 +169,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 3 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {


### PR DESCRIPTION
This PR creates a new migration v2 to v3 of FixationStore to fix the use of prefix.
It also creates an upgrade to modules "plan" and "project" to run this migration.
Finally, it changes the prefix used by module "plan" to be consistent with our naming.