### PR TITLE
CNS-374: fix vrfIndex mismatch between consumer and provider

### DIFF
--- a/protocol/lavasession/end_to_end_lavasession_test.go
+++ b/protocol/lavasession/end_to_end_lavasession_test.go
@@ -50,7 +50,7 @@ func TestHappyFlowE2E(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, ConsumerNotRegisteredYet.Is(err))
 	// expect session to be missing, so we need to register it for the first time
-	sps, err = psm.RegisterProviderSessionWithConsumer(ctx, consumerOneAddress, uint64(cs.Client.PairingEpoch), uint64(cs.SessionId), cs.RelayNum, cs.Client.MaxComputeUnits, selfProviderIndex)
+	sps, err = psm.RegisterProviderSessionWithConsumer(ctx, consumerOneAddress, uint64(cs.Client.PairingEpoch), uint64(cs.SessionId), cs.RelayNum, cs.Client.MaxComputeUnits, selfProviderIndex, pairedProviders)
 	// validate session was added
 	require.NotEmpty(t, psm.sessionsWithAllConsumers)
 	require.Nil(t, err)

--- a/protocol/lavasession/provider_session_manager_test.go
+++ b/protocol/lavasession/provider_session_manager_test.go
@@ -27,6 +27,7 @@ const (
 	epoch2                         = testNumberOfBlocksKeptInMemory + epoch1
 	consumerOneAddress             = "consumer1"
 	selfProviderIndex              = int64(1)
+	pairedProviders                = int64(1)
 )
 
 func initProviderSessionManager() *ProviderSessionManager {
@@ -53,7 +54,7 @@ func prepareSession(t *testing.T, ctx context.Context) (*ProviderSessionManager,
 	require.True(t, ConsumerNotRegisteredYet.Is(err))
 
 	// expect session to be missing, so we need to register it for the first time
-	sps, err = psm.RegisterProviderSessionWithConsumer(ctx, consumerOneAddress, epoch1, sessionId, relayNumber, maxCu, selfProviderIndex)
+	sps, err = psm.RegisterProviderSessionWithConsumer(ctx, consumerOneAddress, epoch1, sessionId, relayNumber, maxCu, selfProviderIndex, pairedProviders)
 
 	// validate session was added
 	require.NotEmpty(t, psm.sessionsWithAllConsumers)
@@ -79,7 +80,7 @@ func prepareDRSession(t *testing.T, ctx context.Context) (*ProviderSessionManage
 	psm := initProviderSessionManager()
 
 	// get data reliability session
-	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex)
+	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex, pairedProviders)
 
 	// validate results
 	require.Nil(t, err)
@@ -268,7 +269,7 @@ func TestPSMDataReliabilityTwicePerEpoch(t *testing.T) {
 	require.Equal(t, epoch1, sps.PairingEpoch)
 
 	// try to get a data reliability session again.
-	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex)
+	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex, pairedProviders)
 
 	// validate we cant get more than one data reliability session per epoch (might change in the future)
 	require.Error(t, err)
@@ -308,7 +309,7 @@ func TestPSMDataReliabilityRetryAfterFailure(t *testing.T) {
 	require.Equal(t, epoch1, sps.PairingEpoch)
 
 	// try to get a data reliability session again.
-	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex)
+	sps, err := psm.GetDataReliabilitySession(consumerOneAddress, epoch1, dataReliabilitySessionId, relayNumber, selfProviderIndex, pairedProviders)
 
 	// validate we can get a data reliability session if we failed before
 	require.Nil(t, err)
