### PR TITLE
CNS-421: allow project delete

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -29674,16 +29674,6 @@ paths:
           in: query
           required: false
           type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
-          in: query
-          required: false
-          type: boolean
       tags:
         - Query
   '/lavanet/lava/epochstorage/fixated_params/{index}':
@@ -29938,16 +29928,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -30232,16 +30212,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -30571,16 +30541,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -30916,16 +30876,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -31339,9 +31289,6 @@ paths:
                   subscription:
                     type: string
                     title: the subscription address that owns the project
-                  description:
-                    type: string
-                    title: the description of the project for the users convinient
                   enabled:
                     type: boolean
                     title: enabled flag
@@ -31468,9 +31415,6 @@ paths:
                   subscription:
                     type: string
                     title: the subscription address that owns the project
-                  description:
-                    type: string
-                    title: the description of the project for the users convinient
                   enabled:
                     type: boolean
                     title: enabled flag
@@ -32103,16 +32047,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -32749,16 +32683,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -56016,9 +55940,6 @@ definitions:
       subscription:
         type: string
         title: the subscription address that owns the project
-      description:
-        type: string
-        title: the description of the project for the users convinient
       enabled:
         type: boolean
         title: enabled flag
@@ -56118,9 +56039,6 @@ definitions:
           subscription:
             type: string
             title: the subscription address that owns the project
-          description:
-            type: string
-            title: the description of the project for the users convinient
           enabled:
             type: boolean
             title: enabled flag
@@ -56215,9 +56133,6 @@ definitions:
           subscription:
             type: string
             title: the subscription address that owns the project
-          description:
-            type: string
-            title: the description of the project for the users convinient
           enabled:
             type: boolean
             title: enabled flag

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -55996,6 +55996,8 @@ definitions:
     title: 'protobuf expected in YAML format: used "moretags" to simplify parsing'
   lavanet.lava.projects.MsgAddKeysResponse:
     type: object
+  lavanet.lava.projects.MsgDelKeysResponse:
+    type: object
   lavanet.lava.projects.MsgSetPolicyResponse:
     type: object
   lavanet.lava.projects.MsgSetSubscriptionPolicyResponse:
@@ -57528,6 +57530,8 @@ definitions:
   lavanet.lava.subscription.MsgAddProjectResponse:
     type: object
   lavanet.lava.subscription.MsgBuyResponse:
+    type: object
+  lavanet.lava.subscription.MsgDelProjectResponse:
     type: object
   lavanet.lava.subscription.Params:
     type: object

--- a/proto/subscription/tx.proto
+++ b/proto/subscription/tx.proto
@@ -10,6 +10,7 @@ option go_package = "github.com/lavanet/lava/x/subscription/types";
 service Msg {
   rpc Buy(MsgBuy) returns (MsgBuyResponse);
   rpc AddProject(MsgAddProject) returns (MsgAddProjectResponse);
+  rpc DelProject(MsgDelProject) returns (MsgDelProjectResponse);
 // this line is used by starport scaffolding # proto/tx/rpc
 }
 
@@ -31,4 +32,13 @@ message MsgAddProject {
 
 message MsgAddProjectResponse {
 }
+
+message MsgDelProject {
+  string creator = 1;
+  string name = 2;
+}
+
+message MsgDelProjectResponse {
+}
+
 // this line is used by starport scaffolding # proto/tx/message

--- a/scripts/init_e2e.sh
+++ b/scripts/init_e2e.sh
@@ -66,5 +66,4 @@ sleep_until_next_epoch
 
 lavad q subscription list-projects user3
 
-# we need to wait for the next epoch for the stake to take action.
-sleep_until_next_epoch
+# the end

--- a/scripts/init_e2e.sh
+++ b/scripts/init_e2e.sh
@@ -61,5 +61,10 @@ sleep_until_next_epoch
 lavad tx project del-keys -y "$user3addr-myproject" --from user3 cookbook/projects/example_project_keys.yml --gas-prices=$GASPRICE
 sleep_until_next_epoch
 
+lavad tx subscription del-project myproject -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+sleep_until_next_epoch
+
+lavad q subscription list-projects user3
+
 # we need to wait for the next epoch for the stake to take action.
 sleep_until_next_epoch

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -686,7 +686,7 @@ func (lt *lavaTest) saveLogs() {
 			panic(err)
 		}
 	}
-	errorLineCount := 0
+	errorFound := false
 	errorFiles := []string{}
 	errorPrint := make(map[string]string)
 	for fileName, logBuffer := range lt.logs {
@@ -713,7 +713,7 @@ func (lt *lavaTest) saveLogs() {
 				}
 				// When test did not finish properly save all logs. If test finished properly save only non allowed errors.
 				if !lt.testFinishedProperly || !isAllowedError {
-					errorLineCount += 1
+					errorFound = true
 					errorLines = append(errorLines, line)
 				}
 			}
