### PR TITLE
CNS-261: enforce lowercase in spec names

### DIFF
--- a/cookbook/specs/spec_add_bsc.json
+++ b/cookbook/specs/spec_add_bsc.json
@@ -27,7 +27,7 @@
             },
             {
                 "index": "BSCT",
-                "name": "BSC testnet",
+                "name": "bsc testnet",
                 "enabled": true,
                 "imports": [
                     "BSC"

--- a/cookbook/specs/spec_add_bsc.json
+++ b/cookbook/specs/spec_add_bsc.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "BSC",
-                "name": "BSC mainnet",
+                "name": "bsc mainnet",
                 "enabled": true,
                 "imports": [
                     "ETH1"

--- a/cookbook/specs/spec_add_cosmossdk.json
+++ b/cookbook/specs/spec_add_cosmossdk.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "COSMOSSDK",
-                "name": "Cosmos SDK",
+                "name": "cosmos sdk",
                 "enabled": false,
                 "imports": [
                     "IBC"

--- a/cookbook/specs/spec_add_cosmossdk_full.json
+++ b/cookbook/specs/spec_add_cosmossdk_full.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "COSMOSSDKFULL",
-                "name": "Full Cosmos SDK",
+                "name": "full cosmos sdk",
                 "enabled": false,
                 "imports": [
                     "COSMOSSDK",

--- a/cookbook/specs/spec_add_cosmoswasm.json
+++ b/cookbook/specs/spec_add_cosmoswasm.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "COSMOSWASM",
-                "name": "Cosmos Wasm",
+                "name": "cosmos wasm",
                 "enabled": false,
                 "reliability_threshold": 268435455,
                 "data_reliability_enabled": true,

--- a/cookbook/specs/spec_add_ibc.json
+++ b/cookbook/specs/spec_add_ibc.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "IBC",
-                "name": "IBC",
+                "name": "ibc",
                 "enabled": false,
                 "reliability_threshold": 268435455,
                 "data_reliability_enabled": true,

--- a/cookbook/specs/spec_add_solana.json
+++ b/cookbook/specs/spec_add_solana.json
@@ -1536,7 +1536,7 @@
             },
             {
                 "index": "SOLANAT",
-                "name": "Solana test net",
+                "name": "solana test net",
                 "enabled": true,
                 "imports": [
                     "SOLANA"

--- a/cookbook/specs/spec_add_solana.json
+++ b/cookbook/specs/spec_add_solana.json
@@ -5,7 +5,7 @@
         "specs": [
             {
                 "index": "SOLANA",
-                "name": "Solana main net",
+                "name": "solana main net",
                 "enabled": true,
                 "reliability_threshold": 268435455,
                 "data_reliability_enabled": true,

--- a/x/spec/types/spec.go
+++ b/x/spec/types/spec.go
@@ -3,6 +3,7 @@ package types
 import (
 	fmt "fmt"
 	"strconv"
+	"unicode"
 
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 )
@@ -24,6 +25,12 @@ func (spec Spec) ValidateSpec(maxCU uint64) (map[string]string, error) {
 		EncodingHex:    {},
 	}
 
+	for _, char := range spec.Name {
+		if !unicode.IsLower(char) && char != ' ' {
+			return details, fmt.Errorf("spec name must contain lowercase characters only")
+		}
+	}
+
 	if spec.ReliabilityThreshold == 0 {
 		return details, fmt.Errorf("ReliabilityThreshold can't be zero")
 	}
@@ -41,11 +48,11 @@ func (spec Spec) ValidateSpec(maxCU uint64) (map[string]string, error) {
 	}
 
 	if spec.MinStakeClient.Denom != epochstoragetypes.TokenDenom || spec.MinStakeClient.Amount.IsZero() {
-		return details, fmt.Errorf("MinStakeClient can't be zero andmust have denom of ulava")
+		return details, fmt.Errorf("MinStakeClient can't be zero and must have denom of ulava")
 	}
 
 	if spec.MinStakeProvider.Denom != epochstoragetypes.TokenDenom || spec.MinStakeProvider.Amount.IsZero() {
-		return details, fmt.Errorf("MinStakeProvider can't be zero andmust have denom of ulava")
+		return details, fmt.Errorf("MinStakeProvider can't be zero and must have denom of ulava")
 	}
 
 	for _, api := range spec.Apis {


### PR DESCRIPTION
added check in spec proposal handler that spec name can only have lowercase chars or ' '.
After talking with @SeanZoR , existing specs should already have all lowercase chain names.