### PR TITLE
CNS-479 add project key effective now

### DIFF
--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -442,8 +442,8 @@ func TestAddDelKeys(t *testing.T) {
 	err = ts.delProjectKeys(project.Index, subAddr, pk)
 	require.Nil(t, err)
 
-	// deletion of admin is immediate; delete of developer take effect in next epoch
-	require.False(t, ts.isKeyInProject(project.Index, admAddr, types.ProjectKey_ADMIN))
+	// deletion take effect in next epoch
+	require.True(t, ts.isKeyInProject(project.Index, admAddr, types.ProjectKey_ADMIN))
 	require.True(t, ts.isKeyInProject(project.Index, dev3Addr, types.ProjectKey_DEVELOPER))
 	ts.AdvanceEpoch(1)
 	require.False(t, ts.isKeyInProject(project.Index, admAddr, types.ProjectKey_ADMIN))

--- a/x/projects/types/project.go
+++ b/x/projects/types/project.go
@@ -16,8 +16,7 @@ func ProjectIndex(subscriptionAddress string, projectName string) string {
 
 func NewProject(subscriptionAddress string, projectName string, enable bool) (Project, error) {
 	if !ValidateProjectName(projectName) {
-		return Project{}, fmt.Errorf("project name must be ASCII, cannot contain \",\" and its length must be less than %d. "+
-			"Name: %s", MAX_PROJECT_NAME_LEN, projectName)
+		return Project{}, fmt.Errorf("invalid project name: %s", projectName)
 	}
 
 	return Project{
@@ -46,6 +45,11 @@ func NewProjectKey(key string) ProjectKey {
 
 func (projectKey ProjectKey) AddType(kind ProjectKey_Type) ProjectKey {
 	projectKey.Kinds |= uint32(kind)
+	return projectKey
+}
+
+func (projectKey ProjectKey) SetType(kind ProjectKey_Type) ProjectKey {
+	projectKey.Kinds = uint32(kind)
 	return projectKey
 }
 


### PR DESCRIPTION
Changes are non-trivial the handle the following two cases:
    
1. delete a key handles admin key immediately, but developer key deferred to beginning of next epoch.
2. add a key after a previous delete key in the same epoch (which created a future entry); not necessarily the same key.
 
