### PR TITLE
Lavavisor improvements v2

### DIFF
--- a/ecosystem/lavavisor/cmd/create-service.go
+++ b/ecosystem/lavavisor/cmd/create-service.go
@@ -187,6 +187,12 @@ func CreateServiceFile(serviceParams *ServiceParams) (string, error) {
 	if err != nil {
 		return "", utils.LavaFormatError("error writing to service file", err)
 	}
+
+	// Create a symbolic link to the systemd directory.
+	if err := createSystemdSymlink(filePath, serviceId+".service"); err != nil {
+		return "", utils.LavaFormatError("error creating symbolic link", err)
+	}
+
 	utils.LavaFormatInfo("Service file has been created successfully", utils.Attribute{Key: "Path", Value: filePath})
 	// Extract filename from filePath
 	filename := filepath.Base(filePath)
@@ -217,5 +223,33 @@ func WriteToConfigFile(lavavisorPath string, serviceFileName string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// Create a symbolic link to the /etc/systemd/system/ directory.
+func createSystemdSymlink(source string, serviceName string) error {
+	target := "/etc/systemd/system/" + serviceName
+	// Check if the target exists
+	if _, err := os.Lstat(target); err == nil || os.IsExist(err) {
+		// Check if it's actually a symlink. If not, return an error.
+		if _, err := os.Readlink(target); err == nil {
+			// If there's a symlink exists, remove it.
+			cmdRemove := exec.Command("sudo", "rm", target)
+			if err := cmdRemove.Run(); err != nil {
+				return utils.LavaFormatError("failed to remove existing link.", nil, utils.Attribute{Key: "Target", Value: target})
+			}
+			utils.LavaFormatInfo("Old service file links are removed.", utils.Attribute{Key: "Path", Value: target})
+		} else {
+			return utils.LavaFormatError("file exists and is not a symlink.", nil, utils.Attribute{Key: "Target", Value: target})
+		}
+	}
+	// Create a new symbolic link pointing to the intended source.
+	// Use 'sudo' to create the symlink with elevated permissions.
+	cmd := exec.Command("sudo", "ln", "-s", source, target)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error creating symbolic link: %v", err)
+	}
+	utils.LavaFormatInfo("Symbolic link for to root has been created successfully.", utils.Attribute{Key: "Path", Value: target})
+
 	return nil
 }

--- a/ecosystem/lavavisor/cmd/create-service.go
+++ b/ecosystem/lavavisor/cmd/create-service.go
@@ -167,9 +167,9 @@ func CreateServiceFile(serviceParams *ServiceParams) (string, error) {
 	content += "[Service]\n"
 	content += "  WorkingDirectory=" + workingDir + "\n"
 	if serviceParams.ServiceType == "consumer" {
-		content += "  ExecStart=" + workingDir + "/lava-protocol rpcconsumer "
+		content += "  ExecStart=" + workingDir + "lava-protocol rpcconsumer "
 	} else if serviceParams.ServiceType == "provider" {
-		content += "  ExecStart=" + workingDir + "/lava-protocol rpcprovider "
+		content += "  ExecStart=" + workingDir + "lava-protocol rpcprovider "
 	}
 	content += ".lava-visor/services/service_configs/" + filepath.Base(serviceParams.ServiceConfigFile) + " --from " + serviceParams.FromUser + " --keyring-backend " + serviceParams.KeyringBackend + " --chain-id " + serviceParams.ChainID + " --geolocation " + fmt.Sprint(serviceParams.GeoLocation) + " --log_level " + serviceParams.LogLevel + " --node " + serviceParams.Node + "\n"
 

--- a/ecosystem/lavavisor/pkg/process/process_manager.go
+++ b/ecosystem/lavavisor/pkg/process/process_manager.go
@@ -46,7 +46,7 @@ func StartProcess(processes []*ServiceProcess, process string, serviceDir string
 	return processes
 }
 
-func getBinaryVersion(binaryPath string) (string, error) {
+func GetBinaryVersion(binaryPath string) (string, error) {
 	cmd := exec.Command(binaryPath, "version")
 	output, err := cmd.Output()
 	if err != nil {

--- a/ecosystem/lavavisor/pkg/process/version_monitor.go
+++ b/ecosystem/lavavisor/pkg/process/version_monitor.go
@@ -82,7 +82,7 @@ func (vm *VersionMonitor) MonitorVersionUpdates(ctx context.Context) {
 }
 
 func (vm *VersionMonitor) ValidateProtocolVersion(incoming *protocoltypes.Version) error {
-	binaryVersion, err := getBinaryVersion(vm.BinaryPath)
+	binaryVersion, err := GetBinaryVersion(vm.BinaryPath)
 	if err != nil || binaryVersion == "" {
 		return utils.LavaFormatError("failed to get binary version", err)
 	}

--- a/ecosystem/lavavisor/pkg/util/common.go
+++ b/ecosystem/lavavisor/pkg/util/common.go
@@ -119,6 +119,14 @@ func IsVersionLessThan(v1, v2 *SemanticVer) bool {
 	return false
 }
 
+func IsVersionGreaterThan(v1, v2 *SemanticVer) bool {
+	return !IsVersionLessThan(v1, v2) && !IsVersionEqual(v1, v2)
+}
+
+func IsVersionEqual(v1, v2 *SemanticVer) bool {
+	return v1.Major == v2.Major && v1.Minor == v2.Minor && v1.Patch == v2.Patch
+}
+
 // Format the version struct back to a string "vX.Y.Z"
 func FormatFromSemanticVersion(v *SemanticVer) string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)


### PR DESCRIPTION
- symlink created for generated service files to root "/etc/systemd/system/" -> this is where service files are read by default
- 'start' command will now traverse `upgrades/` directory and choose the most recent version dir as its working path (ensuring selected version is between min and target version)
- typo fix for service file generation