### PR TITLE
CNS-446: fix testutils block advancement simulation

### DIFF
--- a/testutil/keeper/keepers_init.go
+++ b/testutil/keeper/keepers_init.go
@@ -45,7 +45,7 @@ const (
 
 const BLOCK_HEADER_LEN = 32
 
-// Note: the keeper fields' order is consistent with the app's BeginBlockers order (search in app.go the phrase "app.mm.SetOrderBeginBlockers(")
+// NOTE: the order of the keeper fields must follow that of calling app.mm.SetOrderBeginBlockers() in app/app.go
 type Keepers struct {
 	AccountKeeper mockAccountKeeper
 	BankKeeper    mockBankKeeper
@@ -293,8 +293,8 @@ func NewBlock(ctx context.Context, ks *Keepers) {
 	for i := 0; i < keepersType.NumField(); i++ {
 		fieldValue := keepersValue.Field(i)
 
-		if BeginBlocker, ok := fieldValue.Interface().(KeeperBeginBlocker); ok {
-			BeginBlocker.BeginBlock(unwrapedCtx)
+		if beginBlocker, ok := fieldValue.Interface().(KeeperBeginBlocker); ok {
+			beginBlocker.BeginBlock(unwrapedCtx)
 		}
 	}
 }

--- a/testutil/keeper/keepers_init.go
+++ b/testutil/keeper/keepers_init.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"crypto/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -18,7 +19,6 @@ import (
 	conflicttypes "github.com/lavanet/lava/x/conflict/types"
 	epochstoragekeeper "github.com/lavanet/lava/x/epochstorage/keeper"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
-	"github.com/lavanet/lava/x/pairing"
 	pairingkeeper "github.com/lavanet/lava/x/pairing/keeper"
 	pairingtypes "github.com/lavanet/lava/x/pairing/types"
 	"github.com/lavanet/lava/x/plans"
@@ -45,16 +45,17 @@ const (
 
 const BLOCK_HEADER_LEN = 32
 
+// Note: the keeper fields' order is consistent with the app's BeginBlockers order (search in app.go the phrase "app.mm.SetOrderBeginBlockers(")
 type Keepers struct {
-	Epochstorage  epochstoragekeeper.Keeper
-	Spec          speckeeper.Keeper
-	Plans         planskeeper.Keeper
-	Projects      projectskeeper.Keeper
-	Subscription  subscriptionkeeper.Keeper
-	Pairing       pairingkeeper.Keeper
-	Conflict      conflictkeeper.Keeper
-	BankKeeper    mockBankKeeper
 	AccountKeeper mockAccountKeeper
+	BankKeeper    mockBankKeeper
+	Spec          speckeeper.Keeper
+	Epochstorage  epochstoragekeeper.Keeper
+	Subscription  subscriptionkeeper.Keeper
+	Conflict      conflictkeeper.Keeper
+	Pairing       pairingkeeper.Keeper
+	Projects      projectskeeper.Keeper
+	Plans         planskeeper.Keeper
 	ParamsKeeper  paramskeeper.Keeper
 	BlockStore    MockBlockStore
 }
@@ -67,6 +68,10 @@ type Servers struct {
 	ProjectServer      projectstypes.MsgServer
 	SubscriptionServer subscriptiontypes.MsgServer
 	PlansServer        planstypes.MsgServer
+}
+
+type KeeperBeginBlocker interface {
+	BeginBlock(ctx sdk.Context)
 }
 
 func SimulateParamChange(ctx sdk.Context, paramKeeper paramskeeper.Keeper, subspace string, key string, value string) (err error) {
@@ -199,6 +204,7 @@ func InitAllKeepers(t testing.TB) (*Servers, *Keepers, context.Context) {
 
 	ks.Epochstorage.SetEpochDetails(ctx, *epochstoragetypes.DefaultGenesis().EpochDetails)
 	NewBlock(sdk.WrapSDKContext(ctx), &ks)
+	ctx = ctx.WithBlockTime(time.Now())
 	return &ss, &ks, sdk.WrapSDKContext(ctx)
 }
 
@@ -278,10 +284,17 @@ func AdvanceEpoch(ctx context.Context, ks *Keepers, customBlockTime ...time.Dura
 // Make sure you save the new context
 func NewBlock(ctx context.Context, ks *Keepers) {
 	unwrapedCtx := sdk.UnwrapSDKContext(ctx)
-	if ks.Epochstorage.IsEpochStart(sdk.UnwrapSDKContext(ctx)) {
-		ks.Epochstorage.EpochStart(unwrapedCtx)
-		ks.Pairing.EpochStart(unwrapedCtx, pairing.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER, pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS)
-	}
 
-	ks.Conflict.CheckAndHandleAllVotes(unwrapedCtx)
+	// get the value and type of the Keepers struct
+	keepersType := reflect.TypeOf(*ks)
+	keepersValue := reflect.ValueOf(*ks)
+
+	// iterate over all keepers and call BeginBlock (if it's implemented by the keeper)
+	for i := 0; i < keepersType.NumField(); i++ {
+		fieldValue := keepersValue.Field(i)
+
+		if BeginBlocker, ok := fieldValue.Interface().(KeeperBeginBlocker); ok {
+			BeginBlocker.BeginBlock(unwrapedCtx)
+		}
+	}
 }

--- a/x/conflict/keeper/keeper.go
+++ b/x/conflict/keeper/keeper.go
@@ -60,3 +60,7 @@ func (k Keeper) IsEpochStart(ctx sdk.Context) (res bool) {
 func (k Keeper) PushFixations(ctx sdk.Context) {
 	k.epochstorageKeeper.PushFixatedParams(ctx, 0, 0)
 }
+
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+	k.CheckAndHandleAllVotes(ctx)
+}

--- a/x/conflict/keeper/vote_test.go
+++ b/x/conflict/keeper/vote_test.go
@@ -338,7 +338,7 @@ func TestFullMajorityVote(t *testing.T) {
 	_, err = ts.servers.ConflictServer.ConflictVoteReveal(ts.ctx, &msgReveal)
 	require.Nil(t, err)
 
-	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx)))+1; i++ {
+	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx))); i++ {
 		ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	}
 
@@ -346,7 +346,8 @@ func TestFullMajorityVote(t *testing.T) {
 	_, found := ts.keepers.Conflict.GetConflictVote(sdk.UnwrapSDKContext(ts.ctx), voteID)
 	require.False(t, found)
 
-	LastEvent := sdk.UnwrapSDKContext(ts.ctx).EventManager().Events()[len(sdk.UnwrapSDKContext(ts.ctx).EventManager().Events())-1]
+	events := sdk.UnwrapSDKContext(ts.ctx).EventManager().Events()
+	LastEvent := events[len(events)-1]
 	require.Equal(t, LastEvent.Type, "lava_"+conflicttypes.ConflictVoteResolvedEventName)
 }
 
@@ -383,7 +384,7 @@ func TestFullStrongMajorityVote(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx)))+1; i++ {
+	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx))); i++ {
 		ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	}
 