@@ -660,7 +661,7 @@ func TestPSMUsageSync(t *testing.T) {
 							require.True(t, needsRegister)
 							needsRegister = false
 							utils.LavaFormatInfo("registered session", utils.Attribute{Key: "sessionID", Value: sessionStoreTest.sessionID}, utils.Attribute{Key: "epoch", Value: sessionStoreTest.epoch})
-							session, err := psm.RegisterProviderSessionWithConsumer(ctx, consumerAddress, sessionStoreTest.epoch, sessionStoreTest.sessionID, sessionStoreTest.relayNum+1, maxCuForConsumer, selfProviderIndex)
+							session, err := psm.RegisterProviderSessionWithConsumer(ctx, consumerAddress, sessionStoreTest.epoch, sessionStoreTest.sessionID, sessionStoreTest.relayNum+1, maxCuForConsumer, selfProviderIndex, pairedProviders)
 							require.NoError(t, err)
 							sessionStoreTest.session = session
 							sessionStoreTest.history = append(sessionStoreTest.history, ",RegisterGet")

--- a/protocol/lavasession/provider_types.go
+++ b/protocol/lavasession/provider_types.go
@@ -103,19 +103,26 @@ type ProviderSessionsWithConsumer struct {
 	epochData         *ProviderSessionsEpochData
 	Lock              sync.RWMutex
 	isDataReliability uint32 // 0 is false, 1 is true. set to uint so we can atomically read
+	pairedProviders   int64
 	selfProviderIndex int64
 }
 
-func NewProviderSessionsWithConsumer(consumerAddr string, epochData *ProviderSessionsEpochData, isDataReliability uint32, selfProviderIndex int64) *ProviderSessionsWithConsumer {
+func NewProviderSessionsWithConsumer(consumerAddr string, epochData *ProviderSessionsEpochData, isDataReliability uint32, selfProviderIndex, pairedProviders int64) *ProviderSessionsWithConsumer {
 	pswc := &ProviderSessionsWithConsumer{
 		Sessions:          map[uint64]*SingleProviderSession{},
 		isBlockListed:     0,
 		consumerAddr:      consumerAddr,
 		epochData:         epochData,
 		isDataReliability: isDataReliability,
+		pairedProviders:   pairedProviders,
 		selfProviderIndex: selfProviderIndex,
 	}
 	return pswc
+}
+
+// reads the pairedProviders data atomically for DR
+func (pswc *ProviderSessionsWithConsumer) atomicReadPairedProviders() int64 {
+	return atomic.LoadInt64(&pswc.pairedProviders)
 }
 
 // reads the selfProviderIndex data atomically for DR

--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -52,7 +52,7 @@ type ProviderStateTrackerInf interface {
 	SendVoteCommitment(voteID string, vote *reliabilitymanager.VoteData) error
 	LatestBlock() int64
 	GetVrfPkAndMaxCuForUser(ctx context.Context, consumerAddress string, chainID string, epocu uint64) (vrfPk *utils.VrfPubKey, maxCu uint64, err error)
-	VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index int64, err error)
+	VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index, total int64, err error)
 	GetProvidersCountForConsumer(ctx context.Context, consumerAddress string, epoch uint64, chainID string) (uint32, error)
 	GetEpochSize(ctx context.Context) (uint64, error)
 	EarliestBlockInMemory(ctx context.Context) (uint64, error)

--- a/protocol/rpcprovider/rpcprovider_server.go
+++ b/protocol/rpcprovider/rpcprovider_server.go
@@ -55,7 +55,7 @@ type RewardServerInf interface {
 type StateTrackerInf interface {
 	LatestBlock() int64
 	GetVrfPkAndMaxCuForUser(ctx context.Context, consumerAddress string, chainID string, epocu uint64) (vrfPk *utils.VrfPubKey, maxCu uint64, err error)
-	VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index int64, err error)
+	VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index, total int64, err error)
 	GetProvidersCountForConsumer(ctx context.Context, consumerAddress string, epoch uint64, chainID string) (uint32, error)
 }
 
@@ -352,7 +352,7 @@ func (rpcps *RPCProviderServer) verifyRelaySession(ctx context.Context, request 
 	}
 
 	// try to fetch the selfProviderIndex from the already registered consumers.
