### PR TITLE
[PRT-750] persist provider rewards (#583) (by agilefreaks)

### DIFF
--- a/protocol/rpcprovider/rewardserver/badger_db.go
+++ b/protocol/rpcprovider/rewardserver/badger_db.go
@@ -1,6 +1,8 @@
 package rewardserver
 
 import (
+	"time"
+
 	"github.com/dgraph-io/badger/v4"
 	"github.com/lavanet/lava/utils"
 )
@@ -11,9 +13,10 @@ type BadgerDB struct {
 
 var _ DB = (*BadgerDB)(nil)
 
-func (mdb *BadgerDB) Save(key string, data []byte) error {
+func (mdb *BadgerDB) Save(key string, data []byte, ttl time.Duration) error {
 	err := mdb.db.Update(func(txn *badger.Txn) error {
-		return txn.Set([]byte(key), data)
+		e := badger.NewEntry([]byte(key), data).WithTTL(ttl)
+		return txn.SetEntry(e)
 	})
 
 	return err

--- a/protocol/rpcprovider/rewardserver/db.go
+++ b/protocol/rpcprovider/rewardserver/db.go
@@ -1,7 +1,9 @@
 package rewardserver
 
+import "time"
+
 type DB interface {
-	Save(key string, data []byte) error
+	Save(key string, data []byte, ttl time.Duration) error
 	FindOne(key string) ([]byte, error)
 	FindAll() (map[string][]byte, error)
 	Delete(key string) error

--- a/protocol/rpcprovider/rewardserver/reward_db.go
+++ b/protocol/rpcprovider/rewardserver/reward_db.go
@@ -133,6 +133,11 @@ func (rs *RewardDB) DeleteClaimedRewards(claimedRewards []*pairingtypes.RelaySes
 	return nil
 }
 
+func (rs *RewardDB) DeleteEpochRewards(epoch uint64) error {
+	prefix := strconv.FormatUint(epoch, 10)
+	return rs.db.DeletePrefix(prefix)
+}
+
 func NewRewardDB(db DB) *RewardDB {
 	return &RewardDB{
 		db: db,

--- a/protocol/rpcprovider/rewardserver/reward_db.go
+++ b/protocol/rpcprovider/rewardserver/reward_db.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/utils/sigs"
@@ -14,7 +15,8 @@ import (
 const keySeparator = "."
 
 type RewardDB struct {
-	db DB
+	db  DB
+	ttl time.Duration
 }
 
 type RewardEntity struct {
@@ -41,7 +43,7 @@ func (rs *RewardDB) Save(consumerAddr string, consumerKey string, proof *pairing
 		return false, utils.LavaFormatError("failed to encode proof: %s", err)
 	}
 
-	rs.db.Save(key, buf)
+	rs.db.Save(key, buf, rs.ttl)
 
 	return true, nil
 }
@@ -139,8 +141,13 @@ func (rs *RewardDB) DeleteEpochRewards(epoch uint64) error {
 }
 
 func NewRewardDB(db DB) *RewardDB {
+	return NewRewardDBWithTTL(db, DefaultRewardTTL)
+}
+
+func NewRewardDBWithTTL(db DB, ttl time.Duration) *RewardDB {
 	return &RewardDB{
-		db: db,
+		db:  db,
+		ttl: ttl,
 	}
 }
 

--- a/protocol/rpcprovider/rewardserver/reward_server.go
+++ b/protocol/rpcprovider/rewardserver/reward_server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/protocol/lavasession"
@@ -21,6 +22,8 @@ import (
 const (
 	RewardServerStorageFlagName = "reward-server-storage"
 	DefaultRewardServerStorage  = ".storage/rewardserver"
+	RewardTTLFlagName           = "reward-ttl"
+	DefaultRewardTTL            = 24 * 60 * time.Minute
 )
 
 type PaymentRequest struct {

--- a/protocol/rpcprovider/rewardserver/reward_server.go
+++ b/protocol/rpcprovider/rewardserver/reward_server.go
@@ -226,6 +226,11 @@ func (rws *RewardServer) gatherRewardsForClaim(ctx context.Context, currentEpoch
 		}
 
 		if rws.isEpochTooOld(epoch, currentEpoch, epochsToSave) {
+			err := rws.rewardDB.DeleteEpochRewards(epoch)
+			if err != nil {
+				utils.LavaFormatWarning("failed deleting epoch", err, utils.Attribute{Key: "epoch", Value: epoch})
+			}
+
 			// Epoch is too old, we can't claim the rewards anymore.
 			continue
 		}

--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -60,6 +60,7 @@ type ProviderStateTrackerInf interface {
 	RegisterPaymentUpdatableForPayments(ctx context.Context, paymentUpdatable statetracker.PaymentUpdatable)
 	GetRecommendedEpochNumToCollectPayment(ctx context.Context) (uint64, error)
 	GetEpochSizeMultipliedByRecommendedEpochNumToCollectPayment(ctx context.Context) (uint64, error)
+	GetEpochsToSave(ctx context.Context) (uint64, error)
 }
 
 type RPCProvider struct {
@@ -84,6 +85,7 @@ func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, client
 	if err != nil {
 		return err
 	}
+
 	rpcp.providerStateTracker = providerStateTracker
 	providerStateTracker.RegisterForUpdates(ctx, statetracker.NewMetricsUpdater(providerMetricsManager))
 	// single reward server

--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -69,7 +69,7 @@ type RPCProvider struct {
 	lock                 sync.Mutex
 }
 
-func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, clientCtx client.Context, rpcProviderEndpoints []*lavasession.RPCProviderEndpoint, cache *performance.Cache, parallelConnections uint, metricsListenAddress string, rewardStoragePath string) (err error) {
+func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, clientCtx client.Context, rpcProviderEndpoints []*lavasession.RPCProviderEndpoint, cache *performance.Cache, parallelConnections uint, metricsListenAddress string, rewardStoragePath string, rewardTTL time.Duration) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt)
@@ -89,7 +89,7 @@ func (rpcp *RPCProvider) Start(ctx context.Context, txFactory tx.Factory, client
 	rpcp.providerStateTracker = providerStateTracker
 	providerStateTracker.RegisterForUpdates(ctx, statetracker.NewMetricsUpdater(providerMetricsManager))
 	// single reward server
-	rewardServer := rewardserver.NewRewardServer(providerStateTracker, providerMetricsManager, rewardserver.NewRewardDB(rewardserver.NewLocalDB(rewardStoragePath)))
+	rewardServer := rewardserver.NewRewardServer(providerStateTracker, providerMetricsManager, rewardserver.NewRewardDBWithTTL(rewardserver.NewLocalDB(rewardStoragePath), rewardTTL))
 	rpcp.providerStateTracker.RegisterForEpochUpdates(ctx, rewardServer)
 	rpcp.providerStateTracker.RegisterPaymentUpdatableForPayments(ctx, rewardServer)
 	keyName, err := sigs.GetKeyName(clientCtx)
@@ -425,8 +425,9 @@ rpcprovider 127.0.0.1:3333 COS3 tendermintrpc "wss://www.node-path.com:80,https:
 			}
 			prometheusListenAddr := viper.GetString(metrics.MetricsListenFlagName)
 			rewardStoragePath := viper.GetString(rewardserver.RewardServerStorageFlagName)
+			rewardTTL := viper.GetDuration(rewardserver.RewardTTLFlagName)
 			rpcProvider := RPCProvider{}
-			err = rpcProvider.Start(ctx, txFactory, clientCtx, rpcProviderEndpoints, cache, numberOfNodeParallelConnections, prometheusListenAddr, rewardStoragePath)
+			err = rpcProvider.Start(ctx, txFactory, clientCtx, rpcProviderEndpoints, cache, numberOfNodeParallelConnections, prometheusListenAddr, rewardStoragePath, rewardTTL)
 			return err
 		},
 	}
@@ -444,6 +445,7 @@ rpcprovider 127.0.0.1:3333 COS3 tendermintrpc "wss://www.node-path.com:80,https:
 	cmdRPCProvider.Flags().String(flags.FlagLogLevel, "debug", "log level")
 	cmdRPCProvider.Flags().String(metrics.MetricsListenFlagName, metrics.DisabledFlagOption, "the address to expose prometheus metrics (such as localhost:7779)")
 	cmdRPCProvider.Flags().String(rewardserver.RewardServerStorageFlagName, rewardserver.DefaultRewardServerStorage, "the path to store reward server data")
+	cmdRPCProvider.Flags().Duration(rewardserver.RewardTTLFlagName, rewardserver.DefaultRewardTTL, "reward time to live")
 
 	return cmdRPCProvider
 }

--- a/protocol/statetracker/provider_state_tracker.go
+++ b/protocol/statetracker/provider_state_tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lavanet/lava/protocol/lavasession"
 	"github.com/lavanet/lava/protocol/rpcprovider/reliabilitymanager"
 	"github.com/lavanet/lava/utils"
+	"github.com/lavanet/lava/x/epochstorage/types"
 	pairingtypes "github.com/lavanet/lava/x/pairing/types"
 )
 
@@ -114,4 +115,9 @@ func (pst *ProviderStateTracker) GetRecommendedEpochNumToCollectPayment(ctx cont
 
 func (pst *ProviderStateTracker) GetEpochSizeMultipliedByRecommendedEpochNumToCollectPayment(ctx context.Context) (uint64, error) {
 	return pst.stateQuery.GetEpochSizeMultipliedByRecommendedEpochNumToCollectPayment(ctx)
+}
+
+func (pst *ProviderStateTracker) GetEpochsToSave(ctx context.Context) (uint64, error) {
+	params, err := pst.stateQuery.EpochStorageQueryClient.Params(ctx, &types.QueryParamsRequest{})
+	return params.Params.EpochsToSave, err
 }

--- a/utils/lavalog.go
+++ b/utils/lavalog.go
@@ -28,8 +28,10 @@ const (
 	LAVA_LOG_PANIC
 )
 
-var JsonFormat = false
-var NoColor = true
+var (
+	JsonFormat = false
+	NoColor    = true
+)
 
 type Attribute struct {
 	Key   string

--- a/utils/logger_wrapper.go
+++ b/utils/logger_wrapper.go
@@ -21,12 +21,15 @@ func (lw LoggerWrapper) getAttributes(extraInfo ...interface{}) []Attribute {
 func (lw LoggerWrapper) Errorf(msg string, extraInfo ...interface{}) {
 	LavaFormatError(lw.LoggerName+msg, nil, lw.getAttributes(extraInfo)...)
 }
+
 func (lw LoggerWrapper) Warningf(msg string, extraInfo ...interface{}) {
 	LavaFormatWarning(lw.LoggerName+msg, nil, lw.getAttributes(extraInfo)...)
 }
+
 func (lw LoggerWrapper) Infof(msg string, extraInfo ...interface{}) {
 	LavaFormatInfo(lw.LoggerName+msg, lw.getAttributes(extraInfo)...)
 }
+
 func (lw LoggerWrapper) Debugf(msg string, extraInfo ...interface{}) {
 	LavaFormatDebug(lw.LoggerName+msg, lw.getAttributes(extraInfo)...)
 }


### PR DESCRIPTION
This PR fixes a case where rewards are being sent for an epoch too far in the past, and adds a configurable time to live to stored rewards.

Builds on top of #620 