@@ -721,9 +721,9 @@ func (lt *lavaTest) saveLogs() {
 		if len(errorLines) == 0 {
 			continue
 		}
-		errorFiles = append(errorFiles, fileName)
+
+		// dump all errors into the log file
 		errors := strings.Join(errorLines, "\n")
-		errorPrint[fileName] = errorLines[0] + errorLines[1]
 		errFile, err := os.Create(logsFolder + fileName + "_errors.log")
 		if err != nil {
 			panic(err)
@@ -732,9 +732,17 @@ func (lt *lavaTest) saveLogs() {
 		writer.Write([]byte(errors))
 		writer.Flush()
 		errFile.Close()
+
+		// keep at most 5 errors to display
+		count := len(errorLines)
+		if count > 5 {
+			count = 5
+		}
+		errorPrint[fileName] = strings.Join(errorLines[:count], "\n")
+		errorFiles = append(errorFiles, fileName)
 	}
 
-	if errorLineCount != 0 {
+	if errorFound {
 		for _, errLine := range errorPrint {
 			fmt.Println("ERROR: ", errLine)
 		}

--- a/x/pairing/keeper/msg_server_relay_payment_test.go
+++ b/x/pairing/keeper/msg_server_relay_payment_test.go
@@ -743,6 +743,7 @@ func TestCuUsageInProjectsAndSubscription(t *testing.T) {
 	require.Nil(t, err)
 
 	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
 
 	projectData := projecttypes.ProjectData{
 		Name:    "proj1",
@@ -766,6 +767,9 @@ func TestCuUsageInProjectsAndSubscription(t *testing.T) {
 	}
 	err = subkeeper.AddProjectToSubscription(_ctx, subscriptionOwner, projectData)
 	require.Nil(t, err)
+
+	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
 
 	// create a signed relay request
 	cuSum := uint64(1)

--- a/x/pairing/keeper/pairing_subscription_test.go
+++ b/x/pairing/keeper/pairing_subscription_test.go
@@ -57,14 +57,14 @@ func TestGetPairingForSubscription(t *testing.T) {
 		Provider: pairing.Providers[0].Address,
 		Block:    uint64(_ctx.BlockHeight()),
 	}
-	vefiry, err := ts.keepers.Pairing.VerifyPairing(ts.ctx, verifyPairingQuery)
+	verify, err := ts.keepers.Pairing.VerifyPairing(ts.ctx, verifyPairingQuery)
 	require.Nil(t, err)
-	require.True(t, vefiry.Valid)
+	require.True(t, verify.Valid)
 
-	_, err = ts.keepers.Projects.GetProjectForDeveloper(_ctx, devkey, uint64(_ctx.BlockHeight()))
+	project, err := ts.keepers.Projects.GetProjectForDeveloper(_ctx, devkey, uint64(_ctx.BlockHeight()))
 	require.Nil(t, err)
 
-	err = ts.keepers.Projects.DeleteProject(_ctx, consumer, projectData.Name)
+	err = ts.keepers.Projects.DeleteProject(_ctx, consumer, project.Index)
 	require.Nil(t, err)
 
 	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
@@ -79,9 +79,9 @@ func TestGetPairingForSubscription(t *testing.T) {
 		Provider: pairing.Providers[0].Address,
 		Block:    uint64(_ctx.BlockHeight()),
 	}
-	vefiry, err = ts.keepers.Pairing.VerifyPairing(ts.ctx, verifyPairingQuery)
+	verify, err = ts.keepers.Pairing.VerifyPairing(ts.ctx, verifyPairingQuery)
 	require.NotNil(t, err)
-	require.False(t, vefiry.Valid)
+	require.False(t, verify.Valid)
 }
 
 func TestRelayPaymentSubscription(t *testing.T) {

--- a/x/pairing/keeper/pairing_subscription_test.go
+++ b/x/pairing/keeper/pairing_subscription_test.go
@@ -18,6 +18,8 @@ func TestGetPairingForSubscription(t *testing.T) {
 	var balance int64 = 10000
 
 	consumer := common.CreateNewAccount(ts.ctx, *ts.keepers, balance).Addr.String()
+	devkey := common.CreateNewAccount(ts.ctx, *ts.keepers, balance).Addr.String()
+
 	msgBuy := &subtypes.MsgBuy{
 		Creator:  consumer,
 		Consumer: consumer,
@@ -30,16 +32,28 @@ func TestGetPairingForSubscription(t *testing.T) {
 	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
 	_ctx := sdk.UnwrapSDKContext(ts.ctx)
 
+	projectData := projectstypes.ProjectData{
+		Name:        "project",
+		Enabled:     true,
+		Policy:      &ts.plan.PlanPolicy,
+		ProjectKeys: []projectstypes.ProjectKey{projectstypes.ProjectDeveloperKey(devkey)},
+	}
+	err = ts.keepers.Projects.CreateProject(_ctx, consumer, projectData, ts.plan)
+	require.Nil(t, err)
+
+	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
+
 	pairingReq := types.QueryGetPairingRequest{
 		ChainID: ts.spec.Index,
-		Client:  consumer,
+		Client:  devkey,
 	}
 	pairing, err := ts.keepers.Pairing.GetPairing(ts.ctx, &pairingReq)
 	require.Nil(t, err)
 
 	verifyPairingQuery := &types.QueryVerifyPairingRequest{
 		ChainID:  ts.spec.Index,
-		Client:   consumer,
+		Client:   devkey,
 		Provider: pairing.Providers[0].Address,
 		Block:    uint64(_ctx.BlockHeight()),
 	}
@@ -47,18 +61,21 @@ func TestGetPairingForSubscription(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, vefiry.Valid)
 
-	project, err := ts.keepers.Projects.GetProjectForDeveloper(_ctx, consumer, uint64(_ctx.BlockHeight()))
+	_, err = ts.keepers.Projects.GetProjectForDeveloper(_ctx, devkey, uint64(_ctx.BlockHeight()))
 	require.Nil(t, err)
 
-	err = ts.keepers.Projects.DeleteProject(_ctx, project.Index)
+	err = ts.keepers.Projects.DeleteProject(_ctx, consumer, projectData.Name)
 	require.Nil(t, err)
+
+	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
 
 	_, err = ts.keepers.Pairing.GetPairing(ts.ctx, &pairingReq)
 	require.NotNil(t, err)
 
 	verifyPairingQuery = &types.QueryVerifyPairingRequest{
 		ChainID:  ts.spec.Index,
-		Client:   consumer,
+		Client:   devkey,
 		Provider: pairing.Providers[0].Address,
 		Block:    uint64(_ctx.BlockHeight()),
 	}
@@ -147,14 +164,14 @@ func TestRelayPaymentSubscriptionCU(t *testing.T) {
 	err = ts.keepers.Subscription.AddProjectToSubscription(_ctx, consumerA.Addr.String(), consumerBProjectData)
 	require.Nil(t, err)
 
+	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
+
 	// verify both projects exist
 	projA, err := ts.keepers.Projects.GetProjectForDeveloper(_ctx, consumerA.Addr.String(), uint64(_ctx.BlockHeight()))
 	require.Nil(t, err)
 	projB, err := ts.keepers.Projects.GetProjectForDeveloper(_ctx, consumerB.Addr.String(), uint64(_ctx.BlockHeight()))
 	require.Nil(t, err)
-
-	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
-	_ctx = sdk.UnwrapSDKContext(ts.ctx)
 
 	// verify that both consumers are paired
 	for _, consumer := range consumers {
@@ -426,6 +443,9 @@ func TestStrictestPolicyCuPerEpoch(t *testing.T) {
 				})
 				require.Nil(t, err)
 
+				ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+				_ctx = sdk.UnwrapSDKContext(ts.ctx)
+
 				sub, found := ts.keepers.Subscription.GetSubscription(_ctx, proj.Subscription)
 				require.True(t, found)
 
@@ -612,11 +632,14 @@ func TestAddProjectAfterPlanUpdate(t *testing.T) {
 	err = ts.keepers.Subscription.AddProjectToSubscription(_ctx, ts.clients[0].Addr.String(), projectData)
 	require.Nil(t, err)
 
+	ts.ctx = testkeeper.AdvanceEpoch(ts.ctx, ts.keepers)
+	_ctx = sdk.UnwrapSDKContext(ts.ctx)
+
 	proj, err := ts.keepers.Projects.GetProjectForDeveloper(_ctx, ts.clients[1].Addr.String(),
 		uint64(_ctx.BlockHeight()))
 	require.Nil(t, err)
 
-	// set a new policy to the second project, making it more strict than the old plan but less strict than the new plan
+	// new policy to the second project: stricter than the old plan, weaker than the new plan
 	adminPolicy := ts.plan.PlanPolicy
 	adminPolicy.EpochCuLimit = oldEpochCuLimit - 30
 

--- a/x/projects/keeper/creation.go
+++ b/x/projects/keeper/creation.go
@@ -77,7 +77,7 @@ func (k Keeper) CreateProject(ctx sdk.Context, subAddr string, projectData types
 
 // add a new project to the subscription
 func (k Keeper) doCreateProject(ctx sdk.Context, subAddr string, projectData types.ProjectData, plan plantypes.Plan, block uint64) error {
-	project, err := types.NewProject(subAddr, projectData.GetName(), projectData.GetDescription(), projectData.GetEnabled())
+	project, err := types.NewProject(subAddr, projectData.GetName(), projectData.GetEnabled())
 	if err != nil {
 		return err
 	}
@@ -109,17 +109,15 @@ func (k Keeper) doCreateProject(ctx sdk.Context, subAddr string, projectData typ
 	return k.projectsFS.AppendEntry(ctx, project.Index, block, &project)
 }
 
-func (k Keeper) DeleteProject(ctx sdk.Context, creator string, index string) error {
+func (k Keeper) DeleteProject(ctx sdk.Context, creator string, projectID string) error {
 	ctxBlock := uint64(ctx.BlockHeight())
 
 	nextEpoch, err := k.epochstorageKeeper.GetNextEpoch(ctx, ctxBlock)
 	if err != nil {
 		return utils.LavaFormatError("DeleteProject: failed to get NextEpoch", err,
-			utils.Attribute{Key: "index", Value: index},
+			utils.Attribute{Key: "projectID", Value: projectID},
 		)
 	}
-
-	projectID := types.ProjectIndex(creator, index)
 
 	var project types.Project
 	found := k.projectsFS.FindEntry(ctx, projectID, nextEpoch, &project)

--- a/x/projects/keeper/creation.go
+++ b/x/projects/keeper/creation.go
@@ -42,7 +42,7 @@ import (
 //        find devel-key (now)
 //        if not belong to project: bail
 //        find devel-key (when)
-//        if not belong to project: bail
+//        if the key not belong to this project: bail
 //        else if not found: add to project, AppendEntry(dev-key, when)
 //
 // upon unregisterKey(project, when)
@@ -125,6 +125,7 @@ func (k Keeper) DeleteProject(ctx sdk.Context, creator string, projectID string)
 		return utils.LavaFormatWarning("delete project failed",
 			fmt.Errorf("project not found"),
 			utils.Attribute{Key: "projectID", Value: projectID},
+			utils.Attribute{Key: "block", Value: ctxBlock},
 		)
 	}
 

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -316,6 +316,39 @@ func TestProjectsServerAPI(t *testing.T) {
 	require.Equal(t, 1, len(res.Project.ProjectKeys))
 }
 
+func TestDeleteProject(t *testing.T) {
+	ts := newTestStruct(t)
+	ts.prepareData(1, 0, 0) // 1 sub, 0 adm, 0 dev
+
+	projectData := ts.projects["pd2"]
+	plan := common.CreateMockPlan()
+
+	subAddr := ts.accounts["sub1"]
+	projectID := types.ProjectIndex(subAddr, projectData.Name)
+
+	err := ts.keepers.Projects.CreateProject(ts.ctx, subAddr, projectData, plan)
+	require.Nil(t, err)
+
+	ts.AdvanceEpoch(1)
+
+	_, err = ts.keepers.Projects.GetProjectForBlock(ts.ctx, projectID, ts.BlockHeight())
+	require.Nil(t, err)
+
+	err = ts.keepers.Projects.DeleteProject(ts.ctx, subAddr, "nonsense")
+	require.NotNil(t, err)
+
+	err = ts.keepers.Projects.DeleteProject(ts.ctx, subAddr, projectData.Name)
+	require.Nil(t, err)
+
+	_, err = ts.keepers.Projects.GetProjectForBlock(ts.ctx, projectID, ts.BlockHeight())
+	require.Nil(t, err)
+
+	ts.AdvanceEpoch(1)
+
+	_, err = ts.keepers.Projects.GetProjectForBlock(ts.ctx, projectID, ts.BlockHeight())
+	require.NotNil(t, err)
+}
+
 func TestAddDelKeys(t *testing.T) {
 	ts := newTestStruct(t)
 	ts.prepareData(1, 0, 2) // 1 sub, 0 adm, 2 dev

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -447,14 +447,14 @@ func TestAddAdminInTwoProjects(t *testing.T) {
 }
 
 func TestSetPolicy(t *testing.T) {
-	SetPolicyTest(t, true)
+	setPolicyTest(t, true)
 }
 
 func TestSetSubscriptionPolicy(t *testing.T) {
-	SetPolicyTest(t, false)
+	setPolicyTest(t, false)
 }
 
-func SetPolicyTest(t *testing.T, testAdminPolicy bool) {
+func setPolicyTest(t *testing.T, testAdminPolicy bool) {
 	ts := newTestStruct(t)
 	ts.prepareData(1, 0, 1) // 1 sub, 0 admin, 1 data
 
@@ -469,6 +469,8 @@ func SetPolicyTest(t *testing.T, testAdminPolicy bool) {
 
 	err := ts.keepers.Projects.CreateProject(ts.ctx, subAddr, projectData, plan)
 	require.Nil(t, err)
+
+	ts.AdvanceEpoch(1)
 
 	pk := types.ProjectDeveloperKey(devAddr)
 	err = ts.keepers.Projects.AddKeysToProject(ts.ctx, projectID, admAddr, []types.ProjectKey{pk})

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -337,7 +337,7 @@ func TestDeleteProject(t *testing.T) {
 	err = ts.keepers.Projects.DeleteProject(ts.ctx, subAddr, "nonsense")
 	require.NotNil(t, err)
 
-	err = ts.keepers.Projects.DeleteProject(ts.ctx, subAddr, projectData.Name)
+	err = ts.keepers.Projects.DeleteProject(ts.ctx, subAddr, projectID)
 	require.Nil(t, err)
 
 	_, err = ts.keepers.Projects.GetProjectForBlock(ts.ctx, projectID, ts.BlockHeight())

--- a/x/subscription/client/cli/tx.go
+++ b/x/subscription/client/cli/tx.go
@@ -30,6 +30,7 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdBuy())
 	cmd.AddCommand(CmdAddProject())
+	cmd.AddCommand(CmdDelProject())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/subscription/client/cli/tx_del_project.go
+++ b/x/subscription/client/cli/tx_del_project.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lavanet/lava/x/subscription/types"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdDelProject() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "del-project [project-name]",
+		Short: "Delete a project from a subscription",
+		Long: `The del-project command allows the subscription owner to delete an existing project from its
+		subscription. If successful, the project will be deleted at the end of the current epoch.`,
+		Example: `required flags: --from <subscription_consumer>
+		lavad tx subscription del-project <project-name> --from <subscription_consumer>`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			projectName := args[0]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			creator := clientCtx.GetFromAddress().String()
+
+			msg := types.NewMsgDelProject(
+				creator,
+				projectName,
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.MarkFlagRequired(flags.FlagFrom)
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/subscription/handler.go
+++ b/x/subscription/handler.go
@@ -23,6 +23,9 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 		case *types.MsgAddProject:
 			res, err := msgServer.AddProject(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+		case *types.MsgDelProject:
+			res, err := msgServer.DelProject(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
 			// this line is used by starport scaffolding # 1
 		default:
 			errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)

--- a/x/subscription/keeper/msg_server_del_project.go
+++ b/x/subscription/keeper/msg_server_del_project.go
@@ -1,0 +1,25 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/lavanet/lava/utils"
+	"github.com/lavanet/lava/x/subscription/types"
+)
+
+func (k msgServer) DelProject(goCtx context.Context, msg *types.MsgDelProject) (*types.MsgDelProjectResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	err := k.Keeper.DelProjectFromSubscription(ctx, msg.GetCreator(), msg.GetName())
+	if err == nil {
+		logger := k.Keeper.Logger(ctx)
+		details := map[string]string{
+			"subscription": msg.GetCreator(),
+			"projectName":  msg.GetName(),
+		}
+		utils.LogLavaEvent(ctx, logger, types.DelProjectEventName, details, "project deleted from subscription")
+	}
+
+	return &types.MsgDelProjectResponse{}, err
+}

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -48,7 +48,16 @@ func (k Keeper) RemoveSubscription(ctx sdk.Context, consumer string) {
 
 	allProjectsIDs := k.projectsKeeper.GetAllProjectsForSubscription(ctx, consumer)
 	for _, projectID := range allProjectsIDs {
-		k.projectsKeeper.DeleteProject(ctx, consumer, projectID)
+		err := k.projectsKeeper.DeleteProject(ctx, consumer, projectID)
+		if err != nil {
+			// TODO: this should never fail, because these are exactly the
+			// subscription's current projects.
+			utils.LavaFormatError("Failed to delete project at subscription removal", err,
+				utils.Attribute{Key: "subscription", Value: consumer},
+				utils.Attribute{Key: "project", Value: projectID},
+				utils.Attribute{Key: "block", Value: ctx.BlockHeight()},
+			)
+		}
 	}
 
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SubscriptionKeyPrefix))

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -46,6 +46,11 @@ func (k Keeper) RemoveSubscription(ctx sdk.Context, consumer string) {
 		k.plansKeeper.PutPlan(ctx, sub.PlanIndex, sub.PlanBlock)
 	}
 
+	allProjectsIDs := k.projectsKeeper.GetAllProjectsForSubscription(ctx, consumer)
+	for _, projectID := range allProjectsIDs {
+		k.projectsKeeper.DeleteProject(ctx, consumer, projectID)
+	}
+
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SubscriptionKeyPrefix))
 	store.Delete(types.SubscriptionKey(consumer))
 }
@@ -276,6 +281,15 @@ func (k Keeper) AddProjectToSubscription(ctx sdk.Context, subscription string, p
 	}
 
 	return k.projectsKeeper.CreateProject(ctx, subscription, projectData, plan)
+}
+
+func (k Keeper) DelProjectFromSubscription(ctx sdk.Context, subscription string, index string) error {
+	_, found := k.GetSubscription(ctx, subscription)
+	if !found {
+		return sdkerrors.ErrKeyNotFound.Wrapf("AddProjectToSubscription_can't_get_subscription_of_%s", subscription)
+	}
+
+	return k.projectsKeeper.DeleteProject(ctx, subscription, index)
 }
 
 func (k Keeper) ChargeComputeUnitsToSubscription(ctx sdk.Context, subscription string, cuAmount uint64) error {

--- a/x/subscription/keeper/subscription.go
+++ b/x/subscription/keeper/subscription.go
@@ -283,13 +283,14 @@ func (k Keeper) AddProjectToSubscription(ctx sdk.Context, subscription string, p
 	return k.projectsKeeper.CreateProject(ctx, subscription, projectData, plan)
 }
 
-func (k Keeper) DelProjectFromSubscription(ctx sdk.Context, subscription string, index string) error {
+func (k Keeper) DelProjectFromSubscription(ctx sdk.Context, subscription string, name string) error {
 	_, found := k.GetSubscription(ctx, subscription)
 	if !found {
 		return sdkerrors.ErrKeyNotFound.Wrapf("AddProjectToSubscription_can't_get_subscription_of_%s", subscription)
 	}
 
-	return k.projectsKeeper.DeleteProject(ctx, subscription, index)
+	projectID := projectstypes.ProjectIndex(subscription, name)
+	return k.projectsKeeper.DeleteProject(ctx, subscription, projectID)
 }
 
 func (k Keeper) ChargeComputeUnitsToSubscription(ctx sdk.Context, subscription string, cuAmount uint64) error {

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -748,9 +748,15 @@ func TestGetProjectsForSubscription(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	// check the number of projects are as expected (+1 because there's an auto-generated admin project)
+	// number of projects expected (+1 because there's an auto-generated admin project)
 	require.Equal(t, 3, len(res1.Projects))
 	require.Equal(t, 1, len(res2.Projects))
+
+	_, err = ts.servers.SubscriptionServer.DelProject(ts._ctx, &types.MsgDelProject{
+		Creator: subAcc1,
+		Name:    projData2.Name,
+	})
+	require.Nil(t, err)
 }
 
 func TestAddDelProjectForSubscription(t *testing.T) {

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -67,13 +67,15 @@ func TestSubscriptionGet(t *testing.T) {
 }
 
 func TestSubscriptionRemove(t *testing.T) {
-	keeper, ctx := keepertest.SubscriptionKeeper(t)
-	items := createNSubscription(keeper, ctx, 10)
+	ts := setupTestStruct(t, 3)
+	keeper := &ts.keepers.Subscription
+
+	items := createNSubscription(keeper, ts.ctx, 10)
 	for _, item := range items {
-		keeper.RemoveSubscription(ctx,
+		keeper.RemoveSubscription(ts.ctx,
 			item.Creator,
 		)
-		_, found := keeper.GetSubscription(ctx,
+		_, found := keeper.GetSubscription(ts.ctx,
 			item.Creator,
 		)
 		require.False(t, found)
@@ -583,7 +585,7 @@ func TestExpiryTime(t *testing.T) {
 
 			// TODO: remove when RemoveSubscriptions properly removes projects
 			projectID := projectstypes.ProjectIndex(creator, projectstypes.ADMIN_PROJECT_NAME)
-			ts.keepers.Projects.DeleteProject(ts.ctx, projectID)
+			ts.keepers.Projects.DeleteProject(ts.ctx, creator, projectID)
 		})
 	}
 }
@@ -630,7 +632,7 @@ func TestPrice(t *testing.T) {
 
 			// TODO: remove when RemoveSubscriptions properly removes projects
 			projectID := projectstypes.ProjectIndex(creator, projectstypes.ADMIN_PROJECT_NAME)
-			ts.keepers.Projects.DeleteProject(ts.ctx, projectID)
+			ts.keepers.Projects.DeleteProject(ts.ctx, creator, projectID)
 		})
 	}
 }

--- a/x/subscription/module_simulation.go
+++ b/x/subscription/module_simulation.go
@@ -32,6 +32,10 @@ const (
 	// TODO: Determine the simulation weight value
 	defaultWeightMsgAddProject int = 100
 
+	opWeightMsgDelProject = "op_weight_msg_del_project"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgDelProject int = 100
+
 	// this line is used by starport scaffolding # simapp/module/const
 )
 
@@ -85,6 +89,17 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 	operations = append(operations, simulation.NewWeightedOperation(
 		weightMsgAddProject,
 		subscriptionsimulation.SimulateMsgAddProject(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
+	var weightMsgDelProject int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgDelProject, &weightMsgDelProject, nil,
+		func(_ *rand.Rand) {
+			weightMsgDelProject = defaultWeightMsgDelProject
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgDelProject,
+		subscriptionsimulation.SimulateMsgDelProject(am.accountKeeper, am.bankKeeper, am.keeper),
 	))
 
 	// this line is used by starport scaffolding # simapp/module/operation

--- a/x/subscription/simulation/del_project.go
+++ b/x/subscription/simulation/del_project.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/lavanet/lava/x/subscription/keeper"
+	"github.com/lavanet/lava/x/subscription/types"
+)
+
+func SimulateMsgDelProject(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgDelProject{
+			Creator: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the DelProject simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "DelProject simulation not implemented"), nil, nil
+	}
+}

--- a/x/subscription/types/codec.go
+++ b/x/subscription/types/codec.go
@@ -12,6 +12,7 @@ import (
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgBuy{}, "subscription/Buy", nil)
 	cdc.RegisterConcrete(&MsgAddProject{}, "subscription/AddProject", nil)
+	cdc.RegisterConcrete(&MsgDelProject{}, "subscription/DelProject", nil)
 	// this line is used by starport scaffolding # 2
 }
 
@@ -21,6 +22,9 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	)
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgAddProject{},
+	)
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgDelProject{},
 	)
 	// this line is used by starport scaffolding # 3
 

--- a/x/subscription/types/expected_keepers.go
+++ b/x/subscription/types/expected_keepers.go
@@ -30,7 +30,7 @@ type EpochstorageKeeper interface {
 type ProjectsKeeper interface {
 	CreateAdminProject(ctx sdk.Context, subscriptionAddress string, plan planstypes.Plan) error
 	CreateProject(ctx sdk.Context, subscriptionAddress string, projectData projectstypes.ProjectData, plan planstypes.Plan) error
-	DeleteProject(ctx sdk.Context, index string) error
+	DeleteProject(ctx sdk.Context, creator string, index string) error
 	SnapshotSubscriptionProjects(ctx sdk.Context, subscriptionAddr string)
 	GetAllProjectsForSubscription(ctx sdk.Context, subscription string) []string
 	// Methods imported from projectskeeper should be defined here

--- a/x/subscription/types/message_del_project.go
+++ b/x/subscription/types/message_del_project.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgDelProject = "del_project"
+
+var _ sdk.Msg = &MsgDelProject{}
+
+func NewMsgDelProject(creator string, name string) *MsgDelProject {
+	return &MsgDelProject{
+		Creator: creator,
+		Name:    name,
+	}
+}
+
+func (msg *MsgDelProject) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgDelProject) Type() string {
+	return TypeMsgDelProject
+}
+
+func (msg *MsgDelProject) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
+
+func (msg *MsgDelProject) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgDelProject) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+
+	return nil
+}

--- a/x/subscription/types/message_del_project_test.go
+++ b/x/subscription/types/message_del_project_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/lavanet/lava/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgDelProject_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgDelProject
+		err  error
+	}{
+		{
+			name: "invalid address",
+			msg: MsgDelProject{
+				Creator: "invalid_address",
+				Name:    "validname",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid address",
+			msg: MsgDelProject{
+				Creator: sample.AccAddress(),
+				Name:    "validname",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/x/subscription/types/tx.pb.go
+++ b/x/subscription/types/tx.pb.go
@@ -221,40 +221,132 @@ func (m *MsgAddProjectResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgAddProjectResponse proto.InternalMessageInfo
 
+type MsgDelProject struct {
+	Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+	Name    string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+}
+
+func (m *MsgDelProject) Reset()         { *m = MsgDelProject{} }
+func (m *MsgDelProject) String() string { return proto.CompactTextString(m) }
+func (*MsgDelProject) ProtoMessage()    {}
+func (*MsgDelProject) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cc8b79a0f6744252, []int{4}
+}
+func (m *MsgDelProject) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgDelProject) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgDelProject.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgDelProject) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDelProject.Merge(m, src)
+}
+func (m *MsgDelProject) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgDelProject) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDelProject.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgDelProject proto.InternalMessageInfo
+
+func (m *MsgDelProject) GetCreator() string {
+	if m != nil {
+		return m.Creator
+	}
+	return ""
+}
+
+func (m *MsgDelProject) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+type MsgDelProjectResponse struct {
+}
+
+func (m *MsgDelProjectResponse) Reset()         { *m = MsgDelProjectResponse{} }
+func (m *MsgDelProjectResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgDelProjectResponse) ProtoMessage()    {}
+func (*MsgDelProjectResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cc8b79a0f6744252, []int{5}
+}
+func (m *MsgDelProjectResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgDelProjectResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgDelProjectResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgDelProjectResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDelProjectResponse.Merge(m, src)
+}
+func (m *MsgDelProjectResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgDelProjectResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDelProjectResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgDelProjectResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgBuy)(nil), "lavanet.lava.subscription.MsgBuy")
 	proto.RegisterType((*MsgBuyResponse)(nil), "lavanet.lava.subscription.MsgBuyResponse")
 	proto.RegisterType((*MsgAddProject)(nil), "lavanet.lava.subscription.MsgAddProject")
 	proto.RegisterType((*MsgAddProjectResponse)(nil), "lavanet.lava.subscription.MsgAddProjectResponse")
+	proto.RegisterType((*MsgDelProject)(nil), "lavanet.lava.subscription.MsgDelProject")
+	proto.RegisterType((*MsgDelProjectResponse)(nil), "lavanet.lava.subscription.MsgDelProjectResponse")
 }
 
 func init() { proto.RegisterFile("subscription/tx.proto", fileDescriptor_cc8b79a0f6744252) }
 
 var fileDescriptor_cc8b79a0f6744252 = []byte{
-	// 355 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0xcf, 0x4e, 0xfa, 0x40,
-	0x10, 0xee, 0xfe, 0x28, 0xfc, 0x70, 0x50, 0x43, 0x1a, 0xd0, 0xda, 0x43, 0xc5, 0x9e, 0x30, 0x31,
-	0x5b, 0x83, 0x4f, 0x20, 0x31, 0x1e, 0x34, 0x24, 0xa6, 0xde, 0xbc, 0x98, 0xa5, 0xdd, 0x94, 0x1a,
-	0xe9, 0x36, 0xbb, 0x5b, 0x02, 0x6f, 0xe1, 0x43, 0x79, 0xe0, 0xc8, 0xd1, 0x93, 0x31, 0xf0, 0x22,
-	0xa6, 0xff, 0x80, 0x1e, 0x44, 0x4f, 0x3b, 0xdf, 0xce, 0x37, 0x33, 0xdf, 0x7c, 0x19, 0x68, 0x8b,
-	0x78, 0x28, 0x5c, 0x1e, 0x44, 0x32, 0x60, 0xa1, 0x2d, 0xa7, 0x38, 0xe2, 0x4c, 0x32, 0xed, 0xe4,
-	0x95, 0x4c, 0x48, 0x48, 0x25, 0x4e, 0x5e, 0xbc, 0xcd, 0x31, 0x8e, 0x22, 0xce, 0x5e, 0xa8, 0x2b,
-	0x85, 0x9d, 0x07, 0x59, 0x89, 0xd1, 0xf2, 0x99, 0xcf, 0xd2, 0xd0, 0x4e, 0xa2, 0xec, 0xd7, 0x9a,
-	0x40, 0x6d, 0x20, 0xfc, 0x7e, 0x3c, 0xd3, 0x74, 0xf8, 0xef, 0x72, 0x4a, 0x24, 0xe3, 0x3a, 0xea,
-	0xa0, 0xee, 0x9e, 0x53, 0x40, 0xcd, 0x80, 0xba, 0xcb, 0x42, 0x11, 0x8f, 0x29, 0xd7, 0xff, 0xa5,
-	0xa9, 0x35, 0xd6, 0x5a, 0x50, 0x0d, 0x42, 0x8f, 0x4e, 0xf5, 0x4a, 0x9a, 0xc8, 0x40, 0x52, 0xe1,
-	0xc5, 0x9c, 0x24, 0x7a, 0x74, 0xb5, 0x83, 0xba, 0xaa, 0xb3, 0xc6, 0x77, 0x6a, 0xbd, 0xda, 0xac,
-	0x59, 0x4d, 0x38, 0xcc, 0xe6, 0x3a, 0x54, 0x44, 0x2c, 0x14, 0xd4, 0x9a, 0xc0, 0xc1, 0x40, 0xf8,
-	0xd7, 0x9e, 0xf7, 0x90, 0xc9, 0xde, 0x21, 0xe8, 0x1e, 0xf6, 0xf3, 0xdd, 0x9e, 0x3d, 0x22, 0x49,
-	0x2a, 0xaa, 0xd1, 0xb3, 0x70, 0xc9, 0x94, 0xc2, 0x06, 0x9c, 0xf7, 0xbb, 0x21, 0x92, 0xf4, 0xd5,
-	0xf9, 0xe7, 0xa9, 0xe2, 0x34, 0xa2, 0xcd, 0x97, 0x75, 0x0c, 0xed, 0xd2, 0xdc, 0x42, 0x50, 0xef,
-	0x1d, 0x41, 0x65, 0x20, 0x7c, 0xed, 0x11, 0x2a, 0x89, 0x3f, 0x67, 0xf8, 0x47, 0xcf, 0x71, 0xb6,
-	0x8a, 0x71, 0xfe, 0x2b, 0xa5, 0x68, 0xae, 0x8d, 0x00, 0xb6, 0x56, 0xed, 0xee, 0x2e, 0xdc, 0x30,
-	0x8d, 0xcb, 0xbf, 0x32, 0x8b, 0x49, 0xfd, 0xdb, 0xf9, 0xd2, 0x44, 0x8b, 0xa5, 0x89, 0xbe, 0x96,
-	0x26, 0x7a, 0x5b, 0x99, 0xca, 0x62, 0x65, 0x2a, 0x1f, 0x2b, 0x53, 0x79, 0xba, 0xf0, 0x03, 0x39,
-	0x8a, 0x87, 0xd8, 0x65, 0x63, 0x3b, 0xef, 0x9a, 0xbe, 0xf6, 0xd4, 0x2e, 0x5f, 0xdd, 0x2c, 0xa2,
-	0x62, 0x58, 0x4b, 0x0f, 0xe6, 0xea, 0x3b, 0x00, 0x00, 0xff, 0xff, 0x4c, 0x10, 0x26, 0x58, 0x92,
-	0x02, 0x00, 0x00,
+	// 392 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0xc1, 0x6e, 0xaa, 0x40,
+	0x14, 0x05, 0x45, 0x9f, 0x6f, 0x7c, 0xef, 0xc5, 0x10, 0x7d, 0xa5, 0x2c, 0xa8, 0x65, 0x65, 0x93,
+	0x66, 0x68, 0xec, 0xba, 0x8b, 0x1a, 0xd3, 0x45, 0x1b, 0x93, 0x86, 0xee, 0xba, 0x69, 0x46, 0x98,
+	0x20, 0x8d, 0x32, 0x64, 0x66, 0x30, 0xfa, 0x17, 0xfd, 0x92, 0x7e, 0x87, 0x4b, 0x97, 0x5d, 0x35,
+	0x8d, 0xfe, 0x48, 0xc3, 0x00, 0x82, 0x69, 0x2a, 0x5d, 0xcd, 0xbd, 0x73, 0xcf, 0x3d, 0xe7, 0x70,
+	0x00, 0xd0, 0x61, 0xd1, 0x98, 0x39, 0xd4, 0x0f, 0xb9, 0x4f, 0x02, 0x8b, 0x2f, 0x60, 0x48, 0x09,
+	0x27, 0xea, 0xf1, 0x14, 0xcd, 0x51, 0x80, 0x39, 0x8c, 0x4f, 0x58, 0xc4, 0xe8, 0xff, 0x43, 0x4a,
+	0x9e, 0xb1, 0xc3, 0x99, 0x95, 0x16, 0xc9, 0x8a, 0xde, 0xf6, 0x88, 0x47, 0x44, 0x69, 0xc5, 0x55,
+	0x72, 0x6b, 0xce, 0x41, 0x7d, 0xc4, 0xbc, 0x41, 0xb4, 0x54, 0x35, 0xf0, 0xcb, 0xa1, 0x18, 0x71,
+	0x42, 0x35, 0xb9, 0x2b, 0xf7, 0x7e, 0xdb, 0x59, 0xab, 0xea, 0xa0, 0xe1, 0x90, 0x80, 0x45, 0x33,
+	0x4c, 0xb5, 0x8a, 0x18, 0xed, 0x7a, 0xb5, 0x0d, 0x6a, 0x7e, 0xe0, 0xe2, 0x85, 0x56, 0x15, 0x83,
+	0xa4, 0x89, 0x37, 0xdc, 0x88, 0xa2, 0xd8, 0x8f, 0xa6, 0x74, 0xe5, 0x9e, 0x62, 0xef, 0xfa, 0x5b,
+	0xa5, 0x51, 0x6b, 0xd5, 0xcd, 0x16, 0xf8, 0x97, 0xe8, 0xda, 0x98, 0x85, 0x24, 0x60, 0xd8, 0x9c,
+	0x83, 0xbf, 0x23, 0xe6, 0x5d, 0xbb, 0xee, 0x7d, 0x62, 0xfb, 0x80, 0xa1, 0x3b, 0xf0, 0x27, 0x7d,
+	0xb6, 0x27, 0x17, 0x71, 0x24, 0x4c, 0x35, 0xfb, 0x26, 0xdc, 0x0b, 0x25, 0x8b, 0x01, 0xa6, 0x7c,
+	0x43, 0xc4, 0xd1, 0x40, 0x59, 0xbd, 0x9f, 0x48, 0x76, 0x33, 0xcc, 0xaf, 0xcc, 0x23, 0xd0, 0xd9,
+	0xd3, 0xdd, 0x19, 0xba, 0x12, 0x86, 0x86, 0x78, 0x5a, 0x6e, 0x48, 0x05, 0x4a, 0x80, 0x66, 0x38,
+	0x4d, 0x47, 0xd4, 0x29, 0x6f, 0xbe, 0x9e, 0xf1, 0xf6, 0x5f, 0x2b, 0xa0, 0x3a, 0x62, 0x9e, 0xfa,
+	0x00, 0xaa, 0x71, 0xee, 0xa7, 0xf0, 0xdb, 0x77, 0x09, 0x93, 0x88, 0xf4, 0xb3, 0x52, 0x48, 0x46,
+	0xae, 0x4e, 0x00, 0x28, 0x44, 0xd8, 0x3b, 0xbc, 0x98, 0x23, 0xf5, 0x8b, 0x9f, 0x22, 0x8b, 0x4a,
+	0x85, 0x6c, 0x4a, 0x94, 0x72, 0x64, 0x99, 0xd2, 0xd7, 0xc0, 0x06, 0x37, 0xab, 0x8d, 0x21, 0xaf,
+	0x37, 0x86, 0xfc, 0xb1, 0x31, 0xe4, 0x97, 0xad, 0x21, 0xad, 0xb7, 0x86, 0xf4, 0xb6, 0x35, 0xa4,
+	0xc7, 0x73, 0xcf, 0xe7, 0x93, 0x68, 0x0c, 0x1d, 0x32, 0xb3, 0x52, 0x56, 0x71, 0x5a, 0x0b, 0x6b,
+	0xff, 0xbf, 0x59, 0x86, 0x98, 0x8d, 0xeb, 0xe2, 0x93, 0xbf, 0xfc, 0x0c, 0x00, 0x00, 0xff, 0xff,
+	0xb5, 0x27, 0xf3, 0x1e, 0x54, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -271,6 +363,7 @@ const _ = grpc.SupportPackageIsVersion4
 type MsgClient interface {
 	Buy(ctx context.Context, in *MsgBuy, opts ...grpc.CallOption) (*MsgBuyResponse, error)
 	AddProject(ctx context.Context, in *MsgAddProject, opts ...grpc.CallOption) (*MsgAddProjectResponse, error)
+	DelProject(ctx context.Context, in *MsgDelProject, opts ...grpc.CallOption) (*MsgDelProjectResponse, error)
 }
 
 type msgClient struct {
@@ -299,10 +392,20 @@ func (c *msgClient) AddProject(ctx context.Context, in *MsgAddProject, opts ...g
 	return out, nil
 }
 
+func (c *msgClient) DelProject(ctx context.Context, in *MsgDelProject, opts ...grpc.CallOption) (*MsgDelProjectResponse, error) {
+	out := new(MsgDelProjectResponse)
+	err := c.cc.Invoke(ctx, "/lavanet.lava.subscription.Msg/DelProject", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	Buy(context.Context, *MsgBuy) (*MsgBuyResponse, error)
 	AddProject(context.Context, *MsgAddProject) (*MsgAddProjectResponse, error)
+	DelProject(context.Context, *MsgDelProject) (*MsgDelProjectResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -314,6 +417,9 @@ func (*UnimplementedMsgServer) Buy(ctx context.Context, req *MsgBuy) (*MsgBuyRes
 }
 func (*UnimplementedMsgServer) AddProject(ctx context.Context, req *MsgAddProject) (*MsgAddProjectResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddProject not implemented")
+}
+func (*UnimplementedMsgServer) DelProject(ctx context.Context, req *MsgDelProject) (*MsgDelProjectResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DelProject not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -356,6 +462,24 @@ func _Msg_AddProject_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_DelProject_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgDelProject)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).DelProject(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/lavanet.lava.subscription.Msg/DelProject",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).DelProject(ctx, req.(*MsgDelProject))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "lavanet.lava.subscription.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -367,6 +491,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AddProject",
 			Handler:    _Msg_AddProject_Handler,
+		},
+		{
+			MethodName: "DelProject",
+			Handler:    _Msg_DelProject_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -508,6 +636,66 @@ func (m *MsgAddProjectResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgDelProject) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgDelProject) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgDelProject) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Creator) > 0 {
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Creator)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgDelProjectResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgDelProjectResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgDelProjectResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -568,6 +756,32 @@ func (m *MsgAddProject) Size() (n int) {
 }
 
 func (m *MsgAddProjectResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgDelProject) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Creator)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgDelProjectResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -939,6 +1153,170 @@ func (m *MsgAddProjectResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgAddProjectResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgDelProject) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgDelProject: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgDelProject: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Creator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Creator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgDelProjectResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgDelProjectResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgDelProjectResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/x/subscription/types/types.go
+++ b/x/subscription/types/types.go
@@ -3,4 +3,5 @@ package types
 const (
 	BuySubscriptionEventName = "buy_subscription_event"
 	AddProjectEventName      = "add_project_to_subscription_event"
+	DelProjectEventName      = "del_project_to_subscription_event"
 )


### PR DESCRIPTION
Add logic and tx commands to delete projects.
Change tx subscription add-project semantics to take effect at the end of the current epoch.
The new tx subscription del-project also takes effect at the end of the current epoch.
Adjust semantics of tx project set-policy to also take effect at the end of the current epoch.
Adjust testing to ensure that this operations has enough time/blocks to take effect.