-	selfProviderIndex, errFindingIndex := rpcps.providerSessionManager.GetProviderIndexWithConsumer(uint64(request.RelaySession.Epoch), consumerAddressString)
+	selfProviderIndex, pairedProviders, errFindingIndex := rpcps.providerSessionManager.GetProviderIndexWithConsumer(uint64(request.RelaySession.Epoch), consumerAddressString)
 	// validate the error is the expected type this error is valid and
 	// just indicates this consumer has not registered yet and we need to fetch the index from the blockchain
 	if errFindingIndex != nil && !lavasession.CouldNotFindIndexAsConsumerNotYetRegisteredError.Is(errFindingIndex) {
@@ -370,12 +370,25 @@ func (rpcps *RPCProviderServer) verifyRelaySession(ctx context.Context, request 
 		var validPairing bool
 		var verifyPairingError error
 		// verify pairing for DR session
-		validPairing, selfProviderIndex, verifyPairingError = rpcps.stateTracker.VerifyPairing(ctx, consumerAddressString, rpcps.providerAddress.String(), uint64(request.RelaySession.Epoch), request.RelaySession.SpecId)
+		validPairing, selfProviderIndex, pairedProviders, verifyPairingError = rpcps.stateTracker.VerifyPairing(ctx, consumerAddressString, rpcps.providerAddress.String(), uint64(request.RelaySession.Epoch), request.RelaySession.SpecId)
 		if verifyPairingError != nil {
-			return nil, nil, utils.LavaFormatError("Failed to VerifyPairing after verifyRelaySession for GetDataReliabilitySession", verifyPairingError, utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "provider", Value: rpcps.providerAddress}, utils.Attribute{Key: "relayNum", Value: request.RelaySession.RelayNum}, utils.Attribute{Key: "GUID", Value: ctx})
+			return nil, nil, utils.LavaFormatError("Failed to VerifyPairing after verifyRelaySession for GetDataReliabilitySession", verifyPairingError,
+				utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId},
+				utils.Attribute{Key: "consumer", Value: consumerAddressString},
+				utils.Attribute{Key: "provider", Value: rpcps.providerAddress},
+				utils.Attribute{Key: "relayNum", Value: request.RelaySession.RelayNum},
+				utils.Attribute{Key: "GUID", Value: ctx},
+			)
 		}
 		if !validPairing {
-			return nil, nil, utils.LavaFormatError("VerifyPairing, this consumer address is not valid with this provider for GetDataReliabilitySession", nil, utils.Attribute{Key: "epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "provider", Value: rpcps.providerAddress}, utils.Attribute{Key: "relayNum", Value: request.RelaySession.RelayNum}, utils.Attribute{Key: "GUID", Value: ctx})
+			return nil, nil, utils.LavaFormatError("VerifyPairing, this consumer address is not valid with this provider for GetDataReliabilitySession", nil,
+				utils.Attribute{Key: "epoch", Value: request.RelaySession.Epoch},
+				utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId},
+				utils.Attribute{Key: "consumer", Value: consumerAddressString},
+				utils.Attribute{Key: "provider", Value: rpcps.providerAddress},
+				utils.Attribute{Key: "relayNum", Value: request.RelaySession.RelayNum},
+				utils.Attribute{Key: "GUID", Value: ctx},
+			)
 		}
 	}
 
