### PR TITLE
CNS-578: small fixes for init chain scripts

### DIFF
--- a/scripts/init_chain.sh
+++ b/scripts/init_chain.sh
@@ -6,7 +6,7 @@ source $__dir/useful_commands.sh
 
 # Check if jq is not installed
 if ! command_exists jq; then
-    echo "Unable to install jq using apt or brew. Please install jq manually."
+    echo "jq not found. Please install jq using the init_install.sh script or manually."
     exit 1
 fi
 

--- a/scripts/init_chain.sh
+++ b/scripts/init_chain.sh
@@ -1,43 +1,11 @@
 #!/bin/bash
 # make install-all
 killall -9 lavad
-
-# Function to check if a command is available
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
-# Flag to track if jq installation is successful
-jq_installed=false
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $__dir/useful_commands.sh
 
 # Check if jq is not installed
 if ! command_exists jq; then
-    # Try to install jq using apt (for Debian/Ubuntu)
-    if command_exists apt; then
-        echo "Installing jq using apt..."
-        sudo apt update
-        sudo apt install -y jq
-        if command_exists jq; then
-            echo "jq has been successfully installed."
-            jq_installed=true
-        fi
-    fi
-
-    # Try to install jq using brew (for macOS)
-    if ! $jq_installed && command_exists brew; then
-        echo "Installing jq using brew..."
-        brew install jq
-        if command_exists jq; then
-            echo "jq has been successfully installed."
-            jq_installed=true
-        fi
-    fi
-else
-    jq_installed=true
-fi
-
-# if jq is still not installed, exit
-if ! $jq_installed; then
     echo "Unable to install jq using apt or brew. Please install jq manually."
     exit 1
 fi

--- a/scripts/init_chain.sh
+++ b/scripts/init_chain.sh
@@ -37,52 +37,30 @@ echo $(cat "$path$genesis")
 
 # Determine OS
 os_name=$(uname)
+case "$(uname)" in
+  Darwin)
+    SED_INLINE="-i ''" ;;
+  Linux)
+    SED_INLINE="-i" ;;
+  *)
+    echo "unknown system: $(uname)"
+    exit 1 ;;
+esac
 
-# Check if the OS is macOS or Linux and apply the correct sed command
-if [ "$os_name" = "Darwin" ]; then
-    # For macOS
-    sed -i '' \
-    -e 's/timeout_propose = .*/timeout_propose = "1s"/' \
-    -e 's/timeout_propose_delta = .*/timeout_propose_delta = "500ms"/' \
-    -e 's/timeout_prevote = .*/timeout_prevote = "1s"/' \
-    -e 's/timeout_prevote_delta = .*/timeout_prevote_delta = "500ms"/' \
-    -e 's/timeout_precommit = .*/timeout_precommit = "500ms"/' \
-    -e 's/timeout_precommit_delta = .*/timeout_precommit_delta = "1s"/' \
-    -e 's/timeout_commit = .*/timeout_commit = "1s"/' \
-    -e 's/skip_timeout_commit = .*/skip_timeout_commit = false/' "$path$config"
 
-elif [ "$os_name" = "Linux" ]; then
-    # For Linux
-    sed -i \
-    -e 's/timeout_propose = .*/timeout_propose = "1s"/' \
-    -e 's/timeout_propose_delta = .*/timeout_propose_delta = "500ms"/' \
-    -e 's/timeout_prevote = .*/timeout_prevote = "1s"/' \
-    -e 's/timeout_prevote_delta = .*/timeout_prevote_delta = "500ms"/' \
-    -e 's/timeout_precommit = .*/timeout_precommit = "500ms"/' \
-    -e 's/timeout_precommit_delta = .*/timeout_precommit_delta = "1s"/' \
-    -e 's/timeout_commit = .*/timeout_commit = "1s"/' \
-    -e 's/skip_timeout_commit = .*/skip_timeout_commit = false/' "$path$config"
-
-else
-    echo "Unsupported OS: $os_name"
-    exit 1
-fi
-
+sed $SED_INLINE \
+-e 's/timeout_propose = .*/timeout_propose = "1s"/' \
+-e 's/timeout_propose_delta = .*/timeout_propose_delta = "500ms"/' \
+-e 's/timeout_prevote = .*/timeout_prevote = "1s"/' \
+-e 's/timeout_prevote_delta = .*/timeout_prevote_delta = "500ms"/' \
+-e 's/timeout_precommit = .*/timeout_precommit = "500ms"/' \
+-e 's/timeout_precommit_delta = .*/timeout_precommit_delta = "1s"/' \
+-e 's/timeout_commit = .*/timeout_commit = "1s"/' \
+-e 's/skip_timeout_commit = .*/skip_timeout_commit = false/' "$path$config"
 
 # Edit app.toml file