@@ -401,7 +402,7 @@ func TestNoVotersConflict(t *testing.T) {
 		ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	}
 
-	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx)))+1; i++ {
+	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx))); i++ {
 		ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	}
 
@@ -471,7 +472,7 @@ func TestNoDecisionVote(t *testing.T) {
 	_, err = ts.servers.ConflictServer.ConflictVoteReveal(ts.ctx, &msgReveal)
 	require.Nil(t, err)
 
-	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx)))+1; i++ {
+	for i := 0; i < int(ts.keepers.Conflict.VotePeriod(sdk.UnwrapSDKContext(ts.ctx))); i++ {
 		ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	}
 

--- a/x/conflict/module.go
+++ b/x/conflict/module.go
@@ -167,7 +167,7 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	am.keeper.CheckAndHandleAllVotes(ctx)
+	am.keeper.BeginBlock(ctx)
 }
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It

--- a/x/epochstorage/keeper/keeper.go
+++ b/x/epochstorage/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/epochstorage/types"
 )
 
@@ -70,4 +71,17 @@ func (k *Keeper) AddFixationRegistry(fixationKey string, getParamFunction func(s
 
 func (k *Keeper) GetFixationRegistries() map[string]func(sdk.Context) any {
 	return k.fixationRegistries
+}
+
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+	if k.IsEpochStart(ctx) {
+		// run functions that are supposed to run in epoch start
+		k.EpochStart(ctx)
+
+		// Notify world we have a new session
+
+		details := map[string]string{"height": fmt.Sprintf("%d", ctx.BlockHeight()), "description": "New Block Epoch Started"}
+		logger := k.Logger(ctx)
+		utils.LogLavaEvent(ctx, logger, "new_epoch", details, "")
+	}
 }

--- a/x/epochstorage/keeper/keeper.go
+++ b/x/epochstorage/keeper/keeper.go
@@ -81,7 +81,6 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 		// Notify world we have a new session
 
 		details := map[string]string{"height": fmt.Sprintf("%d", ctx.BlockHeight()), "description": "New Block Epoch Started"}
-		logger := k.Logger(ctx)
-		utils.LogLavaEvent(ctx, logger, "new_epoch", details, "")
+		utils.LogLavaEvent(ctx, k.Logger(ctx), "new_epoch", details, "")
 	}
 }