@@ -385,10 +398,11 @@ func (rpcps *RPCProviderServer) verifyRelaySession(ctx context.Context, request 
 		if err != nil {
 			dataReliabilityMarshalled = []byte{}
 		}
-		return nil, nil, utils.LavaFormatError("Provider identified invalid vrfIndex in data reliability request, the given index and self index are different", nil,
+		return nil, nil, utils.LavaFormatError("Provider identified invalid vrfIndex in data reliability request, given index and self index differ", nil,
 			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
 			utils.Attribute{Key: "userAddr", Value: consumerAddressString},
 			utils.Attribute{Key: "dataReliability", Value: dataReliabilityMarshalled},
+			utils.Attribute{Key: "pairedProviders", Value: pairedProviders},
 			utils.Attribute{Key: "vrfIndex", Value: vrfIndex},
 			utils.Attribute{Key: "self Index", Value: selfProviderIndex},
 			utils.Attribute{Key: "vrf_chainId", Value: request.DataReliability.ChainId},
@@ -399,13 +413,19 @@ func (rpcps *RPCProviderServer) verifyRelaySession(ctx context.Context, request 
 	utils.LavaFormatInfo("Simulation: server got valid DataReliability request")
 
 	// Fetch the DR session!
-	dataReliabilitySingleProviderSession, err := rpcps.providerSessionManager.GetDataReliabilitySession(consumerAddressString, uint64(request.RelaySession.Epoch), request.RelaySession.SessionId, request.RelaySession.RelayNum, selfProviderIndex)
+	dataReliabilitySingleProviderSession, err := rpcps.providerSessionManager.GetDataReliabilitySession(consumerAddressString, uint64(request.RelaySession.Epoch), request.RelaySession.SessionId, request.RelaySession.RelayNum, selfProviderIndex, pairedProviders)
 	if err != nil {
 		if lavasession.DataReliabilityAlreadySentThisEpochError.Is(err) {
 			return nil, nil, err
 		}
-		return nil, nil, utils.LavaFormatError("failed to get a provider data reliability session", err, utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId}, utils.Attribute{Key: "consumer", Value: extractedConsumerAddress}, utils.Attribute{Key: "epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "GUID", Value: ctx})
+		return nil, nil, utils.LavaFormatError("failed to get a provider data reliability session", err,
+			utils.Attribute{Key: "sessionID", Value: request.RelaySession.SessionId},
+			utils.Attribute{Key: "consumer", Value: extractedConsumerAddress},
+			utils.Attribute{Key: "epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "GUID", Value: ctx},
+		)
 	}
+
 	return dataReliabilitySingleProviderSession, extractedConsumerAddress, nil
 }
 
@@ -414,24 +434,54 @@ func (rpcps *RPCProviderServer) getSingleProviderSession(ctx context.Context, re
 	singleProviderSession, err := rpcps.providerSessionManager.GetSession(ctx, consumerAddressString, uint64(request.Epoch), request.SessionId, request.RelayNum)
 	if err != nil {
 		if lavasession.ConsumerNotRegisteredYet.Is(err) {
-			valid, selfProviderIndex, verifyPairingError := rpcps.stateTracker.VerifyPairing(ctx, consumerAddressString, rpcps.providerAddress.String(), uint64(request.Epoch), request.SpecId)
+			valid, selfProviderIndex, pairedProviders, verifyPairingError := rpcps.stateTracker.VerifyPairing(ctx, consumerAddressString, rpcps.providerAddress.String(), uint64(request.Epoch), request.SpecId)
 			if verifyPairingError != nil {
-				return nil, utils.LavaFormatError("Failed to VerifyPairing after ConsumerNotRegisteredYet", verifyPairingError, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "sessionID", Value: request.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "provider", Value: rpcps.providerAddress}, utils.Attribute{Key: "relayNum", Value: request.RelayNum})
+				return nil, utils.LavaFormatError("Failed to VerifyPairing after ConsumerNotRegisteredYet", verifyPairingError,
+					utils.Attribute{Key: "GUID", Value: ctx},
+					utils.Attribute{Key: "sessionID", Value: request.SessionId},
+					utils.Attribute{Key: "consumer", Value: consumerAddressString},
+					utils.Attribute{Key: "provider", Value: rpcps.providerAddress},
+					utils.Attribute{Key: "relayNum", Value: request.RelayNum},
+				)
 			}
 			if !valid {
-				return nil, utils.LavaFormatError("VerifyPairing, this consumer address is not valid with this provider", nil, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "epoch", Value: request.Epoch}, utils.Attribute{Key: "sessionID", Value: request.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "provider", Value: rpcps.providerAddress}, utils.Attribute{Key: "relayNum", Value: request.RelayNum})
+				return nil, utils.LavaFormatError("VerifyPairing, this consumer address is not valid with this provider", nil,
+					utils.Attribute{Key: "GUID", Value: ctx},
+					utils.Attribute{Key: "epoch", Value: request.Epoch},
+					utils.Attribute{Key: "sessionID", Value: request.SessionId},
+					utils.Attribute{Key: "consumer", Value: consumerAddressString},
+					utils.Attribute{Key: "provider", Value: rpcps.providerAddress},
+					utils.Attribute{Key: "relayNum", Value: request.RelayNum},
+				)
 			}
 			_, maxCuForConsumer, getVrfAndMaxCuError := rpcps.stateTracker.GetVrfPkAndMaxCuForUser(ctx, consumerAddressString, request.SpecId, uint64(request.Epoch))
 			if getVrfAndMaxCuError != nil {
-				return nil, utils.LavaFormatError("ConsumerNotRegisteredYet: GetVrfPkAndMaxCuForUser failed", getVrfAndMaxCuError, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "epoch", Value: request.Epoch}, utils.Attribute{Key: "sessionID", Value: request.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "provider", Value: rpcps.providerAddress}, utils.Attribute{Key: "relayNum", Value: request.RelayNum})
+				return nil, utils.LavaFormatError("ConsumerNotRegisteredYet: GetVrfPkAndMaxCuForUser failed", getVrfAndMaxCuError,
+					utils.Attribute{Key: "GUID", Value: ctx},
+					utils.Attribute{Key: "epoch", Value: request.Epoch},
+					utils.Attribute{Key: "sessionID", Value: request.SessionId},
+					utils.Attribute{Key: "consumer", Value: consumerAddressString},
+					utils.Attribute{Key: "provider", Value: rpcps.providerAddress},
+					utils.Attribute{Key: "relayNum", Value: request.RelayNum},
+				)
 			}
 			// After validating the consumer we can register it with provider session manager.
-			singleProviderSession, err = rpcps.providerSessionManager.RegisterProviderSessionWithConsumer(ctx, consumerAddressString, uint64(request.Epoch), request.SessionId, request.RelayNum, maxCuForConsumer, selfProviderIndex)
+			singleProviderSession, err = rpcps.providerSessionManager.RegisterProviderSessionWithConsumer(ctx, consumerAddressString, uint64(request.Epoch), request.SessionId, request.RelayNum, maxCuForConsumer, selfProviderIndex, pairedProviders)
 			if err != nil {
-				return nil, utils.LavaFormatError("Failed to RegisterProviderSessionWithConsumer", err, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "sessionID", Value: request.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "relayNum", Value: request.RelayNum})
+				return nil, utils.LavaFormatError("Failed to RegisterProviderSessionWithConsumer", err,
+					utils.Attribute{Key: "GUID", Value: ctx},
+					utils.Attribute{Key: "sessionID", Value: request.SessionId},
+					utils.Attribute{Key: "consumer", Value: consumerAddressString},
+					utils.Attribute{Key: "relayNum", Value: request.RelayNum},
+				)
 			}
 		} else {
-			return nil, utils.LavaFormatError("Failed to get a provider session", err, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "sessionID", Value: request.SessionId}, utils.Attribute{Key: "consumer", Value: consumerAddressString}, utils.Attribute{Key: "relayNum", Value: request.RelayNum})
+			return nil, utils.LavaFormatError("Failed to get a provider session", err,
+				utils.Attribute{Key: "GUID", Value: ctx},
+				utils.Attribute{Key: "sessionID", Value: request.SessionId},
+				utils.Attribute{Key: "consumer", Value: consumerAddressString},
+				utils.Attribute{Key: "relayNum", Value: request.RelayNum},
+			)
 		}
 	}
 	return singleProviderSession, nil
@@ -453,42 +503,60 @@ func (rpcps *RPCProviderServer) verifyRelayRequestMetaData(ctx context.Context, 
 
 func (rpcps *RPCProviderServer) verifyDataReliabilityRelayRequest(ctx context.Context, request *pairingtypes.RelayRequest, consumerAddress sdk.AccAddress) (vrfIndexToReturn int64, errRet error) {
 	if request.RelaySession.CuSum != lavasession.DataReliabilityCuSum {
-		return lavasession.IndexNotFound, utils.LavaFormatError("request's CU sum is not equal to the data reliability CU sum", nil, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "cuSum", Value: request.RelaySession.CuSum}, utils.Attribute{Key: "DataReliabilityCuSum", Value: lavasession.DataReliabilityCuSum})
+		return lavasession.IndexNotFound, utils.LavaFormatError("request's CU sum is not equal to the data reliability CU sum", nil,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "cuSum", Value: request.RelaySession.CuSum},
+			utils.Attribute{Key: "DataReliabilityCuSum", Value: lavasession.DataReliabilityCuSum},
+		)
 	}
 	vrf_pk, _, err := rpcps.stateTracker.GetVrfPkAndMaxCuForUser(ctx, consumerAddress.String(), request.RelaySession.SpecId, uint64(request.RelaySession.Epoch))
 	if err != nil {
 		return lavasession.IndexNotFound, utils.LavaFormatError("failed to get vrfpk and maxCURes for data reliability!", err,
-			utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "userAddr", Value: consumerAddress},
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
 		)
 	}
 
 	// data reliability is not session dependant, its always sent with sessionID 0 and if not we don't care
 	if vrf_pk == nil {
-		return lavasession.IndexNotFound, utils.LavaFormatError("dataReliability Triggered with vrf_pk == nil", nil, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "userAddr", Value: consumerAddress})
+		return lavasession.IndexNotFound, utils.LavaFormatError("dataReliability Triggered with vrf_pk == nil", nil,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
+		)
 	}
 	// verify the providerSig is indeed a signature by a valid provider on this query
