### PR TITLE
CNS-516: fix rand to ensure determinism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/vpxyz/xorshift v1.2.2 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230724170836-66ad5b6ff146 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1417,6 +1417,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmihailenco/msgpack/v5 v5.1.4/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vpxyz/xorshift v1.2.2 h1:5SyC9lrR0ZvOPjar7sP8Xes3KlrODPfp5p0iilKpKhY=
+github.com/vpxyz/xorshift v1.2.2/go.mod h1:GO+SQPfso/+ABPOLs/X3VNbrNDoO3ltpaU1xVcbwul4=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=

--- a/testutil/common/tester.go
+++ b/testutil/common/tester.go
@@ -456,6 +456,7 @@ func (ts *Tester) QueryPairingGetPairing(chainID string, client string) (*pairin
 	return ts.Keepers.Pairing.GetPairing(ts.GoCtx, msg)
 }
 
+// QueryPairingListEpochPayments implements 'q pairing list-epoch-payments'
 func (ts *Tester) QueryPairingListEpochPayments() (*pairingtypes.QueryAllEpochPaymentsResponse, error) {
 	msg := &pairingtypes.QueryAllEpochPaymentsRequest{}
 	return ts.Keepers.Pairing.EpochPaymentsAll(ts.GoCtx, msg)

--- a/utils/rand/rand.go
+++ b/utils/rand/rand.go
@@ -1,0 +1,33 @@
+package rand
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/vpxyz/xorshift/xoroshiro128starstar"
+)
+
+func generateSeed(data []byte) (seed int64) {
+	sum256 := sha256.Sum256(data)
+
+	// fold the SHA-256 hash into a 64-bit seed using bitwise XOR
+	for i := 0; i < len(sum256)/8; i++ {
+		seed ^= int64(binary.BigEndian.Uint64(sum256[i*8 : (i+1)*8]))
+	}
+
+	return seed
+}
+
+// returns a new RPNG instance properly seeded
+func New(data []byte) *rand.Rand {
+	seed := generateSeed(data)
+	source := xoroshiro128starstar.NewSource(seed)
+	return rand.New(source)
+}
+
+// re-seeds an existing RPNG instance
+func Seed(rng *rand.Rand, data []byte) {
+	seed := generateSeed(data)
+	rng.Seed(seed)
+}

--- a/utils/rand/rand.go
+++ b/utils/rand/rand.go
@@ -8,25 +8,20 @@ import (
 	"github.com/vpxyz/xorshift/xoroshiro128starstar"
 )
 
