### PR TITLE
Lavavisor improvements

### DIFF
--- a/ecosystem/lavavisor/pkg/process/fetcher.go
+++ b/ecosystem/lavavisor/pkg/process/fetcher.go
@@ -14,12 +14,12 @@ import (
 )
 
 func FetchProtocolBinary(lavavisorPath string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (selectedBinaryPath string, err error) {
-	currentVersion := lvutil.ParseVersion(protocolConsensusVersion.ProviderTarget)
-	minVersion := lvutil.ParseVersion(protocolConsensusVersion.ProviderMin)
+	currentVersion := lvutil.ParseToSemanticVersion(protocolConsensusVersion.ProviderTarget)
+	minVersion := lvutil.ParseToSemanticVersion(protocolConsensusVersion.ProviderMin)
 
 	for ; !lvutil.IsVersionLessThan(currentVersion, minVersion); lvutil.DecrementVersion(currentVersion) {
-		utils.LavaFormatInfo("Trying to fetch", utils.Attribute{Key: "version", Value: lvutil.FormatVersion(currentVersion)})
-		versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+lvutil.FormatVersion(currentVersion))
+		utils.LavaFormatInfo("Trying to fetch", utils.Attribute{Key: "version", Value: lvutil.FormatFromSemanticVersion(currentVersion)})
+		versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+lvutil.FormatFromSemanticVersion(currentVersion))
 		selectedBinaryPath, err = checkAndHandleVersionDir(versionDir, autoDownload, protocolConsensusVersion, currentVersion)
 		if err == nil {
 			return selectedBinaryPath, nil
@@ -128,7 +128,7 @@ func handleMissingDir(versionDir string, autoDownload bool, currentVersion *lvut
 	utils.LavaFormatInfo("Version directory does not exist, but auto-download is enabled. Attempting to download binary from GitHub...")
 	utils.LavaFormatInfo("Trying to download:", utils.Attribute{Key: "Version", Value: currentVersion})
 	os.MkdirAll(versionDir, os.ModePerm)
-	if err := downloadAndBuildFromGithub(lvutil.FormatVersion(currentVersion), versionDir); err == nil {
+	if err := downloadAndBuildFromGithub(lvutil.FormatFromSemanticVersion(currentVersion), versionDir); err == nil {
 		binaryPath = filepath.Join(versionDir, "lava-protocol")
 		return binaryPath, nil
 	}

--- a/ecosystem/lavavisor/pkg/process/fetcher.go
+++ b/ecosystem/lavavisor/pkg/process/fetcher.go
@@ -182,7 +182,6 @@ func downloadAndBuildFromGithub(version, versionDir string) error {
 
 	// Prepare the path for downloaded zip
 	zipPath := filepath.Join(versionDir, version+".zip")
-	fmt.Println("zipPath: ", zipPath)
 	// Make sure the directory exists
 	dir := filepath.Dir(zipPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -212,7 +211,6 @@ func downloadAndBuildFromGithub(version, versionDir string) error {
 
 	// Build the binary
 	srcPath := versionDir + "/lava-" + version
-	fmt.Println("srcPath: ", srcPath)
 	protocolPath := srcPath + "/cmd/lava-protocol"
 	utils.LavaFormatInfo("building protocol", utils.Attribute{Key: "protocol-path", Value: protocolPath})
 

--- a/ecosystem/lavavisor/pkg/process/fetcher.go
+++ b/ecosystem/lavavisor/pkg/process/fetcher.go
@@ -14,15 +14,12 @@ import (
 )
 
 func FetchProtocolBinary(lavavisorPath string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (selectedBinaryPath string, err error) {
-	versions := []string{protocolConsensusVersion.ProviderTarget, protocolConsensusVersion.ProviderMin}
+	version := protocolConsensusVersion.ProviderTarget
+	utils.LavaFormatInfo("Trying to fetch", utils.Attribute{Key: "version", Value: version})
 
-	for _, version := range versions {
-		utils.LavaFormatInfo("Trying to fetch", utils.Attribute{Key: "version", Value: version})
-		versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+version)
-		selectedBinaryPath, err = checkAndHandleVersionDir(versionDir, autoDownload, protocolConsensusVersion)
-		if err == nil {
-			return selectedBinaryPath, nil
-		}
+	selectedBinaryPath, err = checkAndHandleVersionDir(lavavisorPath, autoDownload, protocolConsensusVersion)
+	if err == nil {
+		return selectedBinaryPath, nil
 	}
 
 	return "", utils.LavaFormatError("Failed to fetch protocol binary for both target and min versions", nil)
@@ -90,20 +87,29 @@ func setUpLavavisorDirectory(lavavisorPath string) error {
 	return nil
 }
 
-func checkAndHandleVersionDir(versionDir string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (selectedBinaryPath string, err error) {
-	binaryPath := filepath.Join(versionDir, "lava-protocol")
+func checkAndHandleVersionDir(lavavisorPath string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (selectedBinaryPath string, err error) {
+	versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+protocolConsensusVersion.ProviderTarget)
 
+	var binaryPath string
 	if dirExists(versionDir) {
-		err := handleExistingDir(versionDir, autoDownload, protocolConsensusVersion, binaryPath)
+		binaryPath, err = handleExistingDir(lavavisorPath, autoDownload, protocolConsensusVersion)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		err := handleMissingDir(versionDir, autoDownload, protocolConsensusVersion)
+		binaryPath, err = handleMissingDir(lavavisorPath, autoDownload, protocolConsensusVersion)
 		if err != nil {
 			return "", err
 		}
 	}
+	// validate binary version after it has been set
+	vm := VersionMonitor{
+		BinaryPath: binaryPath,
+	}
+	if err := vm.ValidateProtocolVersion(protocolConsensusVersion); err != nil {
+		return "", err
+	}
+
 	utils.LavaFormatInfo("Protocol binary with target version has been successfully set!")
 	return binaryPath, nil
 }
@@ -113,41 +119,48 @@ func dirExists(versionDir string) bool {
 	return !os.IsNotExist(err)
 }
 
-func handleMissingDir(versionDir string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) error {
+func handleMissingDir(lavavisorPath string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (binaryPath string, err error) {
 	if !autoDownload {
-		return utils.LavaFormatError("Sub-directory for version not found and auto-download is disabled.", nil, utils.Attribute{Key: "Version", Value: protocolConsensusVersion.ProviderMin})
+		return "", utils.LavaFormatError("Sub-directory for version not found and auto-download is disabled.", nil, utils.Attribute{Key: "Version", Value: protocolConsensusVersion.ProviderMin})
 	}
 	utils.LavaFormatInfo("Version directory does not exist, but auto-download is enabled. Attempting to download binary from GitHub...")
-	os.MkdirAll(versionDir, os.ModePerm)
-	if err := downloadAndBuildFromGithub(protocolConsensusVersion.ProviderMin, versionDir); err != nil {
-		return utils.LavaFormatError("Failed to auto-download binary from GitHub\n ", err)
+
+	currentVersion := lvutil.ParseVersion(protocolConsensusVersion.ProviderTarget)
+	minVersion := lvutil.ParseVersion(protocolConsensusVersion.ProviderMin)
+
+	for ; !lvutil.IsVersionLessThan(&currentVersion, &minVersion); lvutil.DecrementVersion(&currentVersion) {
+		utils.LavaFormatInfo("Trying to download:", utils.Attribute{Key: "Version", Value: currentVersion})
+		versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+lvutil.FormatVersion(&currentVersion))
+		os.MkdirAll(versionDir, os.ModePerm)
+		if err := downloadAndBuildFromGithub(lvutil.FormatVersion(&currentVersion), versionDir); err == nil {
+			binaryPath = filepath.Join(versionDir, "lava-protocol")
+			return binaryPath, nil
+		}
+		// upon unsuccessful operation, remove versionDir
+		err := os.RemoveAll(versionDir)
+		if err != nil {
+			return "", err
+		}
 	}
-	// ToDo: add ValidateProtocolVersion check here after 'version' command available in protocol binary release in github
-	return nil
+	return "", utils.LavaFormatError("Failed to auto-download binary from GitHub\n ", nil)
 }
 
-func handleExistingDir(versionDir string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version, binaryPath string) error {
+func handleExistingDir(lavavisorPath string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) (binaryPath string, err error) {
+	versionDir := filepath.Join(lavavisorPath, "upgrades", "v"+protocolConsensusVersion.ProviderTarget)
+	binaryPath = filepath.Join(versionDir, "lava-protocol")
 	vm := VersionMonitor{
 		BinaryPath: binaryPath,
 	}
 	if err := vm.ValidateProtocolVersion(protocolConsensusVersion); err != nil {
-		err = handleErrorOnValidation(err, versionDir, autoDownload, protocolConsensusVersion)
+		if !autoDownload {
+			return "", utils.LavaFormatError("Protocol version mismatch or binary not found in lavavisor directory\n ", err)
+		}
+		binaryPath, err = handleMissingDir(lavavisorPath, autoDownload, protocolConsensusVersion)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
-	return nil
-}
-
-func handleErrorOnValidation(err error, versionDir string, autoDownload bool, protocolConsensusVersion *protocoltypes.Version) error {
-	if !autoDownload {
-		return utils.LavaFormatError("Protocol version mismatch or binary not found in lavavisor directory\n ", err)
-	}
-	utils.LavaFormatInfo("Version mismatch or binary not found, but auto-download is enabled. Attempting to download binary from GitHub...")
-	if err := downloadAndBuildFromGithub(protocolConsensusVersion.ProviderMin, versionDir); err != nil {
-		return utils.LavaFormatError("Failed to auto-download binary from GitHub\n ", err)
-	}
-	return nil
+	return binaryPath, nil
 }
 
 func downloadAndBuildFromGithub(version, versionDir string) error {
@@ -174,7 +187,7 @@ func downloadAndBuildFromGithub(version, versionDir string) error {
 
 	// Prepare the path for downloaded zip
 	zipPath := filepath.Join(versionDir, version+".zip")
-
+	fmt.Println("zipPath: ", zipPath)
 	// Make sure the directory exists
 	dir := filepath.Dir(zipPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -204,14 +217,23 @@ func downloadAndBuildFromGithub(version, versionDir string) error {
 
 	// Build the binary
 	srcPath := versionDir + "/lava-" + version
-	protocolPath := srcPath + "/protocol"
+	fmt.Println("srcPath: ", srcPath)
+	protocolPath := srcPath + "/cmd/lava-protocol"
 	utils.LavaFormatInfo("building protocol", utils.Attribute{Key: "protocol-path", Value: protocolPath})
 
 	cmd := exec.Command("go", "build", "-o", "lava-protocol")
 	cmd.Dir = protocolPath
 	err = cmd.Run()
 	if err != nil {
-		return err
+		// try with "cmd/lavad" path again - this is for older versions than v0.22.0
+		protocolPath = srcPath + "/cmd/lavad"
+		utils.LavaFormatInfo("attempting to building protocol again", utils.Attribute{Key: "protocol-path", Value: protocolPath})
+		cmd := exec.Command("go", "build", "-o", "lava-protocol")
+		cmd.Dir = protocolPath
+		err = cmd.Run()
+		if err != nil {
+			return utils.LavaFormatError("Unable to build lava-protocol binary", err)
+		}
 	}
 
 	// Move the binary to binaryPath

--- a/ecosystem/lavavisor/pkg/process/version_monitor.go
+++ b/ecosystem/lavavisor/pkg/process/version_monitor.go
@@ -83,7 +83,7 @@ func (vm *VersionMonitor) MonitorVersionUpdates(ctx context.Context) {
 
 func (vm *VersionMonitor) ValidateProtocolVersion(incoming *protocoltypes.Version) error {
 	binaryVersion, err := getBinaryVersion(vm.BinaryPath)
-	if err != nil {
+	if err != nil || binaryVersion == "" {
 		return utils.LavaFormatError("failed to get binary version", err)
 	}
 

--- a/ecosystem/lavavisor/pkg/util/common.go
+++ b/ecosystem/lavavisor/pkg/util/common.go
@@ -84,18 +84,19 @@ func Unzip(src string, dest string) ([]string, error) {
 	return filenames, nil
 }
 
-// Parse the version string "vX.Y.Z" into a struct with X, Y, Z as integers
-func ParseVersion(version string) (v struct {
+type SemanticVer struct {
 	Major, Minor, Patch int
-}) {
+}
+
+// Parse the version string "vX.Y.Z" into a struct with X, Y, Z as integers
+func ParseVersion(version string) (v *SemanticVer) {
+	v = &SemanticVer{}
 	fmt.Sscanf(version, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
-	return
+	return v
 }
 
 // Decrement the version. If Patch is 0, decrement Minor and reset Patch to 9. If Minor is 0, decrement Major.
-func DecrementVersion(v *struct {
-	Major, Minor, Patch int
-}) {
+func DecrementVersion(v *SemanticVer) {
 	if v.Patch > 0 {
 		v.Patch--
 	} else if v.Minor > 0 {
@@ -105,9 +106,7 @@ func DecrementVersion(v *struct {
 }
 
 // Check if version v1 is less than v2
-func IsVersionLessThan(v1, v2 *struct {
-	Major, Minor, Patch int
-}) bool {
+func IsVersionLessThan(v1, v2 *SemanticVer) bool {
 	if v1.Major < v2.Major {
 		return true
 	}
@@ -121,8 +120,6 @@ func IsVersionLessThan(v1, v2 *struct {
 }
 
 // Format the version struct back to a string "vX.Y.Z"
-func FormatVersion(v *struct {
-	Major, Minor, Patch int
-}) string {
+func FormatVersion(v *SemanticVer) string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }

--- a/ecosystem/lavavisor/pkg/util/common.go
+++ b/ecosystem/lavavisor/pkg/util/common.go
@@ -2,6 +2,7 @@ package lvutil
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -81,4 +82,47 @@ func Unzip(src string, dest string) ([]string, error) {
 		}
 	}
 	return filenames, nil
+}
+
+// Parse the version string "vX.Y.Z" into a struct with X, Y, Z as integers
+func ParseVersion(version string) (v struct {
+	Major, Minor, Patch int
+}) {
+	fmt.Sscanf(version, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
+	return
+}
+
+// Decrement the version. If Patch is 0, decrement Minor and reset Patch to 9. If Minor is 0, decrement Major.
+func DecrementVersion(v *struct {
+	Major, Minor, Patch int
+}) {
+	if v.Patch > 0 {
+		v.Patch--
+	} else if v.Minor > 0 {
+		v.Minor--
+		v.Patch = 9
+	}
+}
+
+// Check if version v1 is less than v2
+func IsVersionLessThan(v1, v2 *struct {
+	Major, Minor, Patch int
+}) bool {
+	if v1.Major < v2.Major {
+		return true
+	}
+	if v1.Major == v2.Major && v1.Minor < v2.Minor {
+		return true
+	}
+	if v1.Major == v2.Major && v1.Minor == v2.Minor && v1.Patch < v2.Patch {
+		return true
+	}
+	return false
+}
+
+// Format the version struct back to a string "vX.Y.Z"
+func FormatVersion(v *struct {
+	Major, Minor, Patch int
+}) string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }

--- a/ecosystem/lavavisor/pkg/util/common.go
+++ b/ecosystem/lavavisor/pkg/util/common.go
@@ -89,7 +89,7 @@ type SemanticVer struct {
 }
 
 // Parse the version string "vX.Y.Z" into a struct with X, Y, Z as integers
-func ParseVersion(version string) (v *SemanticVer) {
+func ParseToSemanticVersion(version string) (v *SemanticVer) {
 	v = &SemanticVer{}
 	fmt.Sscanf(version, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
 	return v
@@ -120,6 +120,6 @@ func IsVersionLessThan(v1, v2 *SemanticVer) bool {
 }
 
 // Format the version struct back to a string "vX.Y.Z"
-func FormatVersion(v *SemanticVer) string {
+func FormatFromSemanticVersion(v *SemanticVer) string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }


### PR DESCRIPTION
* Added a robust mechanism to attempt fetching lava-protocol version starting from target version to minimum version in descending order
* General improvements and small bug fixes:
1. changed protocolPath for building the binary to 'cmd/lava-protocol'
2. added 'ValidateProtocolVersion' check after fetching & building the binary (old versions of lava-protocol will not be supported by lava-visor anymore)