-	valid, otherProviderIndex, err := rpcps.VerifyReliabilityAddressSigning(ctx, consumerAddress, request)
+	valid, otherProviderIndex, pairedProviders, err := rpcps.VerifyReliabilityAddressSigning(ctx, consumerAddress, request)
 	if err != nil {
-		return lavasession.IndexNotFound, utils.LavaFormatError("VerifyReliabilityAddressSigning invalid", err, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "userAddr", Value: consumerAddress}, utils.Attribute{Key: "dataReliability", Value: request.DataReliability})
+		return lavasession.IndexNotFound, utils.LavaFormatError("VerifyReliabilityAddressSigning invalid", err,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
+			utils.Attribute{Key: "dataReliability", Value: request.DataReliability},
+		)
 	}
 	if !valid {
-		return lavasession.IndexNotFound, utils.LavaFormatError("invalid DataReliability Provider signing", nil, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "userAddr", Value: consumerAddress}, utils.Attribute{Key: "dataReliability", Value: request.DataReliability})
+		return lavasession.IndexNotFound, utils.LavaFormatError("invalid DataReliability Provider signing", nil,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
+			utils.Attribute{Key: "dataReliability", Value: request.DataReliability},
+		)
 	}
 	// verify data reliability fields correspond to the right vrf
 	valid = utils.VerifyVrfProof(request, *vrf_pk, uint64(request.RelaySession.Epoch))
 	if !valid {
-		return lavasession.IndexNotFound, utils.LavaFormatError("invalid DataReliability fields, VRF wasn't verified with provided proof", nil, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "userAddr", Value: consumerAddress}, utils.Attribute{Key: "dataReliability", Value: request.DataReliability})
+		return lavasession.IndexNotFound, utils.LavaFormatError("invalid DataReliability fields, VRF wasn't verified with provided proof", nil,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
+			utils.Attribute{Key: "dataReliability", Value: request.DataReliability},
+		)
 	}
