### PR TITLE
CNS-595: changed mock plan index to "free"

### DIFF
--- a/testutil/common/mock.go
+++ b/testutil/common/mock.go
@@ -25,7 +25,7 @@ func CreateMockSpec() spectypes.Spec {
 
 func CreateMockPlan() plantypes.Plan {
 	plan := plantypes.Plan{
-		Index:                    "mock_plan",
+		Index:                    "free",
 		Description:              "plan for testing",
 		Type:                     "rpc",
 		Block:                    100,

--- a/x/conflict/keeper/msg_server_detection_test.go
+++ b/x/conflict/keeper/msg_server_detection_test.go
@@ -27,7 +27,7 @@ type tester struct {
 func newTester(t *testing.T) *tester {
 	ts := &tester{Tester: *common.NewTester(t)}
 
-	ts.AddPlan("mock", common.CreateMockPlan())
+	ts.AddPlan("free", common.CreateMockPlan())
 	ts.AddSpec("mock", common.CreateMockSpec())
 
 	ts.AdvanceEpoch()
@@ -41,7 +41,7 @@ func (ts *tester) setupForConflict(providersCount int) *tester {
 		stake   int64 = 1000
 	)
 
-	ts.plan = ts.Plan("mock")
+	ts.plan = ts.Plan("free")
 	ts.spec = ts.Spec("mock")
 
 	consumer, consumerAddr := ts.AddAccount("consumer", 0, balance)

--- a/x/pairing/keeper/helpers_test.go
+++ b/x/pairing/keeper/helpers_test.go
@@ -27,7 +27,7 @@ const (
 func newTester(t *testing.T) *tester {
 	ts := &tester{Tester: *common.NewTester(t)}
 
-	ts.plan = ts.AddPlan("mock", common.CreateMockPlan()).Plan("mock")
+	ts.plan = ts.AddPlan("free", common.CreateMockPlan()).Plan("free")
 	ts.spec = ts.AddSpec("mock", common.CreateMockSpec()).Spec("mock")
 
 	ts.AdvanceEpoch()
@@ -88,9 +88,9 @@ func (ts *tester) addProviderExtra(
 // using ts.Account(common.PROVIDER, idx) and ts.Account(common.PROVIDER, idx) respectively.
 func (ts *tester) setupForPayments(providersCount, clientsCount, providersToPair int) *tester {
 	if providersToPair > 0 {
-		// will overwrite the default "mock" plan
+		// will overwrite the default "free" plan
 		ts.plan.PlanPolicy.MaxProvidersToPair = uint64(providersToPair)
-		ts.AddPlan("mock", ts.plan)
+		ts.AddPlan("free", ts.plan)
 	}
 
 	ts.addClient(clientsCount)

--- a/x/pairing/keeper/pairing_subscription_test.go
+++ b/x/pairing/keeper/pairing_subscription_test.go
@@ -195,9 +195,9 @@ func TestStrictestPolicyGeolocation(t *testing.T) {
 
 	// make the plan policy's geolocation 7(=111)
 	// (done before setupForPayments() below so subscription will use ths plan)
-	// will overwrite the default "mock" plan
+	// will overwrite the default "free" plan
 	ts.plan.PlanPolicy.GeolocationProfile = 7
-	ts.AddPlan("mock", ts.plan)
+	ts.AddPlan("free", ts.plan)
 
 	ts.setupForPayments(1, 1, 0) // 1 provider, 1 client, default providers-to-pair
 

--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -695,7 +695,7 @@ func TestSelectedProvidersPairing(t *testing.T) {
 			_, sub1Addr := ts.AddAccount("sub", i, 10000)
 
 			// create plan, propose it and buy subscription
-			plan := ts.Plan("mock")
+			plan := ts.Plan("free")
 			providersSet := providerSets[tt.providersSet]
 
 			plan.PlanPolicy.SelectedProvidersMode = tt.planMode
@@ -2169,7 +2169,7 @@ func TestPairingConsistency(t *testing.T) {
 	iterations := 100
 
 	ts.plan.PlanPolicy.MaxProvidersToPair = uint64(3)
-	ts.AddPlan("mock", ts.plan)
+	ts.AddPlan("free", ts.plan)
 	ts.addClient(1)
 	err := ts.addProviderGeolocation(10, 3)
 	require.Nil(t, err)

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -23,7 +23,7 @@ type tester struct {
 
 func newTester(t *testing.T) *tester {
 	ts := &tester{Tester: *common.NewTester(t)}
-	ts.AddPlan("mock", common.CreateMockPlan())
+	ts.AddPlan("free", common.CreateMockPlan())
 	ts.AddPolicy("mock", common.CreateMockPolicy())
 	return ts
 }
@@ -91,7 +91,7 @@ func TestCreateDefaultProject(t *testing.T) {
 	ts := newTester(t)
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 	_, sub1Addr := ts.Account("sub1")
 
 	err := ts.Keepers.Projects.CreateAdminProject(ts.Ctx, sub1Addr, plan)
@@ -114,7 +114,7 @@ func TestCreateProject(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 	ts.setupProjectData()
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 	projectData := ts.ProjectData("pd2")
 
 	_, sub1Addr := ts.Account("sub1")
@@ -197,7 +197,7 @@ func TestProjectsServerAPI(t *testing.T) {
 	_, dev1Addr := ts.Account("dev1")
 	_, dev2Addr := ts.Account("dev2")
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 	err := ts.TxProposalAddPlans(plan)
 	require.Nil(t, err)
 
@@ -235,7 +235,7 @@ func TestDeleteProject(t *testing.T) {
 	ts.SetupAccounts(1, 0, 2) // 1 sub, 0 adm, 2 dev
 	ts.setupProjectData()
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 	projectData := ts.ProjectData("pd2")
 
 	_, sub1Addr := ts.Account("sub1")
@@ -270,7 +270,7 @@ func TestAddDelKeys(t *testing.T) {
 	ts.setupProjectData()
 
 	projectData := ts.ProjectData("pd3")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, sub1Addr := ts.Account("sub1")
 	_, adm1Addr := ts.Account("pd_adm_3")
@@ -373,7 +373,7 @@ func TestAddAdminInTwoProjects(t *testing.T) {
 	ts.setupProjectData()
 
 	projectData := ts.ProjectData("pd1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, sub1Addr := ts.Account("sub1")
 	_, adm1Addr := ts.Account("pd_adm_1")
@@ -409,7 +409,7 @@ func setPolicyTest(t *testing.T, testAdminPolicy bool) {
 	ts.setupProjectData()
 
 	projectData := ts.ProjectData("pd1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, sub1Addr := ts.Account("sub1")
 	_, adm1Addr := ts.Account("pd_adm_1")
@@ -569,7 +569,7 @@ func TestChargeComputeUnits(t *testing.T) {
 	ts.setupProjectData()
 
 	projectData := ts.ProjectData("pd1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, sub1Addr := ts.Account("pd_adm_1")
 	_, dev1Addr := ts.Account("dev1")
@@ -639,7 +639,7 @@ func TestAddAfterDelKeys(t *testing.T) {
 	_, dev1Addr := ts.Account("dev1")
 	_, dev2Addr := ts.Account("dev2")
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	projectData1 := types.ProjectData{
 		Name:        "mockname1",
@@ -708,7 +708,7 @@ func TestAddDelKeysSameEpoch(t *testing.T) {
 	_, dev5Addr := ts.Account("dev5")
 	_, dev6Addr := ts.Account("dev6")
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	projectData1 := types.ProjectData{
 		Name:        "mockname1",
@@ -824,7 +824,7 @@ func TestDelKeysDelProjectSameEpoch(t *testing.T) {
 	_, dev1Addr := ts.Account("dev1")
 	_, dev2Addr := ts.Account("dev2")
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	projectsData := []types.ProjectData{
 		{
@@ -940,7 +940,7 @@ func TestAddDevKeyToDifferentProjectsInSameBlock(t *testing.T) {
 	_, sub2Addr := ts.Account("sub2")
 	_, dev1Addr := ts.Account("dev1")
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	projectName1 := "mockname1"
 	projectName2 := "mockname2"
@@ -1040,7 +1040,7 @@ func TestSetPolicySelectedProviders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			providersSet := providersSets[tt.providerSet]
 
-			plan := ts.Plan("mock")
+			plan := ts.Plan("free")
 			plan.PlanPolicy.SelectedProvidersMode = tt.planMode
 			plan.PlanPolicy.SelectedProviders = providersSet.planProviders
 

--- a/x/subscription/keeper/cluster_test.go
+++ b/x/subscription/keeper/cluster_test.go
@@ -19,8 +19,8 @@ func TestGetCluster(t *testing.T) {
 	_, subEnterprise := ts.Account("sub4")
 
 	// add valid plans for clusters
-	plan := ts.Plan("mock")
-	plans := []string{"free", "basic", "premium", "enterprise"}
+	plan := ts.Plan("free")
+	plans := []string{"basic", "premium", "enterprise"}
 	for _, planName := range plans {
 		plan.Index = planName
 		ts.AddPlan(planName, plan)

--- a/x/subscription/keeper/subscription_test.go
+++ b/x/subscription/keeper/subscription_test.go
@@ -20,7 +20,7 @@ type tester struct {
 
 func newTester(t *testing.T) *tester {
 	ts := &tester{Tester: *common.NewTester(t)}
-	ts.AddPlan("mock", common.CreateMockPlan())
+	ts.AddPlan("free", common.CreateMockPlan())
 	return ts
 }
 
@@ -48,7 +48,7 @@ func TestCreateSubscription(t *testing.T) {
 
 	var plans []planstypes.Plan
 	for i := 0; i < 3; i++ {
-		plan := ts.Plan("mock")
+		plan := ts.Plan("free")
 		plan.Index += strconv.Itoa(i + 1)
 		plan.Block = ts.BlockHeight()
 		err := ts.TxProposalAddPlans(plan)
@@ -171,7 +171,7 @@ func TestSubscriptionExpiration(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 2 sub, 0 adm, 0 dev
 
 	_, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 1)
 	require.Nil(t, err)
@@ -191,7 +191,7 @@ func TestRenewSubscription(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
 	_, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 6)
 	require.Nil(t, err)
@@ -255,7 +255,7 @@ func TestSubscriptionAdminProject(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
 	_, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 1)
 	require.Nil(t, err)
@@ -273,7 +273,7 @@ func TestMonthlyRechargeCU(t *testing.T) {
 	_, sub1Addr := ts.Account("sub1")
 	_, adm1Addr := ts.Account("adm1")
 	_, dev1Addr := ts.Account("dev1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 3)
 	require.Nil(t, err)
@@ -395,7 +395,7 @@ func TestExpiryTime(t *testing.T) {
 		{[3]int{2000, 3, 1}, [3]int{2000, 4, 1}, 12},
 	}
 
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	for _, tt := range template {
 		now := time.Date(tt.now[0], time.Month(tt.now[1]), tt.now[2], 12, 0, 0, 0, time.UTC)
@@ -426,7 +426,7 @@ func TestSubscriptionExpire(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
 	sub1Acct, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	coins := common.NewCoins(10000)
 	ts.Keepers.BankKeeper.SetBalance(ts.Ctx, sub1Acct.Addr, coins)
@@ -484,7 +484,7 @@ func TestPrice(t *testing.T) {
 			// new account per attempt
 			sub1Acct, sub1Addr := ts.AddAccount("tmp", 0, 10000)
 
-			plan := ts.Plan("mock")
+			plan := ts.Plan("free")
 			plan.AnnualDiscountPercentage = tt.discount
 			plan.Price = common.NewCoin(tt.price)
 			err := ts.TxProposalAddPlans(plan)
@@ -512,7 +512,7 @@ func TestAddProjectToSubscription(t *testing.T) {
 	_, sub1Addr := ts.Account("sub1")
 	_, adm1Addr := ts.Account("adm1")
 	_, dev1Addr := ts.Account("dev1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, err := ts.TxSubscriptionBuy(sub1Addr, dev1Addr, plan.Index, 1)
 	require.Nil(t, err)
@@ -560,7 +560,7 @@ func TestGetProjectsForSubscription(t *testing.T) {
 
 	_, sub1Addr := ts.Account("sub1")
 	_, sub2Addr := ts.Account("sub2")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	// buy two subscriptions
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 1)
@@ -604,7 +604,7 @@ func TestAddDelProjectForSubscription(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
 	_, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	// buy subscription and add project
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 1)
@@ -640,7 +640,7 @@ func TestDelProjectEndSubscription(t *testing.T) {
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 
 	_, sub1Addr := ts.Account("sub1")
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	// buy subscription
 	_, err := ts.TxSubscriptionBuy(sub1Addr, sub1Addr, plan.Index, 1)
@@ -687,7 +687,7 @@ func TestDurationTotal(t *testing.T) {
 	ts := newTester(t)
 	ts.SetupAccounts(1, 0, 0) // 1 sub, 0 adm, 0 dev
 	months := 12
-	plan := ts.Plan("mock")
+	plan := ts.Plan("free")
 
 	_, subAddr := ts.Account("sub1")
 	_, err := ts.TxSubscriptionBuy(subAddr, subAddr, plan.Index, months)


### PR DESCRIPTION
This was done so the clustering code won't print lots of errors because there's no "mock" plan