### PR TITLE
Error handling provider - DEPRECATED DO NOT MERGE

### DIFF
--- a/protocol/chainlib/allowed_errors.go
+++ b/protocol/chainlib/allowed_errors.go
@@ -2,6 +2,7 @@ package chainlib
 
 // AllowedErrorsMap is a map of allowed errors for various API interfaces
 var AllowedErrorsMap = map[string]map[string]string{
+	// json-rpc-specific allowed errors
 	"jsonrpc": {
 		"-32700": "Parse error",
 		"-32600": "Invalid request",
@@ -14,12 +15,44 @@ var AllowedErrorsMap = map[string]map[string]string{
 		"-32006": "JSON-RPC version not supported",
 	},
 	"rest": {
-		// Add REST-specific allowed errors here
-	},
-	"grpc": {
-		// Add gRPC-specific allowed errors here
+		// REST-specific allowed errors
+		"2":  "tx parse error",                        // client's fault for sending malformed transaction
+		"3":  "invalid sequence",                      // due to incorrect nonce from client
+		"6":  "unknown request",                       // client is asking for something unknown
+		"7":  "invalid address",                       // client provided an invalid address
+		"8":  "invalid pubkey",                        // client provided an invalid public key
+		"9":  "unknown address",                       // client provided an address that is not known
+		"10": "invalid coins",                         // client provided invalid coin/token information
+		"11": "out of gas",                            // client did not supply enough gas
+		"12": "memo too large",                        // client included a memo that is too large
+		"13": "insufficient fee",                      // client did not provide sufficient fees
+		"14": "maximum number of signatures exceeded", // client provided too many signatures
+		"15": "no signatures supplied",                // client did not provide any signatures
+		"18": "invalid request",                       // client sent a request that couldn't be understood
+		"21": "tx too large",                          // client sent a too-large transaction
+		"26": "invalid height",                        // client specified an invalid block height
+		"27": "invalid version",                       // client is using an unsupported version
+		"28": "invalid chain-id",                      // client provided invalid chain-id
+		"29": "invalid type",                          // client used an invalid type in request
+		"30": "tx timeout height",                     // client set an invalid timeout height for the transaction
+		"32": "incorrect account sequence",            // client used an incorrect sequence number for the account
+		"37": "feature not supported",                 // client tried to use a feature that is not supported
+		"38": "not found",                             // client is asking for a resource that doesn't exist
+		"41": "invalid gas limit",                     // client set an invalid gas limit
 	},
 	"tendermintrpc": {
-		// Add tendermint-rpc-specific allowed errors here
+		// tendermint-rpc-specific allowed errors
+		"-32700": "Parse error",
+		"-32600": "Invalid request",
+		"-32602": "Invalid params",
+		"-32603": "Internal error",
+		"-32000": "Invalid input",
+		"-32001": "Resource not found",
+		"-32002": "Resource unavailable",
+		"-32003": "Transaction rejected",
+		"-32006": "JSON-RPC version not supported",
+	},
+	"grpc": {
+		// gRPC-specific allowed errors
 	},
 }

--- a/protocol/chainlib/allowed_errors.go
+++ b/protocol/chainlib/allowed_errors.go
@@ -1,0 +1,25 @@
+package chainlib
+
+// AllowedErrorsMap is a map of allowed errors for various API interfaces
+var AllowedErrorsMap = map[string]map[string]string{
+	"jsonrpc": {
+		"-32700": "Parse error",
+		"-32600": "Invalid request",
+		"-32602": "Invalid params",
+		"-32603": "Internal error",
+		"-32000": "Invalid input",
+		"-32001": "Resource not found",
+		"-32002": "Resource unavailable",
+		"-32003": "Transaction rejected",
+		"-32006": "JSON-RPC version not supported",
+	},
+	"rest": {
+		// Add REST-specific allowed errors here
+	},
+	"grpc": {
+		// Add gRPC-specific allowed errors here
+	},
+	"tendermintrpc": {
+		// Add tendermint-rpc-specific allowed errors here
+	},
+}

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -483,6 +483,12 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 			Message: fmt.Sprintf("%s", err),
 		}
 		// this later causes returning an error
