### PR TITLE
CNS-501 e2e fails subscription add project

### DIFF
--- a/cookbook/projects/example_policy.yml
+++ b/cookbook/projects/example_policy.yml
@@ -12,11 +12,11 @@ Policy:
     - chain_id: FTM250
       apis:
         - ftm_blockNumber
-  geolocation_profile: 1
+  geolocation_profile: 1  # USC
   total_cu_limit: 1000
   epoch_cu_limit: 100
   max_providers_to_pair: 2
-  selected_providers_mode: EXCLUSIVE
+  selected_providers_mode: 2  # EXCLUSIVE
   selected_providers:
     - lava@1kgd936x3tlz2er9untunk7texfanmaud8yp9kf
     - lava@18puklmhr7u2f9g524tttm24ttf4ud842wtfcna

--- a/scripts/init_e2e.sh
+++ b/scripts/init_e2e.sh
@@ -48,20 +48,20 @@ lavad tx subscription buy "DefaultPlan" -y --from user3 --gas-adjustment "1.5" -
 
 user3addr=$(lavad keys show user3 -a)
 
-lavad tx subscription add-project "myproject" ./cookbook/projects/example_policy.yml -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-sleep_until_next_epoch
+lavad tx subscription add-project "myproject1" -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx subscription add-project "myproject" --policy-file ./cookbook/projects/example_policy.yml -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 
-lavad q subscription list-projects user3addr
+count=$(lavad q subscription list-projects ${user3addr} | grep "lava@" | wc -l)
+if [ "$count" -ne 3 ]; then "echo subscription ${user3addr}: wrong project count $count instead of 3"; exit 1; fi
 
 lavad tx project add-keys -y "$user3addr-myproject" --from user3 cookbook/projects/example_project_keys.yml --gas-prices=$GASPRICE
-sleep_until_next_epoch
-
 lavad tx project del-keys -y "$user3addr-myproject" --from user3 cookbook/projects/example_project_keys.yml --gas-prices=$GASPRICE
 sleep_until_next_epoch
 
 lavad tx subscription del-project myproject -y --from user3 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 sleep_until_next_epoch
 
-lavad q subscription list-projects user3
+count=$(lavad q subscription list-projects ${user3addr} | grep "lava@" | wc -l)
+if [ "$count" -ne 2 ]; then "echo subscription ${user3addr}: wrong project count $count instead of 2"; exit 1; fi
 
 # the end

--- a/x/plans/types/plan.pb.go
+++ b/x/plans/types/plan.pb.go
@@ -56,8 +56,9 @@ func (SELECTED_PROVIDERS_MODE) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5909a10cd0e3497, []int{0}
 }
 
-// The geolocations' values are powers of 2 that act as a bit map.
-// To add a new geolocation, put it before GL and assign it with the next power of 2.
+// The geolocation values are encoded as bits in a bitmask, with two special values:
+// GLS is set to 0 so it will be restrictive with the AND operator.
+// GL is set to -1 so it will be permissive with the AND operator.
 type Geolocation int32
 
 const (

--- a/x/subscription/client/cli/tx_add_project.go
+++ b/x/subscription/client/cli/tx_add_project.go
@@ -45,7 +45,7 @@ func CmdAddProject() *cobra.Command {
 
 			creator := clientCtx.GetFromAddress().String()
 
-			var policy *planstypes.Policy
+			policy := &planstypes.Policy{}
 
 			policyFilePath, err := cmd.Flags().GetString("policy-file")
 			if err != nil {


### PR DESCRIPTION
- fix e2e.go to check for exit status of init_e2e.sh
- fix syntax in init_e2e.sh (subscription add-project)
- fix cookbook/projects/example_poliicy.yml
- fix reading of project policy yml file
- leftover update of .../types/plan.pb.go from ealier PR
