### PR TITLE
GROW-950 Add timestamp when sending relays data from rpc consumer

### DIFF
--- a/protocol/metrics/analytics.go
+++ b/protocol/metrics/analytics.go
@@ -31,6 +31,7 @@ type RelayAnalyticsDTO struct {
 	Latency      uint64
 	SuccessCount int64
 	RelayCounts  int64
+	TotalCu      uint64
 	Source       RelaySource
 }
 

--- a/protocol/metrics/analytics.go
+++ b/protocol/metrics/analytics.go
@@ -25,7 +25,7 @@ type RelayMetrics struct {
 
 type RelayAnalyticsDTO struct {
 	ProjectHash  string
-	Timestamp    time.Time
+	Timestamp    string
 	ChainID      string
 	APIType      string
 	Latency      uint64

--- a/protocol/metrics/metricsService.go
+++ b/protocol/metrics/metricsService.go
@@ -15,6 +15,7 @@ type AggregatedMetric struct {
 	TotalLatency uint64
 	RelaysCount  int64
 	SuccessCount int64
+	TotalCu      uint64
 	TimeStamp    time.Time
 }
 
@@ -104,6 +105,7 @@ func prepareArrayForProject(projectData map[string]map[string]map[RelaySource]*A
 					RelayCounts:  data.RelaysCount,
 					SuccessCount: data.SuccessCount,
 					Source:       sourceKey,
+					TotalCu:      data.TotalCu,
 					Timestamp:    data.TimeStamp.Format(time.RFC3339), // pls note that this is the timestamp of the first record and is not updated afterward
 				})
 			}
@@ -161,6 +163,7 @@ func (m *MetricService) storeAggregatedData(data RelayMetrics) error {
 						RelaysCount:  1,
 						SuccessCount: successCount,
 						TimeStamp:    data.Timestamp,
+						TotalCu:      data.ComputeUnits,
 					},
 				},
 			},
@@ -182,6 +185,7 @@ func (m *MetricService) storeChainIdData(projectData map[string]map[string]map[R
 					RelaysCount:  1,
 					SuccessCount: successCount,
 					TimeStamp:    data.Timestamp,
+					TotalCu:      data.ComputeUnits,
 				},
 			},
 		}
@@ -200,6 +204,7 @@ func (m *MetricService) storeApiTypeData(chainIdData map[string]map[RelaySource]
 				RelaysCount:  1,
 				SuccessCount: successCount,
 				TimeStamp:    data.Timestamp,
+				TotalCu:      data.ComputeUnits,
 			},
 		}
 	}
@@ -210,6 +215,7 @@ func (m *MetricService) storeSourceData(sourceData map[RelaySource]*AggregatedMe
 	if exists {
 		existingData.TotalLatency += successLatencyValue
 		existingData.SuccessCount += successCount
+		existingData.TotalCu += data.ComputeUnits
 		existingData.RelaysCount += 1
 	} else {
 		(*m.AggregatedMetricMap)[data.ProjectHash][data.ChainID][data.APIType][data.Source] = &AggregatedMetric{
@@ -217,6 +223,7 @@ func (m *MetricService) storeSourceData(sourceData map[RelaySource]*AggregatedMe
 			RelaysCount:  1,
 			SuccessCount: successCount,
 			TimeStamp:    data.Timestamp,
+			TotalCu:      data.ComputeUnits,
 		}
 	}
 }

--- a/protocol/metrics/metricsService.go
+++ b/protocol/metrics/metricsService.go
@@ -15,6 +15,7 @@ type AggregatedMetric struct {
 	TotalLatency uint64
 	RelaysCount  int64
 	SuccessCount int64
+	TimeStamp    time.Time
 }
 
 type MetricService struct {
@@ -103,6 +104,7 @@ func prepareArrayForProject(projectData map[string]map[string]map[RelaySource]*A
 					RelayCounts:  data.RelaysCount,
 					SuccessCount: data.SuccessCount,
 					Source:       sourceKey,
+					Timestamp:    data.TimeStamp.Format(time.RFC3339), // pls note that this is the timestamp of the first record and is not updated afterward
 				})
 			}
 		}
@@ -158,6 +160,7 @@ func (m *MetricService) storeAggregatedData(data RelayMetrics) error {
 						TotalLatency: successLatencyValue,
 						RelaysCount:  1,
 						SuccessCount: successCount,
+						TimeStamp:    data.Timestamp,
 					},
 				},
 			},
@@ -178,6 +181,7 @@ func (m *MetricService) storeChainIdData(projectData map[string]map[string]map[R
 					TotalLatency: successLatencyValue,
 					RelaysCount:  1,
 					SuccessCount: successCount,
+					TimeStamp:    data.Timestamp,
 				},
 			},
 		}
@@ -195,6 +199,7 @@ func (m *MetricService) storeApiTypeData(chainIdData map[string]map[RelaySource]
 				TotalLatency: successLatencyValue,
 				RelaysCount:  1,
 				SuccessCount: successCount,
+				TimeStamp:    data.Timestamp,
 			},
 		}
 	}
@@ -211,6 +216,7 @@ func (m *MetricService) storeSourceData(sourceData map[RelaySource]*AggregatedMe
 			TotalLatency: successLatencyValue,
 			RelaysCount:  1,
 			SuccessCount: successCount,
+			TimeStamp:    data.Timestamp,
 		}
 	}
 }

--- a/protocol/metrics/metricsService.go
+++ b/protocol/metrics/metricsService.go
@@ -106,7 +106,7 @@ func prepareArrayForProject(projectData map[string]map[string]map[RelaySource]*A
 					SuccessCount: data.SuccessCount,
 					Source:       sourceKey,
 					TotalCu:      data.TotalCu,
-					Timestamp:    data.TimeStamp.Format(time.RFC3339), // pls note that this is the timestamp of the first record and is not updated afterward
+					Timestamp:    data.TimeStamp.UTC().Format(time.RFC3339),
 				})
 			}
 		}


### PR DESCRIPTION
BUG FIX:

- Send the corresponding date of the relays when doing HTTP call