+
 	_, dataReliabilityThreshold := rpcps.chainParser.DataReliabilityParams()
-	providersCount, err := rpcps.stateTracker.GetProvidersCountForConsumer(ctx, consumerAddress.String(), uint64(request.RelaySession.Epoch), request.RelaySession.SpecId)
-	if err != nil {
-		return lavasession.IndexNotFound, utils.LavaFormatError("VerifyReliabilityAddressSigning failed fetching providers count for consumer", err, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "chainID", Value: request.RelaySession.SpecId}, utils.Attribute{Key: "consumer", Value: consumerAddress}, utils.Attribute{Key: "epoch", Value: request.RelaySession.Epoch})
-	}
-	vrfIndex, vrfErr := utils.GetIndexForVrf(request.DataReliability.VrfValue, providersCount, dataReliabilityThreshold)
+
+	vrfIndex, vrfErr := utils.GetIndexForVrf(request.DataReliability.VrfValue, uint32(pairedProviders), dataReliabilityThreshold)
 	if vrfErr != nil || otherProviderIndex == vrfIndex {
 		dataReliabilityMarshalled, err := json.Marshal(request.DataReliability)
 		if err != nil {
@@ -496,8 +564,10 @@ func (rpcps *RPCProviderServer) verifyDataReliabilityRelayRequest(ctx context.Co
 		}
 		return lavasession.IndexNotFound, utils.LavaFormatError("Provider identified vrf value in data reliability request does not meet threshold", vrfErr,
 			utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch}, utils.Attribute{Key: "userAddr", Value: consumerAddress},
+			utils.Attribute{Key: "requested epoch", Value: request.RelaySession.Epoch},
+			utils.Attribute{Key: "userAddr", Value: consumerAddress},
 			utils.Attribute{Key: "dataReliability", Value: dataReliabilityMarshalled},
+			utils.Attribute{Key: "pariedProviders", Value: pairedProviders},
 			utils.Attribute{Key: "vrfIndex", Value: vrfIndex},
 			utils.Attribute{Key: "other signing vrf provider index", Value: otherProviderIndex},
 			utils.Attribute{Key: "request.DataReliability.VrfValue", Value: request.DataReliability.VrfValue},
@@ -510,34 +580,49 @@ func (rpcps *RPCProviderServer) verifyDataReliabilityRelayRequest(ctx context.Co
 	return vrfIndex, nil
 }
 
-func (rpcps *RPCProviderServer) VerifyReliabilityAddressSigning(ctx context.Context, consumer sdk.AccAddress, request *pairingtypes.RelayRequest) (valid bool, index int64, err error) {
+func (rpcps *RPCProviderServer) VerifyReliabilityAddressSigning(ctx context.Context, consumer sdk.AccAddress, request *pairingtypes.RelayRequest) (valid bool, index, total int64, err error) {
 	queryHash := utils.CalculateQueryHash(*request.RelayData)
 	if !bytes.Equal(queryHash, request.DataReliability.QueryHash) {
-		return false, 0, utils.LavaFormatError("query hash mismatch on data reliability message", nil, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "queryHash", Value: queryHash}, utils.Attribute{Key: "request QueryHash", Value: request.DataReliability.QueryHash})
+		return false, 0, 0, utils.LavaFormatError("query hash mismatch on data reliability message", nil,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "queryHash", Value: queryHash},
+			utils.Attribute{Key: "request QueryHash", Value: request.DataReliability.QueryHash},
+		)
 	}
 
 	// validate consumer signing on VRF data
 	valid, err = sigs.ValidateSignerOnVRFData(consumer, *request.DataReliability)
 	if err != nil {
-		return false, 0, utils.LavaFormatError("failed to Validate Signer On VRF Data", err, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "consumer", Value: consumer}, utils.Attribute{Key: "request.DataReliability", Value: request.DataReliability})
+		return false, 0, 0, utils.LavaFormatError("failed to Validate Signer On VRF Data", err,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "consumer", Value: consumer},
+			utils.Attribute{Key: "request.DataReliability", Value: request.DataReliability},
+		)
 	}
 	if !valid {
-		return false, 0, nil
+		return false, 0, 0, nil
 	}
