### PR TITLE
PRT-883 Fix content type in HTTP response

### DIFF
--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -306,6 +306,9 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context) {
 	app.Get("/websocket", websocketCallbackWithDappID) // catching http://HOST:PORT/1/websocket requests.
 
 	app.Post("/*", func(fiberCtx *fiber.Ctx) error {
+		// Set response header content-type to application/json
+		fiberCtx.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+
 		endTx := apil.logger.LogStartTransaction("jsonRpc-http post")
 		defer endTx()
 		msgSeed := apil.logger.GetMessageSeed()

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -247,6 +247,9 @@ func (apil *RestChainListener) Serve(ctx context.Context) {
 	apiInterface := apil.endpoint.ApiInterface
 	// Catch Post
 	app.Post("/*", func(c *fiber.Ctx) error {
+		// Set response header content-type to application/json
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+
 		endTx := apil.logger.LogStartTransaction("rest-http")
 		defer endTx()
 
@@ -294,6 +297,9 @@ func (apil *RestChainListener) Serve(ctx context.Context) {
 
 	// Catch the others
 	app.Use("/*", func(c *fiber.Ctx) error {
+		// Set response header content-type to application/json
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+
 		endTx := apil.logger.LogStartTransaction("rest-http")
 		defer endTx()
 		msgSeed := apil.logger.GetMessageSeed()
@@ -343,6 +349,7 @@ func addHeadersAndSendString(c *fiber.Ctx, metaData []pairingtypes.Metadata, dat
 	for _, value := range metaData {
 		c.Set(value.Name, value.Value)
 	}
+
 	return c.SendString(data)
 }
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -335,6 +335,9 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context) {
 	app.Get("/websocket", websocketCallbackWithDappID) // catching http://HOST:PORT/1/websocket requests.
 
 	app.Post("/*", func(c *fiber.Ctx) error {
+		// Set response header content-type to application/json
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+
 		endTx := apil.logger.LogStartTransaction("tendermint-WebSocket")
 		defer endTx()
 		msgSeed := apil.logger.GetMessageSeed()
@@ -372,6 +375,9 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context) {
 	})
 
 	app.Get("/*", func(c *fiber.Ctx) error {
+		// Set response header content-type to application/json
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+
 		endTx := apil.logger.LogStartTransaction("tendermint-WebSocket")
 		defer endTx()
 


### PR DESCRIPTION
Description:

In our current implementation we are returning responses with header content-type: text/plain.This PR fixes it and makes it as application/json