-os_name=$(uname)
+sed $SED_INLINE -e "s/enable = .*/enable = true/" "$path$app"
 
-# Check if the OS is macOS or Linux and apply the correct sed command
-if [ "$os_name" = "Darwin" ]; then
-    # For macOS
-    sed -i '' -e "s/enable = .*/enable = true/" "$path$app"
-elif [ "$os_name" = "Linux" ]; then
-    # For Linux
-    sed -i -e "s/enable = .*/enable = true/" "$path$app"
-else
-    echo "Unsupported OS: $os_name"
-    exit 1
-fi
 # Add users
 users=("alice" "bob" "user1" "user2" "user3" "user4" "servicer1" "servicer2" "servicer3" "servicer4" "servicer5" "servicer6" "servicer7" "servicer8" "servicer9" "servicer10")
 

--- a/scripts/init_chain.sh
+++ b/scripts/init_chain.sh
@@ -2,6 +2,46 @@
 # make install-all
 killall -9 lavad
 
+# Function to check if a command is available
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Flag to track if jq installation is successful
+jq_installed=false
+
+# Check if jq is not installed
+if ! command_exists jq; then
+    # Try to install jq using apt (for Debian/Ubuntu)
+    if command_exists apt; then
+        echo "Installing jq using apt..."
+        sudo apt update
+        sudo apt install -y jq
+        if command_exists jq; then
+            echo "jq has been successfully installed."
+            jq_installed=true
+        fi
+    fi
+
+    # Try to install jq using brew (for macOS)
+    if ! $jq_installed && command_exists brew; then
+        echo "Installing jq using brew..."
+        brew install jq
+        if command_exists jq; then
+            echo "jq has been successfully installed."
+            jq_installed=true
+        fi
+    fi
+else
+    jq_installed=true
+fi
+
+# if jq is still not installed, exit
+if ! $jq_installed; then
+    echo "Unable to install jq using apt or brew. Please install jq manually."
+    exit 1
+fi
+
 rm -rf ~/.lava
 lavad init validator --chain-id lava
 lavad config broadcast-mode sync

--- a/scripts/init_chain_commands.sh
+++ b/scripts/init_chain_commands.sh
@@ -11,6 +11,7 @@ GASPRICE="0.000000001ulava"
 
 lavad tx gov submit-legacy-proposal spec-add ./cookbook/specs/spec_add_ibc.json,./cookbook/specs/spec_add_cosmoswasm.json,./cookbook/specs/spec_add_cosmossdk.json,./cookbook/specs/spec_add_cosmossdk_full.json,./cookbook/specs/spec_add_ethereum.json,./cookbook/specs/spec_add_cosmoshub.json,./cookbook/specs/spec_add_lava.json,./cookbook/specs/spec_add_osmosis.json,./cookbook/specs/spec_add_fantom.json,./cookbook/specs/spec_add_celo.json,./cookbook/specs/spec_add_optimism.json,./cookbook/specs/spec_add_arbitrum.json,./cookbook/specs/spec_add_starknet.json,./cookbook/specs/spec_add_aptos.json,./cookbook/specs/spec_add_juno.json,./cookbook/specs/spec_add_polygon.json,./cookbook/specs/spec_add_evmos.json,./cookbook/specs/spec_add_base.json,./cookbook/specs/spec_add_canto.json,./cookbook/specs/spec_add_sui.json,./cookbook/specs/spec_add_solana.json,./cookbook/specs/spec_add_bsc.json,./cookbook/specs/spec_add_axelar.json,./cookbook/specs/spec_add_avalanche.json,./cookbook/specs/spec_add_fvm.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
 wait_next_block
+wait_next_block
 echo "submitted first proposal"
 lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
 wait_next_block