+
 	// validate provider signing on query data
 	pubKey, err := sigs.RecoverProviderPubKeyFromVrfDataAndQuery(request)
 	if err != nil {
-		return false, 0, utils.LavaFormatError("failed to Recover Provider PubKey From Vrf Data And Query", err, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "consumer", Value: consumer}, utils.Attribute{Key: "request", Value: request})
+		return false, 0, 0, utils.LavaFormatError("failed to Recover Provider PubKey From Vrf Data And Query", err,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "consumer", Value: consumer},
+			utils.Attribute{Key: "request", Value: request},
+		)
 	}
 	providerAccAddress, err := sdk.AccAddressFromHex(pubKey.Address().String()) // consumer signer
 	if err != nil {
-		return false, 0, utils.LavaFormatError("failed converting signer to address", err, utils.Attribute{Key: "GUID", Value: ctx},
-			utils.Attribute{Key: "consumer", Value: consumer}, utils.Attribute{Key: "PubKey", Value: pubKey.Address()})
+		return false, 0, 0, utils.LavaFormatError("failed converting signer to address", err,
+			utils.Attribute{Key: "GUID", Value: ctx},
+			utils.Attribute{Key: "consumer", Value: consumer},
+			utils.Attribute{Key: "PubKey", Value: pubKey.Address()},
+		)
 	}