--- a/x/epochstorage/module.go
+++ b/x/epochstorage/module.go
@@ -16,7 +16,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/epochstorage/client/cli"
 	"github.com/lavanet/lava/x/epochstorage/keeper"
 	"github.com/lavanet/lava/x/epochstorage/types"
@@ -168,16 +167,7 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	if am.keeper.IsEpochStart(ctx) {
-		// run functions that are supposed to run in epoch start
-		am.keeper.EpochStart(ctx)
-
-		// Notify world we have a new session
-
-		details := map[string]string{"height": fmt.Sprintf("%d", ctx.BlockHeight()), "description": "New Block Epoch Started"}
-		logger := am.keeper.Logger(ctx)
-		utils.LogLavaEvent(ctx, logger, "new_epoch", details, "")
-	}
+	am.keeper.BeginBlock(ctx)
 }
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It

--- a/x/pairing/keeper/keeper.go
+++ b/x/pairing/keeper/keeper.go
@@ -61,3 +61,10 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) IsEpochStart(ctx sdk.Context) (res bool) {
 	return k.epochStorageKeeper.GetEpochStart(ctx) == uint64(ctx.BlockHeight())
 }
+
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+	if k.IsEpochStart(ctx) {
+		// run functions that are supposed to run in epoch start
+		k.EpochStart(ctx, types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER, types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS)
+	}
+}