-func generateSeed(data []byte) (seed int64) {
+func generateSeed(data []byte) int64 {
 	sum256 := sha256.Sum256(data)
-
-	// fold the SHA-256 hash into a 64-bit seed using bitwise XOR
-	for i := 0; i < len(sum256)/8; i++ {
-		seed ^= int64(binary.BigEndian.Uint64(sum256[i*8 : (i+1)*8]))
-	}
-
+	seed := int64(binary.LittleEndian.Uint64(sum256[0:8]))
 	return seed
 }
 
-// returns a new RPNG instance properly seeded
+// New returns a new RPNG instance properly seeded
 func New(data []byte) *rand.Rand {
 	seed := generateSeed(data)
 	source := xoroshiro128starstar.NewSource(seed)
 	return rand.New(source)
 }
 
-// re-seeds an existing RPNG instance
+// Seed re-seeds an existing RPNG instance
 func Seed(rng *rand.Rand, data []byte) {
 	seed := generateSeed(data)
 	rng.Seed(seed)

--- a/utils/rand/rand_test.go
+++ b/utils/rand/rand_test.go
@@ -32,10 +32,10 @@ func isUniformlyDistributed(t *testing.T, f func(n int64) int64) {
 func TestDeterminism(t *testing.T) {
 	// copied from the output of the loop below
 	expected := []int64{
-		93, 3, 11, 16, 98, 9, 29, 14,
-		25, 43, 70, 61, 0, 33, 22, 34,
-		84, 19, 61, 87, 18, 68, 67, 89,
-		98, 16, 9, 87, 83, 40, 79, 9,
+		34, 18, 63, 3, 16, 24, 81, 49,
+		49, 65, 81, 66, 10, 89, 6, 85,
+		71, 68, 89, 52, 7, 4, 3, 21,
+		17, 90, 2, 36, 5, 4, 75, 93,
 	}
 
 	rng := New([]byte("pre-determined-data"))

--- a/utils/rand/rand_test.go
+++ b/utils/rand/rand_test.go
@@ -1,0 +1,70 @@
+package rand
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func isUniformlyDistributed(t *testing.T, f func(n int64) int64) {
+	t.Helper()
+
+	const iterations = 100000
+	const maxValue = 50
+
+	numberToCount := make(map[int64]int64, maxValue)
+
+	for i := 0; i < iterations; i++ {
+		out := f(maxValue)
+		numberToCount[out]++
+	}
+
+	target := iterations / maxValue
+	const maxPercentDivergence = 0.07
+
+	for i := 0; i < maxValue; i++ {
+		count := numberToCount[int64(i)]
+		require.InEpsilon(t, target, count, maxPercentDivergence, "slot "+strconv.Itoa(i))
+	}
+}
+
+func TestDeterminism(t *testing.T) {
+	// copied from the output of the loop below
+	expected := []int64{
+		93, 3, 11, 16, 98, 9, 29, 14,
+		25, 43, 70, 61, 0, 33, 22, 34,
+		84, 19, 61, 87, 18, 68, 67, 89,
+		98, 16, 9, 87, 83, 40, 79, 9,
+	}
+
+	rng := New([]byte("pre-determined-data"))
+
+	for i := 0; i < 32; i++ {
+		random := rng.Int63n(100)
+		require.Equal(t, expected[i], random, "item "+strconv.Itoa(i))
+	}
+
+	Seed(rng, []byte("other-determined-data"))
+
+	count := 0
+	for i := 0; i < 32; i++ {
+		random := rng.Int63n(100)
+		if expected[i] == random {
+			count++
+		}
+	}
+	require.Less(t, count, 32)
+}
+
+func TestDistribution(t *testing.T) {
+	rng := New([]byte("pre-determined-data"))
+	t.Run("new rand", func(t *testing.T) {
+		isUniformlyDistributed(t, rng.Int63n)
+	})
+
+	Seed(rng, []byte("other-determined-data"))
+	t.Run("new seed", func(t *testing.T) {
+		isUniformlyDistributed(t, rng.Int63n)
+	})
+}

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -797,7 +797,7 @@ func (ts *tester) verifyPairingDistribution(desc string, client string, provider
 		totalWeight += weight(provider)
 	}
 
-	// calculate calculate the histogram
+	// calculate the occurrence histogram
 	histogram := make(map[int]int64)
 	for i := 0; i < iterations; i++ {
 		res, err := ts.QueryPairingGetPairing(ts.spec.Index, client)

--- a/x/pairing/keeper/scores/score.go
+++ b/x/pairing/keeper/scores/score.go
@@ -29,22 +29,19 @@
 // and so on).
 //
 //
-// To add a new requirement, one should create a new object that satisfies the ScoreReq interface and update the
-// CalcSlots() function so the new requirement will be assigned to the pairing slots (according to some logic).
-// Lastly, append the new requirement object in the GetAllReqs() function. Use StakeReq or GeoReq as examples.
+// To add a new requirement, create an object implementing the ScoreReq interface and update CalcSlots()
+// to assign it to the pairing slots as desired. Lastly, add the new requirement in GetAllReqs().
 
 package scores
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
-	"math/rand"
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/utils"
+	"github.com/lavanet/lava/utils/rand"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	planstypes "github.com/lavanet/lava/x/plans/types"
 )
@@ -63,9 +60,10 @@ func init() {
 }
 
 func GetAllReqs() []ScoreReq {
-	stakeReq := StakeReq{}
-	geoReq := GeoReq{}
-	return []ScoreReq{&stakeReq, &geoReq}
+	return []ScoreReq{
+		&StakeReq{},
+		&GeoReq{},
+	}
 }
 
 // get the overall requirements from the policy and assign slots that'll fulfil them
@@ -170,7 +168,8 @@ func PrepareHashData(projectIndex string, chainID string, epochHash []byte, idx 
 	return bytes.Join([][]byte{epochHash, []byte(chainID), []byte(projectIndex), []byte(strconv.Itoa(idx))}, nil)
 }
 
-// PickProviders pick a <group-count> providers set with a pseudo-random weighted choice (using the providers' score list and hashData)
+// PickProviders pick a <group-count> providers set with a pseudo-random weighted choice
+// (using the providers' score list and hashData)
 func PickProviders(ctx sdk.Context, scores []*PairingScore, groupCount int, hashData []byte) (returnedProviders []epochstoragetypes.StakeEntry) {
 	if len(scores) == 0 {
 		return returnedProviders
@@ -189,17 +188,10 @@ func PickProviders(ctx sdk.Context, scores []*PairingScore, groupCount int, hash
 		return returnedProviders
 	}
 
-	sum256 := sha256.Sum256(hashData)
-	// Fold the SHA-256 hash into a 64-bit seed using bitwise XOR
-	var seed int64
-	for i := 0; i < len(sum256)/8; i++ {
-		seed ^= int64(binary.BigEndian.Uint64(sum256[i*8 : (i+1)*8]))
-	}
-
-	rand.Seed(seed)
+	rng := rand.New(hashData)
 
 	for it := 0; it < groupCount; it++ {
-		randomValue := uint64(rand.Int63n(scoreSum.BigInt().Int64())) + 1
+		randomValue := uint64(rng.Int63n(scoreSum.BigInt().Int64())) + 1
 		newScoreSum := sdk.ZeroUint()
 
 		for idx := len(scores) - 1; idx >= 0; idx-- {
@@ -211,8 +203,9 @@ func PickProviders(ctx sdk.Context, scores []*PairingScore, groupCount int, hash
 			newScoreSum = newScoreSum.Add(providerScore.Score)
 			if randomValue <= newScoreSum.Uint64() {
 				// we hit our chosen provider
+				// remove this provider from the random pool, so the sum is lower now
 				returnedProviders = append(returnedProviders, *providerScore.Provider)
-				scoreSum = scoreSum.Sub(providerScore.Score) // we remove this provider from the random pool, so the sum is lower now
+				scoreSum = scoreSum.Sub(providerScore.Score)
 				scores[idx].SkipForSelection = true
 				break
 			}


### PR DESCRIPTION
Using the global rand directly is not safe in terms of determinism, e.g. if
another go routine calls (now or in the future) it to get a random number at
the wrong time. Likewise, rand.Seed() is deprecated in Go (for very similar
reasons).
    
Also, Go does not guarantee that the PRNG driving the default source for rand
will always provide the same output for a given seed - across different Go
versions.
    
Instead, implement our own source (PRNG) that combines rand.New() to provide
a dedicated (private) instance of a PRNG that uses the xoroshiro256** PRNG
from the the xorshift package as a source.
    
(See https://en.wikipedia.org/wiki/Xorshift for more details)
 
