### PR TITLE
CNS-593: fix "make proto-gen" breakage

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -22,7 +22,7 @@ cd proto
 proto_dirs=$(find . -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    if grep "option go_package" $file &> /dev/null ; then
+    if grep -q "option go_package" $file 2> /dev/null ; then
       echo "Generating gogo proto code for $file"
       buf generate --template buf.gen.gogo.yaml $file
     fi

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -1,21 +1,24 @@
-#!/usr/bin/env bash
-__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source $__dir/useful_commands.sh
+#!/usr/bin/env /bin/sh
+__dir=$(dirname "$0")
+. $__dir/useful_commands.sh
 
 if ! command_exists buf; then
-    echo "buf not found. Please install buf using the init_install.sh script or manually."
-    exit 1
+  echo "buf not found."
+  echo "Please install buf using the init_install.sh script or manually."
+  exit 1
 fi
 
 if ! command_exists protoc-gen-gocosmos; then
-    echo "protoc-gen-gocosmos not found. Please install protoc-gen-gocosmos using the init_install.sh script or manually."
-    exit 1
+  echo "protoc-gen-gocosmos not found."
+  echo "Please install protoc-gen-gocosmos using the init_install.sh script or manually."
+  exit 1
 fi
 
-set -eo pipefail
+set -e
 
 echo "Generating gogo proto code"
 cd proto
+
 proto_dirs=$(find . -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
@@ -27,6 +30,7 @@ for dir in $proto_dirs; do
 done
 
 cd ..
+
 # move proto files to the right places
 cp -r github.com/lavanet/lava/* ./
 rm -rf github.com

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -15,7 +15,7 @@ sleep_until_next_epoch() {
   while true; do
     epoch_now=$(lavad query epochstorage show-epoch-details | grep "startBlock: ")
     display_ticker
-    if [ "$epoch_start" -ne "$epoch_now" ]; then
+    if [ "$epoch_start" != "$epoch_now" ]; then
       echo "finished waiting"
       break
     fi
@@ -25,12 +25,12 @@ sleep_until_next_epoch() {
 # Function to wait until next block
 wait_next_block() {
   current=$( lavad q block | jq .block.header.height)
-  echo "Waiting for next block $current"
+  echo "waiting for next block $current"
   while true; do
     display_ticker
     new=$( lavad q block | jq .block.header.height)
-    if [ "$current" -ne "$new" ]; then
-      echo "finished waiting for block $new"
+    if [ "$current" != "$new" ]; then
+      echo "finished waiting at block $new"
       break
     fi
   done

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -1,37 +1,43 @@
-
-function sleep_until_next_epoch {
-    epoch_start=$(lavad query epochstorage show-epoch-details | grep "startBlock: ")
-    echo "Waiting for the next epoch for the changes to be active"
-    loading_animation="/-\\|"
-    while true; do
-    epoch_now=$(lavad query epochstorage show-epoch-details | grep "startBlock: ")
-    for (( i=0; i<${#loading_animation}; i++ )); do
-        sleep 0.2
-        echo -en "${loading_animation:$i:1}" "\r"
-    done
-    if [[ $epoch_start != $epoch_now ]] 
-    then
-        echo "finished waiting"
-        break
-    fi
-    done
+# Function to show ticker (full cycle)
+display_ticker() {
+  animation='/ - \ |'
+  for c in $loading_animation; do
+    sleep 0.2
+    /bin/echo -e -n "$c" "\r"
+  done
 }
 
-function wait_next_block {
-  current=$( lavad q block | jq .block.header.height)
-  echo "Waiting for next block $current"
+# Function to wait until next epoch
+sleep_until_next_epoch() {
+  epoch_start=$(lavad query epochstorage show-epoch-details | grep "startBlock: ")
+  echo "Waiting for the next epoch for the changes to be active"
+  loading_animation='/ - \ |'
   while true; do
-    sleep 0.5
-    new=$( lavad q block | jq .block.header.height)
-    if [[ $current != $new ]]
-    then
-      echo "finished waiting for block $new"
-        break
+    epoch_now=$(lavad query epochstorage show-epoch-details | grep "startBlock: ")
+    display_ticker
+    if [ "$epoch_start" -ne "$epoch_now" ]; then
+      echo "finished waiting"
+      break
     fi
   done
 }
 
-function wait_count_blocks {
+# Function to wait until next block
+wait_next_block() {
+  current=$( lavad q block | jq .block.header.height)
+  echo "Waiting for next block $current"
+  while true; do
+    display_ticker
+    new=$( lavad q block | jq .block.header.height)
+    if [ "$current" -ne "$new" ]; then
+      echo "finished waiting for block $new"
+      break
+    fi
+  done
+}
+
+# function to wait until count ($1) blocks complete
+wait_count_blocks() {
   for i in $(seq 1 $1); do
     wait_next_block
   done
@@ -44,6 +50,8 @@ command_exists() {
 
 # Function to check the Go version is at least 1.20
 check_go_version() {
+  local GO_VERSION=1.20
+
   if ! command_exists go; then
     return 1
   fi
@@ -51,14 +59,15 @@ check_go_version() {
   go_version=$(go version)
   go_version_major_full=$(echo "$go_version" | awk '{print $3}')
   go_version_major=${go_version_major_full:2}
-  result=$(bc -l <<<"${go_version_major}-1.20")
-  if [[ "$result" -ge "0" ]]; then
+  result=$(echo "${go_version_major}-$GO_VERSION" | bc -l)
+  if [ "$result" -ge 0 ]; then
     return 0
   fi
 
   return 1
 }
 
+# Function to find the latest vote
 latest_vote() {
   # Check if jq is not installed
   if ! command_exists yq; then


### PR DESCRIPTION
The build 'make proto-gen' stopped working because the 'proto-build' docker image from cosmos no longer supports bash. Fix by adjusting the script to be compatible with 'sh' instead of 'bash'.