-	return rpcps.stateTracker.VerifyPairing(ctx, consumer.String(), providerAccAddress.String(), uint64(request.RelaySession.Epoch), request.RelaySession.SpecId) // return if this pairing is authorised
+
+	// return if this pairing is authorised
+	return rpcps.stateTracker.VerifyPairing(ctx, consumer.String(), providerAccAddress.String(), uint64(request.RelaySession.Epoch), request.RelaySession.SpecId)
 }
 
 func (rpcps *RPCProviderServer) handleRelayErrorStatus(err error) error {

--- a/protocol/statetracker/provider_state_tracker.go
+++ b/protocol/statetracker/provider_state_tracker.go
@@ -95,7 +95,7 @@ func (pst *ProviderStateTracker) GetVrfPkAndMaxCuForUser(ctx context.Context, co
 	return pst.stateQuery.GetVrfPkAndMaxCuForUser(ctx, consumerAddress, chainID, epoch)
 }
 
-func (pst *ProviderStateTracker) VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index int64, err error) {
+func (pst *ProviderStateTracker) VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index, total int64, err error) {
 	return pst.stateQuery.VerifyPairing(ctx, consumerAddress, providerAddress, epoch, chainID)
 }
 

--- a/protocol/statetracker/state_query.go
+++ b/protocol/statetracker/state_query.go
@@ -227,7 +227,7 @@ func (psq *ProviderStateQuery) VoteEvents(ctx context.Context, latestBlock int64
 	return votes, err
 }
 
-func (psq *ProviderStateQuery) VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index int64, err error) {
+func (psq *ProviderStateQuery) VerifyPairing(ctx context.Context, consumerAddress string, providerAddress string, epoch uint64, chainID string) (valid bool, index, total int64, err error) {
 	key := psq.entryKey(consumerAddress, chainID, epoch, providerAddress)
 	extractedResultFromCache := false
 	cachedInterface, found := psq.ResponsesCache.Get(VerifyPairingRespKey + key)
@@ -248,14 +248,14 @@ func (psq *ProviderStateQuery) VerifyPairing(ctx context.Context, consumerAddres
 			Block:    epoch,
 		})
 		if err != nil {
-			return false, 0, err
+			return false, 0, 0, err
 		}
 		psq.ResponsesCache.SetWithTTL(VerifyPairingRespKey+key, verifyResponse, 1, DefaultTimeToLiveExpiration)
 	}
 	if !verifyResponse.Valid {
-		return false, 0, utils.LavaFormatError("invalid self pairing with consumer", nil, utils.Attribute{Key: "provider", Value: providerAddress}, utils.Attribute{Key: "consumer address", Value: consumerAddress}, utils.Attribute{Key: "epoch", Value: epoch}, utils.Attribute{Key: "from_cache", Value: extractedResultFromCache})
+		return false, 0, 0, utils.LavaFormatError("invalid self pairing with consumer", nil, utils.Attribute{Key: "provider", Value: providerAddress}, utils.Attribute{Key: "consumer address", Value: consumerAddress}, utils.Attribute{Key: "epoch", Value: epoch}, utils.Attribute{Key: "from_cache", Value: extractedResultFromCache})
 	}
-	return verifyResponse.Valid, verifyResponse.GetIndex(), nil
+	return verifyResponse.Valid, verifyResponse.GetIndex(), int64(verifyResponse.GetPairedProviders()), nil
 }
 
 func (psq *ProviderStateQuery) GetProvidersCountForConsumer(ctx context.Context, consumerAddress string, epoch uint64, chainID string) (uint32, error) {


### PR DESCRIPTION
Following a data reliability message, the provider verifies that it indeed is the designated provider by checking that its "self" vrfIndex matches that of the client.

This got broken with the use of subscription in E2E tests, becuase the default plan uses 5 providers while E2E uses 2 providers, the while the consumer uses the number of providers from the pairing, the provider gets it from the plan. Since they disagree, the VRF output also (likely) differs and triggers error.

The error message was:

    testutil/e2e/logs/05_LavaProvider_01_errors.log:Apr  2 08:10:13 ERR
    Provider identified invalid vrfIndex in data reliability request, the given
    index and self index are different GUID=16864668971218711883....

Actually, in the non-subscription case, the providers gets that number from the params. Therefore, similar issue would happen also in any case where the number of providers in a consumer's current pairing differs from that saved in the params.

This commit fixes the issue by teaching the provider to use the pairing to get the respective data. It also adds it to `ProviderSessionsWithConsumer struct` for fast access.