@@ -19,6 +20,7 @@ sleep 4
 
 
 lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/default.json,./cookbook/plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
 wait_next_block
 lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block
@@ -33,6 +35,7 @@ PROVIDER3_LISTENER="127.0.0.1:2223"
 sleep 4
 
 lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
 wait_next_block
 lavad tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block

--- a/scripts/init_chain_commands.sh
+++ b/scripts/init_chain_commands.sh
@@ -10,7 +10,7 @@ GASPRICE="0.000000001ulava"
 # ,./cookbook/specs/spec_add_mantle.json
 
 lavad tx gov submit-legacy-proposal spec-add ./cookbook/specs/spec_add_ibc.json,./cookbook/specs/spec_add_cosmoswasm.json,./cookbook/specs/spec_add_cosmossdk.json,./cookbook/specs/spec_add_cosmossdk_full.json,./cookbook/specs/spec_add_ethereum.json,./cookbook/specs/spec_add_cosmoshub.json,./cookbook/specs/spec_add_lava.json,./cookbook/specs/spec_add_osmosis.json,./cookbook/specs/spec_add_fantom.json,./cookbook/specs/spec_add_celo.json,./cookbook/specs/spec_add_optimism.json,./cookbook/specs/spec_add_arbitrum.json,./cookbook/specs/spec_add_starknet.json,./cookbook/specs/spec_add_aptos.json,./cookbook/specs/spec_add_juno.json,./cookbook/specs/spec_add_polygon.json,./cookbook/specs/spec_add_evmos.json,./cookbook/specs/spec_add_base.json,./cookbook/specs/spec_add_canto.json,./cookbook/specs/spec_add_sui.json,./cookbook/specs/spec_add_solana.json,./cookbook/specs/spec_add_bsc.json,./cookbook/specs/spec_add_axelar.json,./cookbook/specs/spec_add_avalanche.json,./cookbook/specs/spec_add_fvm.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
-wait_two_blocks
+wait_count_blocks 2
 echo "submitted first proposal"
 lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
 wait_next_block
@@ -19,7 +19,7 @@ sleep 4
 
 
 lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/default.json,./cookbook/plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_two_blocks
+wait_count_blocks 2
 lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block
 
@@ -33,7 +33,7 @@ PROVIDER3_LISTENER="127.0.0.1:2223"
 sleep 4
 
 lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_two_blocks
+wait_count_blocks 2
 lavad tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block
 lavad tx  subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE

--- a/scripts/init_chain_commands.sh
+++ b/scripts/init_chain_commands.sh
@@ -10,8 +10,7 @@ GASPRICE="0.000000001ulava"
 # ,./cookbook/specs/spec_add_mantle.json
 
 lavad tx gov submit-legacy-proposal spec-add ./cookbook/specs/spec_add_ibc.json,./cookbook/specs/spec_add_cosmoswasm.json,./cookbook/specs/spec_add_cosmossdk.json,./cookbook/specs/spec_add_cosmossdk_full.json,./cookbook/specs/spec_add_ethereum.json,./cookbook/specs/spec_add_cosmoshub.json,./cookbook/specs/spec_add_lava.json,./cookbook/specs/spec_add_osmosis.json,./cookbook/specs/spec_add_fantom.json,./cookbook/specs/spec_add_celo.json,./cookbook/specs/spec_add_optimism.json,./cookbook/specs/spec_add_arbitrum.json,./cookbook/specs/spec_add_starknet.json,./cookbook/specs/spec_add_aptos.json,./cookbook/specs/spec_add_juno.json,./cookbook/specs/spec_add_polygon.json,./cookbook/specs/spec_add_evmos.json,./cookbook/specs/spec_add_base.json,./cookbook/specs/spec_add_canto.json,./cookbook/specs/spec_add_sui.json,./cookbook/specs/spec_add_solana.json,./cookbook/specs/spec_add_bsc.json,./cookbook/specs/spec_add_axelar.json,./cookbook/specs/spec_add_avalanche.json,./cookbook/specs/spec_add_fvm.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
-wait_next_block
-wait_next_block
+wait_two_blocks
 echo "submitted first proposal"
 lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
 wait_next_block
