### PR TITLE
CNS-BUG-FIX: make VerifyTotalCuUsage work with effective total cu

### DIFF
--- a/x/pairing/keeper/grpc_query_user_entry.go
+++ b/x/pairing/keeper/grpc_query_user_entry.go
@@ -52,9 +52,8 @@ func (k Keeper) UserEntry(goCtx context.Context, req *types.QueryUserEntryReques
 	if err != nil {
 		return nil, err
 	}
-	allowedCU, _ := k.CalculateEffectiveAllowedCuPerEpochFromPolicies(policies, project.GetUsedCu(), sub.GetMonthCuLeft())
-
-	if !planstypes.VerifyTotalCuUsage(policies, project.GetUsedCu()) {
+	allowedCU, allowedCUTotal := k.CalculateEffectiveAllowedCuPerEpochFromPolicies(policies, project.GetUsedCu(), sub.GetMonthCuLeft())
+	if !planstypes.VerifyTotalCuUsage(allowedCUTotal, project.GetUsedCu()) {
 		allowedCU = 0
 	}
 

--- a/x/plans/types/policy.go
+++ b/x/plans/types/policy.go
@@ -181,16 +181,8 @@ func GetStrictestChainPolicyForSpec(chainID string, policies []*Policy) (chainPo
 	return ChainPolicy{ChainId: chainID, Requirements: requirements}, true
 }
 
-func VerifyTotalCuUsage(policies []*Policy, cuUsage uint64) bool {
-	for _, policy := range policies {
-		if policy != nil {
-			if cuUsage >= policy.GetTotalCuLimit() {
-				return false
-			}
-		}
-	}
-
-	return true
+func VerifyTotalCuUsage(effectiveTotalCu uint64, cuUsage uint64) bool {
+	return cuUsage < effectiveTotalCu
 }
 
 // allows unmarshaling parser func


### PR DESCRIPTION
the UserEntry query, which is used in both consensus and protocol code, didn't verify the CU usage correctly. The CU usage was compared against a wrong value of total CU 