### PR TITLE
CNS-443 propagate spec change to descendants

### DIFF
--- a/proto/spec/api_collection.proto
+++ b/proto/spec/api_collection.proto
@@ -11,28 +11,28 @@ message ApiCollection {
   CollectionData collection_data =2 [(gogoproto.nullable) = false];
   repeated Api apis = 3;
   repeated Header headers = 4;
-	repeated CollectionData inheritance_apis = 5; // by collectionKey
-	repeated ParseDirective parse_directives = 6;
+  repeated CollectionData inheritance_apis = 5; // by collectionKey
+  repeated ParseDirective parse_directives = 6;
 }
 
 message CollectionData {
   string api_interface = 1;
   string internal_path = 2;
   string type = 3;
-	string add_on = 4;
+  string add_on = 4;
 }
 
 message Header {
-	string name = 1;
+  string name = 1;
 	
-	enum HeaderType {
+  enum HeaderType {
     pass_send = 0;
     pass_reply = 1;
     pass_both = 2;
     pass_ignore = 3; // allows it to pass around but is not signed
   }
 
-	HeaderType kind = 2;
+  HeaderType kind = 2;
   FUNCTION_TAG function_tag = 3;
 }
 
@@ -42,7 +42,7 @@ message Api {
   uint64 compute_units = 3; 
   uint64 extra_compute_units = 4;
   SpecCategory category = 6 [(gogoproto.nullable) = false];
-	BlockParser block_parsing = 7 [(gogoproto.nullable) = false];
+  BlockParser block_parsing = 7 [(gogoproto.nullable) = false];
 }
 
 message ParseDirective {

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -35,6 +35,14 @@ type Attribute struct {
 	Value interface{}
 }
 
+func StringMapToAttributes(details map[string]string) []Attribute {
+	var attrs []Attribute
+	for key, val := range details {
+		attrs = append(attrs, Attribute{Key: key, Value: val})
+	}
+	return attrs
+}
+
 func LogAttr(key string, value interface{}) Attribute {
 	return Attribute{Key: key, Value: value}
 }

--- a/x/spec/keeper/spec.go
+++ b/x/spec/keeper/spec.go
@@ -71,8 +71,9 @@ func (k Keeper) GetAllSpec(ctx sdk.Context) (list []types.Spec) {
 // from the imported Spec(s). It returns the expanded Spec.
 func (k Keeper) ExpandSpec(ctx sdk.Context, spec types.Spec) (types.Spec, error) {
 	depends := map[string]bool{spec.Index: true}
+	inherit := map[string]bool{}
 
-	details, err := k.doExpandSpec(ctx, &spec, depends, spec.Index)
+	details, err := k.doExpandSpec(ctx, &spec, depends, &inherit, spec.Index)
 	if err != nil {
 		return spec, utils.LavaFormatError("spec expand failed", err,
 			utils.Attribute{Key: "imports", Value: details},
@@ -82,11 +83,22 @@ func (k Keeper) ExpandSpec(ctx sdk.Context, spec types.Spec) (types.Spec, error)
 }
 
 // doExpandSpec performs the actual work and recusion for ExpandSpec above.
-func (k Keeper) doExpandSpec(ctx sdk.Context, spec *types.Spec, depends map[string]bool, details string) (string, error) {
+func (k Keeper) doExpandSpec(
+	ctx sdk.Context,
+	spec *types.Spec,
+	depends map[string]bool,
+	inherit *map[string]bool,
+	details string,
+) (string, error) {
 	parentsCollections := map[types.CollectionData][]*types.ApiCollection{}
 
 	if len(spec.Imports) != 0 {
 		var parents []types.Spec
+
+		// update (cumulative) inherit
+		for _, index := range spec.Imports {
+			(*inherit)[index] = true
+		}
 
 		// visual markers when import deepens
 		details += "->["
@@ -109,7 +121,7 @@ func (k Keeper) doExpandSpec(ctx sdk.Context, spec *types.Spec, depends map[stri
 			}
 
 			depends[index] = true
-			details, err := k.doExpandSpec(ctx, &imported, depends, details)
+			details, err := k.doExpandSpec(ctx, &imported, depends, inherit, details)
 			if err != nil {
 				return details, err
 			}

--- a/x/spec/keeper/spec.go
+++ b/x/spec/keeper/spec.go
@@ -79,7 +79,41 @@ func (k Keeper) ExpandSpec(ctx sdk.Context, spec types.Spec) (types.Spec, error)
 			utils.Attribute{Key: "imports", Value: details},
 		)
 	}
+
 	return spec, nil
+}
+
+// RefreshSpec checks which one Spec inherits from another (just recently
+// updated) Spec, and if so updates the the BlockLastUpdated of the former.
+func (k Keeper) RefreshSpec(ctx sdk.Context, spec types.Spec, ancestors []types.Spec) ([]string, error) {
+	depends := map[string]bool{spec.Index: true}
+	inherit := map[string]bool{}
+
+	if details, err := k.doExpandSpec(ctx, &spec, depends, &inherit, spec.Index); err != nil {
+		return nil, utils.LavaFormatWarning("spec refresh failed (import)", err,
+			utils.Attribute{Key: "imports", Value: details},
+		)
+	}
+
+	if details, err := spec.ValidateSpec(k.MaxCU(ctx)); err != nil {
+		details["invalidates"] = spec.Index
+		attrs := utils.StringMapToAttributes(details)
+		return nil, utils.LavaFormatWarning("spec refresh failed (invalidate)", err, attrs...)
+	}
+
+	var inherited []string
+	for _, ancestor := range ancestors {
+		if _, ok := inherit[ancestor.Index]; ok {
+			inherited = append(inherited, ancestor.Index)
+		}
+	}
+
+	if len(inherited) > 0 {
+		spec.BlockLastUpdated = uint64(ctx.BlockHeight())
+		k.SetSpec(ctx, spec)
+	}
+
+	return inherited, nil
 }
 
 // doExpandSpec performs the actual work and recusion for ExpandSpec above.

--- a/x/spec/proposal_handler.go
+++ b/x/spec/proposal_handler.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -87,18 +88,21 @@ func NewSpecProposalsHandler(k keeper.Keeper) govtypes.Handler {
 func handleSpecProposal(ctx sdk.Context, k keeper.Keeper, p *types.SpecAddProposal) error {
 	logger := k.Logger(ctx)
 
+	type event struct {
+		name    string
+		event   string
+		details map[string]string
+	}
+
+	var events []event
+
 	for _, spec := range p.Specs {
 		_, found := k.GetSpec(ctx, spec.Index)
 
 		details, err := k.ValidateSpec(ctx, spec)
-		detailsList := []utils.Attribute{}
-		for key, val := range details {
-			detailsList = append(detailsList, utils.Attribute{Key: key, Value: val})
-		}
 		if err != nil {
-			return utils.LavaFormatWarning("invalid spec", err,
-				detailsList...,
-			)
+			attrs := utils.StringMapToAttributes(details)
+			return utils.LavaFormatWarning("invalid spec", err, attrs...)
 		}
 
 		spec.BlockLastUpdated = uint64(ctx.BlockHeight())
@@ -110,23 +114,40 @@ func handleSpecProposal(ctx sdk.Context, k keeper.Keeper, p *types.SpecAddPropos
 			name = types.SpecModifyEventName
 		}
 
-		utils.LogLavaEvent(ctx, logger, name, details, "Gov Proposal Accepted Spec")
+		// collect the events first, and only log them after everything succeeded
+		events = append(events, event{
+			name:    name,
+			event:   "Gov Proposal Accepted Spec",
+			details: details,
+		})
+
 		// TODO: add api types once its implemented to the event
 	}
 
 	// re-validate all the specs, in case the modified spec is imported by
-	// other specs and the new version creates a conflict.
+	// other specs and the new version creates a conflict; also update the
+	// BlockLastUpdated of all specs that inherit from the modified spec.
 	for _, spec := range k.GetAllSpec(ctx) {
-		if details, err := k.ValidateSpec(ctx, spec); err != nil {
-			details["invalidates"] = spec.Index
-			detailsList := []utils.Attribute{}
-			for key, val := range details {
-				detailsList = append(detailsList, utils.Attribute{Key: key, Value: val})
-			}
-			return utils.LavaFormatWarning("invalidated_spec", err,
-				detailsList...,
-			)
+		inherits, err := k.RefreshSpec(ctx, spec, p.Specs)
+		if err != nil {
+			return utils.LavaFormatWarning("invalidated spec", err)
 		}
+		if len(inherits) > 0 {
+			details := map[string]string{
+				"name":   spec.Index,
+				"import": strings.Join(inherits, ","),
+			}
+			name := types.SpecRefreshEventName
+			events = append(events, event{
+				name:    name,
+				event:   "Gov Proposal Refreshsed Spec",
+				details: details,
+			})
+		}
+	}
+
+	for _, e := range events {
+		utils.LogLavaEvent(ctx, logger, e.name, e.details, e.event)
 	}
 
 	return nil

--- a/x/spec/types/types.go
+++ b/x/spec/types/types.go
@@ -16,6 +16,7 @@ const (
 	ParamChangeEventName = "param_change"
 	SpecAddEventName     = "spec_add"
 	SpecModifyEventName  = "spec_modify"
+	SpecRefreshEventName = "spec_refresh"
 )
 
 const (


### PR DESCRIPTION
When a Spec gets updated, we set its BlockLastUpdated field to the current
block height (useful for producers to know whether they use the latest Spec
version).
    
If there are other Specs that inherit this Spec, then they effectively also
changed - so we hunt them and set their BlockLastUpdated field too.
