### PR TITLE
[PRT-786] Validate chain id for all rpc interfaces

### DIFF
--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -165,6 +165,16 @@ func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, client
 			chainCommonSetup := func() error {
 				chainMutexes[chainID].Lock()
 				defer chainMutexes[chainID].Unlock()
+
+				// Create temp chain fetcher so we can validate chainID
+				tempChainFetcher := chainlib.NewChainFetcher(ctx, chainRouter, chainParser, rpcProviderEndpoint)
+
+				// Fetch and validate chain id
+				err = tempChainFetcher.Validate(ctx)
+				if err != nil {
+					return utils.LavaFormatError("panic severity critical error, aborting support for chain api due to failing to fetch chain ID, continuing with other endpoints", err, utils.Attribute{Key: "endpoint", Value: rpcProviderEndpoint})
+				}
+
 				chainTrackerInf, found := stateTrackersPerChain.Load(chainID)
 				if !found {
 					blocksToSaveChainTracker := uint64(blocksToFinalization + blocksInFinalizationData)
@@ -184,13 +194,9 @@ func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, client
 					if err != nil {
 						return utils.LavaFormatError("panic severity critical error, aborting support for chain api due to node access, continuing with other endpoints", err, utils.Attribute{Key: "chainTrackerConfig", Value: chainTrackerConfig}, utils.Attribute{Key: "endpoint", Value: rpcProviderEndpoint})
 					}
-					stateTrackersPerChain.Store(rpcProviderEndpoint.ChainID, chainTracker)
 
-					// Fetch chain id
-					err := chainFetcher.Validate(ctx)
-					if err != nil {
-						return utils.LavaFormatError("panic severity critical error, aborting support for chain api due to failing to fetch chain ID, continuing with other endpoints", err, utils.Attribute{Key: "endpoint", Value: rpcProviderEndpoint})
-					}
+					// Any validation needs to be before we store chain tracker for given chain id
+					stateTrackersPerChain.Store(rpcProviderEndpoint.ChainID, chainTracker)
 				} else {
 					var ok bool
 					chainTracker, ok = chainTrackerInf.(*chaintracker.ChainTracker)


### PR DESCRIPTION
## Description

This PR fixes a bug where we are not validating chainId for all interfaces, but only till first valid


## Test Cases

```
screen -d -m -S provider1 bash -c "source ~/.bashrc; lava-protocol rpcprovider \
$PROVIDER1_LISTENER COS3 rest '$OSMOT_REST' \
$PROVIDER1_LISTENER COS3 tendermintrpc '$OSMO_RPC,$OSMO_RPC' \
$PROVIDER1_LISTENER COS3 grpc '$OSMOT_GRPC' \
$EXTRA_PROVIDER_FLAGS --metrics-listen-address ":7780" --geolocation 1 --log_level debug --from servicer1 2>&1 | tee $LOGS_DIR/PROVIDER1.log" && sleep 0.25
```

```
Jul 20 08:41:51 ERR RPCProvider running with disabled endpoints:
	COS3:rest Network Address:127.0.0.1:2221 Node: https://bekotopopo2:99al9YwXTnvJohMW39ZBqVH5AWnWBDV8@prod-pnet-osmosisnode-1.lavapro.xyz/testnet/rest/ Geolocation:1 Addons:
COS3:grpc Network Address:127.0.0.1:2221 Node: prod-pnet-osmosisnode-1.lavapro.xyz:9092 Geolocation:1 Addons:
```

Also i tried every other combination of these 3 rpc interfaces with correct and wrong node urls