@@ -20,8 +19,7 @@ sleep 4
 
 
 lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/default.json,./cookbook/plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
-wait_next_block
+wait_two_blocks
 lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block
 
@@ -35,8 +33,7 @@ PROVIDER3_LISTENER="127.0.0.1:2223"
 sleep 4
 
 lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
-wait_next_block
+wait_two_blocks
 lavad tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 wait_next_block
 lavad tx  subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE

--- a/scripts/init_install.sh
+++ b/scripts/init_install.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $__dir/useful_commands.sh
+
+############################## JQ INSTALLATION ######################################
+# Flag to track if jq installation is successful
+jq_installed=false
+
+# Check if jq is not installed
+if ! command_exists jq; then
+    # Try to install jq using apt (for Debian/Ubuntu)
+    if command_exists apt; then
+        echo "Installing jq using apt..."
+        sudo apt update
+        sudo apt install -y jq
+        if command_exists jq; then
+            echo "jq has been successfully installed."
+            jq_installed=true
+        fi
+    fi
+
+    # Try to install jq using brew (for macOS)
+    if ! $jq_installed && command_exists brew; then
+        echo "Installing jq using brew..."
+        brew install jq
+        if command_exists jq; then
+            echo "jq has been successfully installed."
+            jq_installed=true
+        fi
+    fi
+else
+    echo "jq is already installed"
+    jq_installed=true
+fi
+
+# if jq is still not installed, exit
+if ! $jq_installed; then
+    echo "Unable to install jq using apt or brew. Please install jq manually."
+fi
+
+############################# BUF INSTALLATION ######################################
+
+if ! command_exists buf; then
+    # Define the version of buf to install
+    BUF_VERSION="0.56.0"  # Update this to the latest version if needed
+
+    # Define the installation directory
+    INSTALL_DIR="/usr/local/bin"  # You might need to adjust this based on your preferences
+
+    # Download and install buf
+    echo "Downloading buf version $BUF_VERSION..."
+    curl -sSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-$(uname -s)-$(uname -m)" -o "${INSTALL_DIR}/buf"
+
+    # Add execute permissions to the buf binary
+    chmod +x "${INSTALL_DIR}/buf"
+
+    # Check if the installation was successful
+    if [ $? -eq 0 ]; then
+        echo "buf version $BUF_VERSION has been installed to $INSTALL_DIR."
+        exit 0
+    else
+        echo "An error occurred during the buf installation process. Please install buf manually."
+        exit 1
+    fi
+else
+    echo "buf is already installed"
+fi

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $__dir/useful_commands.sh
+
+if ! command_exists buf; then
+    echo "buf not found. Please install buf using the init_install.sh script or manually."
+    exit 1
+fi
 
 set -eo pipefail
 

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -30,3 +30,19 @@ function wait_next_block {
     fi
   done
 }
+
+function wait_two_blocks {
+  current=$( lavad q block | jq -r .block.header.height)
+  currentNum=$(($current))
+  echo "Waiting for two blocks"
+  while true; do
+    sleep 0.5
+    new=$( lavad q block | jq -r .block.header.height)
+    newNum=$(($new))
+    if [[ $((newNum - current)) -ge 2 ]]
+    then
+      echo "finished waiting for two blocks"
+        break
+    fi
+  done
+}

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -46,3 +46,8 @@ function wait_two_blocks {
     fi
   done
 }
+
+# Function to check if a command is available
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -31,19 +31,9 @@ function wait_next_block {
   done
 }
 
-function wait_two_blocks {
-  current=$( lavad q block | jq -r .block.header.height)
-  currentNum=$(($current))
-  echo "Waiting for two blocks"
-  while true; do
-    sleep 0.5
-    new=$( lavad q block | jq -r .block.header.height)
-    newNum=$(($new))
-    if [[ $((newNum - current)) -ge 2 ]]
-    then
-      echo "finished waiting for two blocks"
-        break
-    fi
+function wait_count_blocks {
+  for i in $(seq 1 $1); do
+    wait_next_block
   done
 }
 


### PR DESCRIPTION
init_chain.sh - if `jq` is not installed, the script fails. Added jq installation
init_chain_commands.sh - added another `wait_next_block` after proposals to avoid statistical `account sequence mismatch` error