### PR TITLE
PRT-784 Move dappID from path to headers

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -71,6 +71,7 @@ func extractDappIDFromFiberContext(c *fiber.Ctx) (dappID string) {
 	return dappID
 }
 
+// extractDappIDFromGrpcHeader extracts dappID from GRPC header
 func extractDappIDFromGrpcHeader(metadataValues metadata.MD) string {
 	dappId := generateNewDappID()
 	if values, ok := metadataValues["dapp-id"]; ok && len(values) > 0 {
@@ -79,6 +80,8 @@ func extractDappIDFromGrpcHeader(metadataValues metadata.MD) string {
 	return dappId
 }
 
+// generateNewDappID generates default dappID
+// In future we can also implement unique dappID generation
 func generateNewDappID() string {
 	return "DefaultDappID"
 }

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -73,7 +73,7 @@ func extractDappIDFromFiberContext(c *fiber.Ctx) (dappID string) {
 
 func generateNewDappID() string {
 	// TODO generate new dappID
-	return "NewDappID"
+	return "NoDappID"
 }
 
 func constructFiberCallbackWithHeaderAndParameterExtraction(callbackToBeCalled fiber.Handler, isMetricEnabled bool) fiber.Handler {

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -71,9 +71,16 @@ func extractDappIDFromFiberContext(c *fiber.Ctx) (dappID string) {
 	return dappID
 }
 
+func extractDappIDFromGrpcHeader(metadataValues metadata.MD) string {
+	dappId := generateNewDappID()
+	if values, ok := metadataValues["dapp-id"]; ok && len(values) > 0 {
+		dappId = values[0]
+	}
+	return dappId
+}
+
 func generateNewDappID() string {
-	// TODO generate new dappID
-	return "NoDappID"
+	return "DefaultDappID"
 }
 
 func constructFiberCallbackWithHeaderAndParameterExtraction(callbackToBeCalled fiber.Handler, isMetricEnabled bool) fiber.Handler {

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -184,7 +184,7 @@ func TestExtractDappIDFromWebsocketConnection(t *testing.T) {
 			name:     "dappId does not exist in params",
 			route:    "/ws",
 			headers:  map[string][]string{},
-			expected: "NoDappID",
+			expected: "DefaultDappID",
 		},
 	}
 
@@ -250,7 +250,7 @@ func TestExtractDappIDFromFiberContext(t *testing.T) {
 		{
 			name:     "dappId does not exist in headers",
 			headers:  map[string]string{},
-			expected: "NoDappID",
+			expected: "DefaultDappID",
 		},
 	}
 

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -184,7 +184,7 @@ func TestExtractDappIDFromWebsocketConnection(t *testing.T) {
 			name:     "dappId does not exist in params",
 			route:    "/ws",
 			headers:  map[string][]string{},
-			expected: "NewDappID",
+			expected: "NoDappID",
 		},
 	}
 

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -192,7 +192,10 @@ func TestExtractDappIDFromWebsocketConnection(t *testing.T) {
 
 	webSocketCallback := websocket.New(func(websockConn *websocket.Conn) {
 		mt, _, _ := websockConn.ReadMessage()
-		dappID := websockConn.Locals("dappId").(string)
+		dappID, ok := websockConn.Locals("dappId").(string)
+		if !ok {
+			t.Fatalf("Unable to extract dappID")
+		}
 		websockConn.WriteMessage(mt, []byte(dappID))
 	})
 
@@ -247,7 +250,7 @@ func TestExtractDappIDFromFiberContext(t *testing.T) {
 		{
 			name:     "dappId does not exist in headers",
 			headers:  map[string]string{},
-			expected: "NewDappID",
+			expected: "NoDappID",
 		},
 	}
 

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -278,9 +278,10 @@ func (apil *GrpcChainListener) Serve(ctx context.Context) {
 		ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())
 		msgSeed := apil.logger.GetMessageSeed()
 		metadataValues, _ := metadata.FromIncomingContext(ctx)
+
+		// Extract dappID from grpc header
 		dappID := extractDappIDFromGrpcHeader(metadataValues)
 
-		fmt.Println("USAOOO ", dappID)
 		grpcHeaders := convertToMetadataMapOfSlices(metadataValues)
 		utils.LavaFormatInfo("GRPC Got Relay ", utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "method", Value: method})
 		var relayReply *pairingtypes.RelayReply

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -278,11 +278,14 @@ func (apil *GrpcChainListener) Serve(ctx context.Context) {
 		ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())
 		msgSeed := apil.logger.GetMessageSeed()
 		metadataValues, _ := metadata.FromIncomingContext(ctx)
+		dappID := extractDappIDFromGrpcHeader(metadataValues)
+
+		fmt.Println("USAOOO ", dappID)
 		grpcHeaders := convertToMetadataMapOfSlices(metadataValues)
 		utils.LavaFormatInfo("GRPC Got Relay ", utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "method", Value: method})
 		var relayReply *pairingtypes.RelayReply
-		metricsData := metrics.NewRelayAnalytics("NoDappID", apil.endpoint.ChainID, apiInterface)
-		relayReply, _, err := apil.relaySender.SendRelay(ctx, method, string(reqBody), "", "NoDappID", metricsData, grpcHeaders)
+		metricsData := metrics.NewRelayAnalytics(dappID, apil.endpoint.ChainID, apiInterface)
+		relayReply, _, err := apil.relaySender.SendRelay(ctx, method, string(reqBody), "", dappID, metricsData, grpcHeaders)
 		go apil.logger.AddMetricForGrpc(metricsData, err, &metadataValues)
 
 		if err != nil {

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -245,7 +245,10 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context) {
 				apil.logger.AnalyzeWebSocketErrorAndWriteMessage(websockConn, messageType, err, msgSeed, msg, spectypes.APIInterfaceJsonRPC)
 				break
 			}
-			dappID := websockConn.Locals("dappId").(string)
+			dappID, ok := websockConn.Locals("dappId").(string)
+			if !ok {
+				apil.logger.AnalyzeWebSocketErrorAndWriteMessage(websockConn, messageType, nil, msgSeed, []byte("Unable to extract dappID"), spectypes.APIInterfaceJsonRPC)
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -246,7 +246,7 @@ func (apil *RestChainListener) Serve(ctx context.Context) {
 	chainID := apil.endpoint.ChainID
 	apiInterface := apil.endpoint.ApiInterface
 	// Catch Post
-	app.Post("/:dappId/*", func(c *fiber.Ctx) error {
+	app.Post("/*", func(c *fiber.Ctx) error {
 		endTx := apil.logger.LogStartTransaction("rest-http")
 		defer endTx()
 
@@ -293,7 +293,7 @@ func (apil *RestChainListener) Serve(ctx context.Context) {
 	})
 
 	// Catch the others
-	app.Use("/:dappId/*", func(c *fiber.Ctx) error {
+	app.Use("/*", func(c *fiber.Ctx) error {
 		endTx := apil.logger.LogStartTransaction("rest-http")
 		defer endTx()
 		msgSeed := apil.logger.GetMessageSeed()

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -275,7 +275,10 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context) {
 				apil.logger.AnalyzeWebSocketErrorAndWriteMessage(c, mt, err, msgSeed, msg, "tendermint")
 				break
 			}
-			dappID := c.Locals("dappId").(string)
+			dappID, ok := c.Locals("dappId").(string)
+			if !ok {
+				apil.logger.AnalyzeWebSocketErrorAndWriteMessage(c, mt, nil, msgSeed, []byte("Unable to extract dappID"), spectypes.APIInterfaceJsonRPC)
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())

--- a/testutil/e2e/protocolE2E.go
+++ b/testutil/e2e/protocolE2E.go
@@ -608,10 +608,10 @@ func tendermintURITests(rpcURL string, testDuration time.Duration) error {
 	utils.LavaFormatInfo("Starting TENDERMINTRPC URI Tests")
 	errors := []string{}
 	mostImportantApisToTest := map[string]bool{
-		"/health":                              true,
-		"/status":                              true,
-		"/block?height=1":                      true,
-		"/blockchain?minHeight=0&maxHeight=10": true,
+		"%s/health":                              true,
+		"%s/status":                              true,
+		"%s/block?height=1":                      true,
+		"%s/blockchain?minHeight=0&maxHeight=10": true,
 		// "%s/dial_peers?persistent=true&unconditional=true&private=true": false, // this is a rpc affecting query and is not available on the spec so it should fail
 	}
 	for start := time.Now(); time.Since(start) < testDuration; {
@@ -663,12 +663,12 @@ func restTests(rpcURL string, testDuration time.Duration) error {
 	utils.LavaFormatInfo("Starting REST Tests")
 	errors := []string{}
 	mostImportantApisToTest := []string{
-		"/blocks/latest",
-		"/lavanet/lava/pairing/providers/LAV1",
-		"/lavanet/lava/pairing/clients/LAV1",
-		"/cosmos/gov/v1beta1/proposals",
-		"/lavanet/lava/spec/spec",
-		"/blocks/1",
+		"%s/blocks/latest",
+		"%s/lavanet/lava/pairing/providers/LAV1",
+		"%s/lavanet/lava/pairing/clients/LAV1",
+		"%s/cosmos/gov/v1beta1/proposals",
+		"%s/lavanet/lava/spec/spec",
+		"%s/blocks/1",
 	}
 	for start := time.Now(); time.Since(start) < testDuration; {
 		for _, api := range mostImportantApisToTest {

--- a/testutil/e2e/protocolE2E.go
+++ b/testutil/e2e/protocolE2E.go
@@ -608,10 +608,10 @@ func tendermintURITests(rpcURL string, testDuration time.Duration) error {
 	utils.LavaFormatInfo("Starting TENDERMINTRPC URI Tests")
 	errors := []string{}
 	mostImportantApisToTest := map[string]bool{
-		"%s/health":                              true,
-		"%s/status":                              true,
-		"%s/block?height=1":                      true,
-		"%s/blockchain?minHeight=0&maxHeight=10": true,
+		"/health":                              true,
+		"/status":                              true,
+		"/block?height=1":                      true,
+		"/blockchain?minHeight=0&maxHeight=10": true,
 		// "%s/dial_peers?persistent=true&unconditional=true&private=true": false, // this is a rpc affecting query and is not available on the spec so it should fail
 	}
 	for start := time.Now(); time.Since(start) < testDuration; {
@@ -663,12 +663,12 @@ func restTests(rpcURL string, testDuration time.Duration) error {
 	utils.LavaFormatInfo("Starting REST Tests")
 	errors := []string{}
 	mostImportantApisToTest := []string{
-		"%s/blocks/latest",
-		"%s/lavanet/lava/pairing/providers/LAV1",
-		"%s/lavanet/lava/pairing/clients/LAV1",
-		"%s/cosmos/gov/v1beta1/proposals",
-		"%s/lavanet/lava/spec/spec",
-		"%s/blocks/1",
+		"/blocks/latest",
+		"/lavanet/lava/pairing/providers/LAV1",
+		"/lavanet/lava/pairing/clients/LAV1",
+		"/cosmos/gov/v1beta1/proposals",
+		"/lavanet/lava/spec/spec",
+		"/blocks/1",
 	}
 	for start := time.Now(); time.Since(start) < testDuration; {
 		for _, api := range mostImportantApisToTest {
@@ -1139,7 +1139,7 @@ func runProtocolE2E(timeout time.Duration) {
 	lt.startJSONRPCConsumer(ctx)
 
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:333%d/1", n)
+		url := fmt.Sprintf("http://127.0.0.1:333%d", n)
 		msg := fmt.Sprintf("JSONRPCConsumer%d OK", n)
 		lt.checkJSONRPCConsumer(url, time.Minute*2, msg)
 	})
@@ -1150,9 +1150,9 @@ func runProtocolE2E(timeout time.Duration) {
 
 	// staked client then with subscription
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:334%d/1", (n-1)*3)
+		url := fmt.Sprintf("http://127.0.0.1:334%d", (n-1)*3)
 		lt.checkTendermintConsumer(url, time.Second*30)
-		url = fmt.Sprintf("http://127.0.0.1:334%d/1", (n-1)*3+1)
+		url = fmt.Sprintf("http://127.0.0.1:334%d", (n-1)*3+1)
 		lt.checkRESTConsumer(url, time.Second*30)
 		url = fmt.Sprintf("127.0.0.1:334%d", (n-1)*3+2)
 		lt.checkGRPCConsumer(url, time.Second*30)
@@ -1160,7 +1160,7 @@ func runProtocolE2E(timeout time.Duration) {
 
 	// staked client then with subscription
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:333%d/1", n)
+		url := fmt.Sprintf("http://127.0.0.1:333%d", n)
 		if err := jsonrpcTests(url, time.Second*30); err != nil {
 			panic(err)
 		}
@@ -1169,7 +1169,7 @@ func runProtocolE2E(timeout time.Duration) {
 
 	// staked client then with subscription
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:334%d/1", (n-1)*3)
+		url := fmt.Sprintf("http://127.0.0.1:334%d", (n-1)*3)
 		if err := tendermintTests(url, time.Second*30); err != nil {
 			panic(err)
 		}
@@ -1178,7 +1178,7 @@ func runProtocolE2E(timeout time.Duration) {
 
 	// staked client then with subscription
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:334%d/1", (n-1)*3)
+		url := fmt.Sprintf("http://127.0.0.1:334%d", (n-1)*3)
 		if err := tendermintURITests(url, time.Second*30); err != nil {
 			panic(err)
 		}
@@ -1189,7 +1189,7 @@ func runProtocolE2E(timeout time.Duration) {
 
 	// staked client then with subscription
 	repeat(1, func(n int) {
-		url := fmt.Sprintf("http://127.0.0.1:334%d/1", (n-1)*3+1)
+		url := fmt.Sprintf("http://127.0.0.1:334%d", (n-1)*3+1)
 		if err := restTests(url, time.Second*30); err != nil {
 			panic(err)
 		}
@@ -1206,7 +1206,7 @@ func runProtocolE2E(timeout time.Duration) {
 	})
 	utils.LavaFormatInfo("GRPC TEST OK")
 
-	lt.checkResponse("http://127.0.0.1:3340/1", "http://127.0.0.1:3341/1", "127.0.0.1:3342")
+	lt.checkResponse("http://127.0.0.1:3340", "http://127.0.0.1:3341", "127.0.0.1:3342")
 
 	// TODO: Add payment tests when subscription payment mechanism is implemented
 


### PR DESCRIPTION
### Description

In our current implementation, dappID is inside path which makes requests more complicated and there is no way to support optional dappID-s. THis PR fixes this problem by moving the dappID in headers and if user does not specify it it will auto-generate new dappID


### Manual tests
```
# Rest

### HTTP/HTTPS

1.  Post
    curl -X POST -H "dappId: dappID\_8765"/ "127.0.0.1:3360/cosmos/base/tendermint/v1beta1/node\_info"
    curl -X POST "127.0.0.1:3360/cosmos/base/tendermint/v1beta1/node_info"
2.  Get
    curl -X GET "127.0.0.1:3360/cosmos/base/tendermint/v1beta1/node_info"
    curl -X GET -H "dappId: dappID\_12345" "127.0.0.1:3360/cosmos/base/tendermint/v1beta1/node\_info"

# JsonRPC

### HTTP/HTTPS

1.  Post
    curl -X POST -H "Content-Type: application/json" http://127.0.0.1:3333 --data '{"jsonrpc":"2.0","id":535439332833,"method":"eth_blockNumber","params":\[\]}'
    curl -X POST -H "dappId: dappID_12345" -H "Content-Type: application/json" http://127.0.0.1:3333 --data '{"jsonrpc":"2.0","id":535439332833,"method":"eth_blockNumber","params":\[\]}'
	
	
### WS/WSS
Open conncetion -> websocat ws://127.0.0.1:3333/ws -H "dappId: YOUR_DAPP_ID"
Send request -> {"jsonrpc":"2.0","method":"getBlockHeight","params":[],"id":1}

Open conncetion -> websocat ws://127.0.0.1:3333/ws
Send request -> {"jsonrpc":"2.0","method":"getBlockHeight","params":[],"id":1}


# TendermintRPC

### HTTP/HTTPS

1.  Post
	curl -X POST -H "Content-Type: application/json" -H "dappId: dappID_12345"  http://127.0.0.1:3361 --data '{"jsonrpc":"2.0","id":535439332833,"method":"status","params":[]}'
curl -X POST -H "Content-Type: application/json"  http://127.0.0.1:3361 --data '{"jsonrpc":"2.0","id":535439332833,"method":"status","params":[]}'

2.  Get
    curl -X GET "127.0.0.1:3361/cosmos/base/tendermint/v1beta1/node_info"
    curl -X GET -H "dappId: dappID\_12345" "127.0.0.1:3361/cosmos/base/tendermint/v1beta1/node\_info"
	
### WS/WSS
Open conncetion -> websocat ws://127.0.0.1:3361/ws -H "dappId: YOUR_DAPP_ID"
Send request -> {"jsonrpc":"2.0","method":"getBlockHeight","params":[],"id":1}

Open conncetion -> websocat ws://127.0.0.1:3361/ws
Send request -> {"jsonrpc":"2.0","method":"getBlockHeight","params":[],"id":1}


### GRPC

grpcurl -plaintext -H 'dapp-id:your-dapp-id-value' 127.0.0.1:3362 cosmos.auth.v1beta1.Query 
grpcurl -plaintext 127.0.0.1:3362 cosmos.auth.v1beta1.Query 
```

### Additional Info

Some of the example methods are not valid rpc calls, but they are sufficient to log dappID
