### PR TITLE
CNS-580: let multi-geo values work in our unit tests

### DIFF
--- a/testutil/common/tester.go
+++ b/testutil/common/tester.go
@@ -148,12 +148,16 @@ func (ts *Tester) StakeProviderExtra(
 	// if necessary, generate mock endpoints
 	if endpoints == nil {
 		apiInterface := spec.ApiCollections[0].CollectionData.ApiInterface
-		endpoint := epochstoragetypes.Endpoint{
-			IPPORT:        "123",
-			ApiInterfaces: []string{apiInterface},
-			Geolocation:   geoloc,
+		geolocations := planstypes.GetGeolocationsFromUint(int32(geoloc))
+
+		for _, geo := range geolocations {
+			endpoint := epochstoragetypes.Endpoint{
+				IPPORT:        "123",
+				ApiInterfaces: []string{apiInterface},
+				Geolocation:   uint64(geo),
+			}
+			endpoints = append(endpoints, endpoint)
 		}
-		endpoints = []epochstoragetypes.Endpoint{endpoint}
 	}
 
 	stake := sdk.NewCoin(epochstoragetypes.TokenDenom, sdk.NewInt(amount))

--- a/x/pairing/keeper/helpers_test.go
+++ b/x/pairing/keeper/helpers_test.go
@@ -94,7 +94,8 @@ func (ts *tester) setupForPayments(providersCount, clientsCount, providersToPair
 	}
 
 	ts.addClient(clientsCount)
-	ts.addProvider(providersCount)
+	err := ts.addProvider(providersCount)
+	require.Nil(ts.T, err)
 
 	ts.AdvanceEpoch()
 

--- a/x/pairing/keeper/msg_server_stake_provider_test.go
+++ b/x/pairing/keeper/msg_server_stake_provider_test.go
@@ -33,7 +33,8 @@ func TestStakeProviderWithMoniker(t *testing.T) {
 			ts.AdvanceEpoch()
 
 			// Note: using the same "ts" means each provider added gets a new index ("it")
-			ts.addProviderMoniker(1, tt.moniker)
+			err := ts.addProviderMoniker(1, tt.moniker)
+			require.Nil(t, err)
 			providerAcct, _ := ts.GetAccount(common.PROVIDER, it)
 
 			ts.AdvanceEpoch()
@@ -60,7 +61,8 @@ func TestModifyStakeProviderWithMoniker(t *testing.T) {
 	ts.AdvanceEpoch()
 
 	moniker := "exampleMoniker"
-	ts.addProviderMoniker(1, moniker)
+	err := ts.addProviderMoniker(1, moniker)
+	require.Nil(t, err)
 	ts.AdvanceEpoch()
 
 	providerAcct, providerAddr := ts.GetAccount(common.PROVIDER, 0)

--- a/x/pairing/keeper/msg_server_stake_unstake_gov_test.go
+++ b/x/pairing/keeper/msg_server_stake_unstake_gov_test.go
@@ -32,7 +32,8 @@ func TestStakeGovEpochBlocksDecrease(t *testing.T) {
 	ts.AdvanceBlocks(19)
 
 	// stake a provider
-	ts.addProvider(1)
+	err = ts.addProvider(1)
+	require.Nil(t, err)
 	providerAcct, _ := ts.GetAccount(common.PROVIDER, 0)
 
 	// Verify the provider paid for its stake request
@@ -93,7 +94,8 @@ func TestStakeGovEpochBlocksIncrease(t *testing.T) {
 	// Advance to blockHeight = 39, one block before the EpochBlocks change apply
 	ts.AdvanceBlocks(19)
 	// stake a provider
-	ts.addProvider(1)
+	err = ts.addProvider(1)
+	require.Nil(t, err)
 	providerAcct, _ := ts.GetAccount(common.PROVIDER, 0)
 
 	// Verify the provider/client paid for its stake request

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -1894,11 +1894,15 @@ func TestExtensionAndAddonPairing(t *testing.T) {
 }
 
 // TestPairingConsistency checks we consistently get the same pairing in the same epoch
-// TODO: stake providers with geolocation=3 to actually test pairing consistency
 func TestPairingConsistency(t *testing.T) {
 	ts := newTester(t)
-	ts.setupForPayments(10, 1, 3)
 	iterations := 100
+
+	ts.plan.PlanPolicy.MaxProvidersToPair = uint64(3)
+	ts.AddPlan("mock", ts.plan)
+	ts.addClient(1)
+	ts.addProviderGeolocation(10, 3)
+	ts.AdvanceEpoch()
 
 	consumers := ts.Accounts(common.CONSUMER)
 

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -132,7 +132,8 @@ func TestGetPairing(t *testing.T) {
 	// (for the benefit of users) but the "zeroEpoch" test below expects to start at the
 	// same epoch of staking the providers.
 	ts.addClient(1)
-	ts.addProvider(1)
+	err := ts.addProvider(1)
+	require.Nil(t, err)
 
 	// BLOCK_TIME = 30sec (testutil/keeper/keepers_init.go)
 	constBlockTime := testkeeper.BLOCK_TIME
@@ -579,7 +580,8 @@ func TestAddonPairing(t *testing.T) {
 func TestSelectedProvidersPairing(t *testing.T) {
 	ts := newTester(t)
 
-	ts.addProvider(200)
+	err := ts.addProvider(200)
+	require.Nil(t, err)
 
 	policy := &planstypes.Policy{
 		GeolocationProfile: math.MaxUint64,
@@ -595,7 +597,9 @@ func TestSelectedProvidersPairing(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	ts.addProvider(200)
+	err = ts.addProvider(200)
+	require.Nil(t, err)
+
 	_, p1 := ts.GetAccount(common.PROVIDER, 0)
 	_, p2 := ts.GetAccount(common.PROVIDER, 1)
 	_, p3 := ts.GetAccount(common.PROVIDER, 2)
@@ -1901,7 +1905,9 @@ func TestPairingConsistency(t *testing.T) {
 	ts.plan.PlanPolicy.MaxProvidersToPair = uint64(3)
 	ts.AddPlan("mock", ts.plan)
 	ts.addClient(1)
-	ts.addProviderGeolocation(10, 3)
+	err := ts.addProviderGeolocation(10, 3)
+	require.Nil(t, err)
+
 	ts.AdvanceEpoch()
 
 	consumers := ts.Accounts(common.CONSUMER)

--- a/x/pairing/keeper/unresponsive_provider_test.go
+++ b/x/pairing/keeper/unresponsive_provider_test.go
@@ -291,7 +291,8 @@ func TestNotUnstakingProviderForUnresponsivenessWithMinProviders(t *testing.T) {
 
 	ts := newTester(t)
 	ts.setupForPayments(providersCount, clientsCount, providersCount) // set providers-to-pair
-	ts.addProviderGeolocation(2, 2)
+	err := ts.addProviderGeolocation(2, 2)
+	require.Nil(t, err)
 
 	clients := ts.Accounts(common.CONSUMER)
 


### PR DESCRIPTION
There was a small bug in the endpoints generation in out testing suite. Also added error checks when staking providers