### PR TITLE
Save logs even if go routine panics

### DIFF
--- a/testutil/e2e/protocolE2E.go
+++ b/testutil/e2e/protocolE2E.go
@@ -118,6 +118,13 @@ func (lt *lavaTest) execCommandWithRetry(ctx context.Context, funcName string, l
 }
 
 func (lt *lavaTest) execCommand(ctx context.Context, funcName string, logName string, command string, wait bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			lt.saveLogs()
+			panic(fmt.Sprintf("Panic happened with command: %s", command))
+		}
+	}()
+
 	lt.logs[logName] = new(bytes.Buffer)
 
 	cmd := exec.CommandContext(ctx, "", "")


### PR DESCRIPTION
### Description

In the current implementation of e2e, we are starting many go routines for different processes but we are not recovering panics if they occur. This PR fixes this problem and makes sure that even if executing command fails we would print the logs