+
+		// JsonRPC External Error Handling
+		err = cp.HandleExternalError(replyMsg.Error.Message)
+		if err != nil {
+			return nil, "", nil, err
+		}
 	} else {
 		replyMessage, err = rpcInterfaceMessages.ConvertJsonRPCMsg(rpcMessage)
 		if err != nil {
@@ -498,12 +504,6 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 
 	reply := &pairingtypes.RelayReply{
 		Data: retData,
-	}
-
-	// JsonRPC External Error Handling
-	err = cp.HandleExternalError(string(reply.Data))
-	if err != nil {
-		return nil, "", nil, err
 	}
 
 	if ch != nil {

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -500,6 +500,12 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 		Data: retData,
 	}
 
+	// JsonRPC External Error Handling
+	err = cp.HandleExternalError(string(reply.Data))
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	if ch != nil {
 		subscriptionID, err = strconv.Unquote(string(replyMsg.Result))
 		if err != nil {

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -172,7 +172,7 @@ func (teh *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) e
 	return nil
 }
 
-func (teh *GRPCErrorHandler) HandleExternalError(replyData string) error {
+func (geh *GRPCErrorHandler) HandleExternalError(replyData string) error {
 	return nil
 }
 

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -130,6 +130,23 @@ func extractNestedCode(message string) (int, error) {
 
 // External Errors
 func (jeh *JsonRPCErrorHandler) HandleExternalError(replyData string) error {
+	return handleExternalError(replyData, "jsonrpc")
+}
+
+func (geh *RestErrorHandler) HandleExternalError(replyData string) error {
+	return handleExternalError(replyData, "rest")
+}
+
+func (teh *GRPCErrorHandler) HandleExternalError(replyData string) error {
+	return handleExternalError(replyData, "grpc")
+}
+
+func (teh *TendermintRPCErrorHandler) HandleExternalError(replyData string) error {
+	return handleExternalError(replyData, "tendermintrpc")
+}
+
+// external error handling
+func handleExternalError(replyData string, apiMethod string) error {
 	// Try to parse the reply into a JsonRPCResponse
 	var jsonResponse JsonResponse
 	err := json.Unmarshal([]byte(replyData), &jsonResponse)
@@ -143,24 +160,12 @@ func (jeh *JsonRPCErrorHandler) HandleExternalError(replyData string) error {
 			return utils.LavaFormatProduction("Cannot extract nested error code.", err)
 		}
 		// Check if this internal error code is in our map of allowed errors
-		_, exists := AllowedErrorsMap["jsonrpc"][fmt.Sprintf("%d", nestedCode)]
+		_, exists := AllowedErrorsMap[apiMethod][fmt.Sprintf("%d", nestedCode)]
 		if !exists {
 			// If the error code is not allowed, return a node error
 			errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
 			return utils.LavaFormatProduction(errMsg, nil)
 		}
 	}
-	return nil
-}
-
-func (geh *RestErrorHandler) HandleExternalError(replyData string) error {
-	return nil
-}
-
-func (teh *TendermintRPCErrorHandler) HandleExternalError(replyData string) error {
-	return nil
-}
-
-func (teh *GRPCErrorHandler) HandleExternalError(replyData string) error {
 	return nil
 }

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -118,6 +118,7 @@ func (jeh *JsonRPCErrorHandler) HandleExternalError(errorMessage string) error {
 		errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
 		return utils.LavaFormatProduction(errMsg, nil)
 	}
+	utils.LavaFormatInfo("Allowed error detected in JSONRPC response:", utils.Attribute{Key: "Allowed Error", Value: errorMessage})
 	return nil
 }
 
@@ -169,6 +170,7 @@ func (te *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) er
 		errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
 		return utils.LavaFormatProduction(errMsg, nil)
 	}
+	utils.LavaFormatInfo("Allowed error detected in tendermint-RPC response:", utils.Attribute{Key: "Allowed Error", Value: errorMessage})
 	return nil
 }
 

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -193,7 +193,6 @@ func extractRPCNestedCode(message string) (int, error) {
 
 		// Extract the JSON substring
 		jsonSubStr = jsonSubStr[:jsonEnd+1]
-
 	} else {
 		// The message seems to already be a JSON object
 		jsonSubStr = message

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -97,55 +97,27 @@ func (geh *GRPCErrorHandler) HandleNodeError(ctx context.Context, nodeError erro
 
 type ErrorHandler interface {
 	HandleNodeError(context.Context, error) error
-	HandleExternalError(replyData string) error
-}
-
-type JsonRPCResponse struct {
-	Result *interface{} `json:"result,omitempty"`
-	Error  *struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
+	HandleExternalError(errorMessage string) error
 }
 
 // HandleExternalError handles external errors for JSON-RPC calls.
-func (jeh *JsonRPCErrorHandler) HandleExternalError(replyData string) error {
-	// Try to parse the reply into a JsonRPCResponse
-	var jsonResponse JsonRPCResponse
-	err := json.Unmarshal([]byte(replyData), &jsonResponse)
+func (jeh *JsonRPCErrorHandler) HandleExternalError(errorMessage string) error {
+	// Extract the nested error code from the error message
+	nestedCode, err := extractRPCNestedCode(errorMessage)
 	if err != nil {
-		return utils.LavaFormatProduction("Unparsable external provider error detected.", err)
+		return utils.LavaFormatProduction("Cannot extract nested error code.", err)
 	}
-
-	// Check if this is a successful response
-	if jsonResponse.Result != nil {
-		return nil // It's a successful response, so just return nil (no error)
+	// Check if this internal error code is in our map of allowed errors
+	allowedErrors, ok := AllowedErrorsMap["jsonrpc"]
+	if !ok {
+		return utils.LavaFormatProduction("Allowed errors for json-RPC not configured", nil)
 	}
-
-	// Check if there is an "error" in the response
-	if jsonResponse.Error != nil {
-		nestedCode, err := extractRPCNestedCode(jsonResponse.Error.Message)
-		if err != nil {
-			return utils.LavaFormatProduction("Cannot extract nested error code.", err)
-		}
-
-		// Check if this internal error code is in our map of allowed errors
-		allowedErrors, ok := AllowedErrorsMap["jsonrpc"]
-		if !ok {
-			return utils.LavaFormatProduction("allowed errors for json-RPC not configured", nil)
-		}
-
-		_, exists := allowedErrors[fmt.Sprintf("%d", nestedCode)]
-		if !exists {
-			// If the error code is not allowed, return a node error
-			errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
-			return utils.LavaFormatProduction(errMsg, nil)
-		}
-	} else {
-		// Neither Result nor Error field is present
-		return utils.LavaFormatProduction("Received unexpected response: neither Result nor Error is present.", nil)
+	_, exists := allowedErrors[fmt.Sprintf("%d", nestedCode)]
+	if !exists {
+		// If the error code is not allowed, return a node error
+		errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
+		return utils.LavaFormatProduction(errMsg, nil)
 	}
-
 	return nil
 }
 
@@ -188,52 +160,22 @@ func (geh *RestErrorHandler) HandleExternalError(replyData string) error {
 	return utils.LavaFormatProduction("Unparsable external provider response detected.", err)
 }
 
-// Tendermint-RPC error handler
-type TendermintRPCResponse struct {
-	Result *interface{} `json:"result,omitempty"`
-	Error  *struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
-}
-
-func (teh *TendermintRPCErrorHandler) HandleExternalError(replyData string) error {
-	// Try to parse the reply into a TendermintRPCResponse
-	var tendermintResponse TendermintRPCResponse
-	err := json.Unmarshal([]byte(replyData), &tendermintResponse)
+func (teh *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) error {
+	nestedCode, err := extractRPCNestedCode(errorMessage)
 	if err != nil {
-		return utils.LavaFormatProduction("Unparsable external provider error detected.", err)
+		return utils.LavaFormatProduction("Cannot extract nested error code.", err)
 	}
-
-	// Check if this is a successful response
-	if tendermintResponse.Result != nil {
-		return nil // It's a successful response, so just return nil (no error)
+	// Check if this internal error code is in our map of allowed errors
+	allowedErrors, ok := AllowedErrorsMap["tendermint"]
+	if !ok {
+		return utils.LavaFormatProduction("allowed errors for tendermint-RPC not configured", nil)
 	}
-
-	// Check if there is an "error" in the response
-	if tendermintResponse.Error != nil {
-		nestedCode, err := extractRPCNestedCode(tendermintResponse.Error.Message)
-		if err != nil {
-			return utils.LavaFormatProduction("Cannot extract nested error code.", err)
-		}
-
-		// Check if this internal error code is in our map of allowed errors
-		allowedErrors, ok := AllowedErrorsMap["tendermint"]
-		if !ok {
-			return utils.LavaFormatProduction("allowed errors for tendermint-RPC not configured", nil)
-		}
-
-		_, exists := allowedErrors[fmt.Sprintf("%d", nestedCode)]
-		if !exists {
-			// If the error code is not allowed, return a node error
-			errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
-			return utils.LavaFormatProduction(errMsg, nil)
-		}
-	} else {
-		// Neither Result nor Error field is present
-		return utils.LavaFormatProduction("Received unexpected response: neither Result nor Error is present.", nil)
+	_, exists := allowedErrors[fmt.Sprintf("%d", nestedCode)]
+	if !exists {
+		// If the error code is not allowed, return a node error
+		errMsg := fmt.Sprintf("Disallowed provider error code: %d", nestedCode)
+		return utils.LavaFormatProduction(errMsg, nil)
 	}
-
 	return nil
 }
 

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -105,7 +105,7 @@ func (jeh *JsonRPCErrorHandler) HandleExternalError(errorMessage string) error {
 	// Extract the nested error code from the error message
 	errorCode, err := extractRPCNestedCode(errorMessage)
 	if err != nil {
-		return utils.LavaFormatProduction("Disallowed error detected in relay response", err, utils.Attribute{Key: "errorMessage", Value: errorMessage})
+		return utils.LavaFormatProduction("Unparsable external JsonRPC error detected", err, utils.Attribute{Key: "errorMessage", Value: errorMessage})
 	}
 	// Check if this internal error code is in our map of allowed errors
 	if allowedErrors, ok := AllowedErrorsMap["jsonrpc"]; !ok {
@@ -154,7 +154,7 @@ func (te *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) er
 	// Extract the nested error code from the error message
 	errorCode, err := extractRPCNestedCode(errorMessage)
 	if err != nil {
-		return utils.LavaFormatProduction("Disallowed error detected in relay response", err, utils.Attribute{Key: "errorMessage", Value: errorMessage})
+		return utils.LavaFormatProduction("Unparsable external TendermintRPC error detected", err, utils.Attribute{Key: "errorMessage", Value: errorMessage})
 	}
 	// Check if this internal error code is in our map of allowed errors
 	if allowedErrors, ok := AllowedErrorsMap["tendermintrpc"]; !ok {

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -153,7 +153,7 @@ func (geh *RestErrorHandler) HandleExternalError(replyData string) error {
 	return nil
 }
 
-func (teh *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) error {
+func (te *TendermintRPCErrorHandler) HandleExternalError(errorMessage string) error {
 	nestedCode, err := extractRPCNestedCode(errorMessage)
 	if err != nil {
 		return utils.LavaFormatProduction("Disallowed error detected in relay response", err, utils.Attribute{Key: "errorMessage:", Value: errorMessage})

--- a/protocol/chainlib/node_error_handler_test.go
+++ b/protocol/chainlib/node_error_handler_test.go
@@ -159,5 +159,4 @@ func TestHandleExternalErrorForREST(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected not nil for an ill response, got %s", err.Error())
 	}
-
 }

--- a/protocol/chainlib/node_error_handler_test.go
+++ b/protocol/chainlib/node_error_handler_test.go
@@ -78,6 +78,7 @@ func TestNodeErrorHandlerGenericErrors(t *testing.T) {
 	err = neh.handleGenericErrors(ctx, errors.New("dummy error"))
 	require.Equal(t, err, nil)
 }
+
 func TestHandleExternalErrorJSONRPC(t *testing.T) {
 	jeh := &JsonRPCErrorHandler{}
 
@@ -147,5 +148,4 @@ func TestHandleExternalErrorForREST(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error for a malformed response, got nil")
 	}
-
 }

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -442,5 +443,13 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		Data:     body,
 		Metadata: convertToMetadataMapOfSlices(res.Header),
 	}
+
+	// JsonRPC External Error Handling
+	fmt.Println("HERE IN REST! ")
+	err = rcp.HandleExternalError(string(reply.Data))
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	return reply, "", nil, nil
 }

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -424,9 +423,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 	if err != nil {
 		// Validate if the error is related to the provider connection to the node or it is a valid error
 		// in case the error is valid (e.g. bad input parameters) the error will return in the form of a valid error reply
-		fmt.Println("REST - err:", err)
 		if parsedError := rcp.HandleNodeError(ctx, err); parsedError != nil {
-			fmt.Println("parsedError:", parsedError)
 			return nil, "", nil, parsedError
 		}
 		return nil, "", nil, err
@@ -444,6 +441,12 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 	reply := &pairingtypes.RelayReply{
 		Data:     body,
 		Metadata: convertToMetadataMapOfSlices(res.Header),
+	}
+
+	// Check for external errors
+	err = rcp.HandleExternalError(string(reply.Data))
+	if err != nil {
+		return nil, "", nil, err
 	}
 
 	return reply, "", nil, nil

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -424,7 +424,9 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 	if err != nil {
 		// Validate if the error is related to the provider connection to the node or it is a valid error
 		// in case the error is valid (e.g. bad input parameters) the error will return in the form of a valid error reply
+		fmt.Println("REST - err:", err)
 		if parsedError := rcp.HandleNodeError(ctx, err); parsedError != nil {
+			fmt.Println("parsedError:", parsedError)
 			return nil, "", nil, parsedError
 		}
 		return nil, "", nil, err
@@ -442,13 +444,6 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 	reply := &pairingtypes.RelayReply{
 		Data:     body,
 		Metadata: convertToMetadataMapOfSlices(res.Header),
-	}
-
-	// JsonRPC External Error Handling
-	fmt.Println("HERE IN REST! ")
-	err = rcp.HandleExternalError(string(reply.Data))
-	if err != nil {
-		return nil, "", nil, err
 	}
 
 	return reply, "", nil, nil

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -626,6 +626,12 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		Data: data,
 	}
 
+	// JsonRPC External Error Handling
+	err = cp.HandleExternalError(string(reply.Data))
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	if ch != nil {
 		// get the params for the rpc call
 		params := nodeMessage.Params

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -607,7 +607,7 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 			Error:   rpcInterfaceMessages.ConvertErrorToRPCError(err.Error(), -1), // TODO: extract code from error status / message
 		}
 		// TendermintRPC External Error Handling
-		err = cp.HandleExternalError(string(replyMsg.Error.Data))
+		err = cp.HandleExternalError(replyMsg.Error.Data)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -611,7 +611,6 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		if err != nil {
 			return nil, "", nil, err
 		}
-
 	} else {
 		replyMessage, err = rpcInterfaceMessages.ConvertTendermintMsg(rpcMessage)
 		if err != nil {

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -606,6 +606,12 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 			ID:      id,
 			Error:   rpcInterfaceMessages.ConvertErrorToRPCError(err.Error(), -1), // TODO: extract code from error status / message
 		}
+		// TendermintRPC External Error Handling
+		err = cp.HandleExternalError(string(replyMsg.Error.Data))
+		if err != nil {
+			return nil, "", nil, err
+		}
+
 	} else {
 		replyMessage, err = rpcInterfaceMessages.ConvertTendermintMsg(rpcMessage)
 		if err != nil {
@@ -624,12 +630,6 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 	// create a new relay reply struct
 	reply := &pairingtypes.RelayReply{
 		Data: data,
-	}
-
-	// JsonRPC External Error Handling
-	err = cp.HandleExternalError(string(reply.Data))
-	if err != nil {
-		return nil, "", nil, err
 	}
 
 	if ch != nil {

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -607,7 +607,7 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 			Error:   rpcInterfaceMessages.ConvertErrorToRPCError(err.Error(), -1), // TODO: extract code from error status / message
 		}
 		// TendermintRPC External Error Handling
-		err = cp.HandleExternalError(replyMsg.Error.Data)
+		err = cp.HandleExternalError(replyMsg.Error.Message)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/protocol/rpcprovider/reliabilitymanager/reliability_manager_test.go
+++ b/protocol/rpcprovider/reliabilitymanager/reliability_manager_test.go
@@ -176,7 +176,7 @@ func TestFullFlowReliabilityConflict(t *testing.T) {
 	providerDR_sk, providerDR_address := ts.Providers[1].SK, ts.Providers[1].Addr
 	unwrapedCtx := sdk.UnwrapSDKContext(ts.Ctx)
 	epoch := int64(ts.Keepers.Epochstorage.GetEpochStart(unwrapedCtx))
-	replyDataBuf := []byte("REPLY-STUB")
+	replyDataBuf := []byte(`{"reply": "REPLY-STUB"}`)
 	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle the incoming request and provide the desired response
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
### Description
This PR aims to identify and categorize **external** errors received from JSON-RPC, REST and TendermintRPC interfaces. Once an external error is detected, the error code is parsed and checked against a predefined list of 'allowed' errors. If the error code exists in this list, the protocol proceeds as normal; otherwise, it returns a 'disallowed error' response - as a node error. If the reply is not parsable (due to not being in JSON format), error handler returns a node error.

This strategy ensures that we only bypass known, manageable errors while halting execution for unexpected or critical issues.

### Testing
**1. Unit Tests:** In the unit tests, we simulate both allowed and disallowed error responses through mocking. These mocked responses are then run through the error handlers of each API interface we support to ensure correct behavior.
**2. Manuel Tests:** Relays that causes allowed errors sent to Lava and behavior of the error handler is observed. 
Example relay: ` curl localhost:3360/lavanet/lava/pairing/user_entry/0x213123/LAV1`
Response:
<img width="837" alt="Screenshot 2023-09-05 at 17 30 59" src="https://github.com/lavanet/lava/assets/82905251/e2a812d8-a687-4674-9011-fcd5a5b04ae6">