--- a/x/pairing/keeper/keeper.go
+++ b/x/pairing/keeper/keeper.go
@@ -57,13 +57,8 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-// we dont want to do the calculation here too, epochStorage keeper did it
-func (k Keeper) IsEpochStart(ctx sdk.Context) (res bool) {
-	return k.epochStorageKeeper.GetEpochStart(ctx) == uint64(ctx.BlockHeight())
-}
-
 func (k Keeper) BeginBlock(ctx sdk.Context) {
-	if k.IsEpochStart(ctx) {
+	if k.epochStorageKeeper.IsEpochStart(ctx) {
 		// run functions that are supposed to run in epoch start
 		k.EpochStart(ctx, types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER, types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS)
 	}

--- a/x/pairing/keeper/msg_server_relay_payment_test.go
+++ b/x/pairing/keeper/msg_server_relay_payment_test.go
@@ -866,7 +866,7 @@ func TestCuUsageInProjectsAndSubscription(t *testing.T) {
 	var Relays []*types.RelaySession
 	Relays = append(Relays, relaySession)
 	relayPaymentMessage := types.MsgRelayPayment{Creator: ts.providers[0].Addr.String(), Relays: Relays}
-	payAndVerifyBalanceLegacy(t, ts, relayPaymentMessage, true, ts.clients[0].Addr, ts.providers[0].Addr)
+	payAndVerifyBalance(t, ts, relayPaymentMessage, true, true, ts.clients[0].Addr, ts.providers[0].Addr)
 
 	sub, found := subkeeper.GetSubscription(_ctx, subscriptionOwner)
 	require.True(t, found)

--- a/x/pairing/keeper/unresponsive_provider_test.go
+++ b/x/pairing/keeper/unresponsive_provider_test.go
@@ -9,7 +9,6 @@ import (
 	testkeeper "github.com/lavanet/lava/testutil/keeper"
 	"github.com/lavanet/lava/utils/sigs"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
-	"github.com/lavanet/lava/x/pairing"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/stretchr/testify/require"
 )
@@ -24,9 +23,9 @@ func TestUnresponsivenessStressTest(t *testing.T) {
 	recommendedEpochNumToCollectPayment := ts.keepers.Pairing.RecommendedEpochNumToCollectPayment(sdk.UnwrapSDKContext(ts.ctx))
 
 	// check which const is larger
-	largerConst := pairing.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
-	if largerConst < pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
-		largerConst = pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
+	largerConst := types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
+	if largerConst < types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
+		largerConst = types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
 	}
 
 	// advance enough epochs so we can check punishment due to unresponsiveness (if the epoch is too early, there's no punishment)
@@ -121,9 +120,9 @@ func TestUnstakingProviderForUnresponsiveness(t *testing.T) {
 	recommendedEpochNumToCollectPayment := ts.keepers.Pairing.RecommendedEpochNumToCollectPayment(sdk.UnwrapSDKContext(ts.ctx))
 
 	// check which const is larger
-	largerConst := pairing.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
-	if largerConst < pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
-		largerConst = pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
+	largerConst := types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
+	if largerConst < types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
+		largerConst = types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
 	}
 
 	// advance enough epochs so we can check punishment due to unresponsiveness (if the epoch is too early, there's no punishment)
@@ -230,9 +229,9 @@ func TestUnstakingProviderForUnresponsivenessContinueComplainingAfterUnstake(t *
 	recommendedEpochNumToCollectPayment := ts.keepers.Pairing.RecommendedEpochNumToCollectPayment(sdk.UnwrapSDKContext(ts.ctx))
 
 	// check which const is larger
-	largerConst := pairing.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
-	if largerConst < pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
-		largerConst = pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
+	largerConst := types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
+	if largerConst < types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
+		largerConst = types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
 	}
 
 	// advance enough epochs so we can check punishment due to unresponsiveness (if the epoch is too early, there's no punishment)
@@ -351,9 +350,9 @@ func TestNotUnstakingProviderForUnresponsivenessWithMinProviders(t *testing.T) {
 	recommendedEpochNumToCollectPayment := ts.keepers.Pairing.RecommendedEpochNumToCollectPayment(sdk.UnwrapSDKContext(ts.ctx))
 
 	// check which const is larger
-	largerConst := pairing.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
-	if largerConst < pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
-		largerConst = pairing.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
+	largerConst := types.EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER
+	if largerConst < types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS {
+		largerConst = types.EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS
 	}
 
 	// advance enough epochs so we can check punishment due to unresponsiveness (if the epoch is too early, there's no punishment)

--- a/x/pairing/module.go
+++ b/x/pairing/module.go
@@ -26,11 +26,6 @@ var (
 	_ module.AppModuleBasic = AppModuleBasic{}
 )
 
-const (
-	EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER uint64 = 4 // number of epochs to sum CU that the provider serviced
-	EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS              uint64 = 2 // number of epochs to sum CU of complainers against the provider
-)
-
 // ----------------------------------------------------------------------------
 // AppModuleBasic
 // ----------------------------------------------------------------------------
@@ -172,10 +167,7 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	if am.keeper.IsEpochStart(ctx) {
-		// run functions that are supposed to run in epoch start
-		am.keeper.EpochStart(ctx, EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER, EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS)
-	}
+	am.keeper.BeginBlock(ctx)
 }
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It

--- a/x/pairing/types/types.go
+++ b/x/pairing/types/types.go
@@ -26,6 +26,12 @@ const (
 	MAX_LEN_MONIKER = 50
 )
 
+// unresponsiveness consts
+const (
+	EPOCHS_NUM_TO_CHECK_CU_FOR_UNRESPONSIVE_PROVIDER uint64 = 4 // number of epochs to sum CU that the provider serviced
+	EPOCHS_NUM_TO_CHECK_FOR_COMPLAINERS              uint64 = 2 // number of epochs to sum CU of complainers against the provider
+)
+
 func StakeNewEventName(isProvider bool) string {
 	if isProvider {
 		return ProviderStakeEventName

--- a/x/spec/keeper/keeper.go
+++ b/x/spec/keeper/keeper.go
@@ -42,3 +42,5 @@ func NewKeeper(
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
+
+func (k Keeper) BeginBlock(ctx sdk.Context) {}

--- a/x/spec/module.go
+++ b/x/spec/module.go
@@ -166,7 +166,9 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
-func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	am.keeper.BeginBlock(ctx)
+}
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.

--- a/x/subscription/keeper/epoch_start_test.go
+++ b/x/subscription/keeper/epoch_start_test.go
@@ -20,9 +20,6 @@ func TestSubscriptionExpire(t *testing.T) {
 	creator := account.String()
 	consumer := account.String()
 
-	// advance block to reach time > 0
-	ts.advanceBlock()
-
 	err := keeper.CreateSubscription(ts.ctx, creator, consumer, "mockPlan1", 1)
 	require.Nil(t, err)
 

--- a/x/subscription/keeper/keeper.go
+++ b/x/subscription/keeper/keeper.go
@@ -61,12 +61,8 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-func (k Keeper) IsEpochStart(ctx sdk.Context) bool {
-	return k.epochstorageKeeper.GetEpochStart(ctx) == uint64(ctx.BlockHeight())
-}
-
 func (k Keeper) BeginBlock(ctx sdk.Context) {
-	if k.IsEpochStart(ctx) {
+	if k.epochstorageKeeper.IsEpochStart(ctx) {
 		// run functions that are supposed to run in epoch start
 		k.EpochStart(ctx)
 	}

--- a/x/subscription/keeper/keeper.go
+++ b/x/subscription/keeper/keeper.go
@@ -64,3 +64,10 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) IsEpochStart(ctx sdk.Context) bool {
 	return k.epochstorageKeeper.GetEpochStart(ctx) == uint64(ctx.BlockHeight())
 }
+
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+	if k.IsEpochStart(ctx) {
+		// run functions that are supposed to run in epoch start
+		k.EpochStart(ctx)
+	}
+}

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -111,7 +111,6 @@ func (ts *testStruct) expireSubscription(sub types.Subscription) types.Subscript
 	// trigger EpochStart() processing
 	ts._ctx = keepertest.AdvanceEpoch(ts._ctx, ts.keepers)
 	ts.ctx = sdk.UnwrapSDKContext(ts._ctx)
-	keeper.EpochStart(ts.ctx)
 
 	// might not be found - that's ok
 	sub, _ = keeper.GetSubscription(ts.ctx, sub.Consumer)

--- a/x/subscription/module.go
+++ b/x/subscription/module.go
@@ -168,10 +168,7 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	if am.keeper.IsEpochStart(ctx) {
-		// run functions that are supposed to run in epoch start
-		am.keeper.EpochStart(ctx)
-	}
+	am.keeper.BeginBlock(ctx)
 }
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It

--- a/x/subscription/types/expected_keepers.go
+++ b/x/subscription/types/expected_keepers.go
@@ -23,6 +23,7 @@ type BankKeeper interface {
 type EpochstorageKeeper interface {
 	BlocksToSave(ctx sdk.Context, block uint64) (uint64, error)
 	GetEpochStart(ctx sdk.Context) uint64
+	IsEpochStart(ctx sdk.Context) bool
 	// Methods imported from epochstorage should be defined here
 }
 


### PR DESCRIPTION
I made the NewBlock() function iterate over all keepers and call their corresponding BeginBlock() callback (instead of calling the inner functions directly). Also fixed some unit tests issues