### PR TITLE
PRT-847: Providerside Error Handling

### DIFF
--- a/protocol/chainlib/chainproxy/rpcclient/client.go
+++ b/protocol/chainlib/chainproxy/rpcclient/client.go
@@ -389,7 +389,7 @@ func (c *Client) Notify(ctx context.Context, method string, args ...interface{})
 	msg.ID = nil
 
 	if c.isHTTP {
-		return c.sendHTTP(ctx, op, msg, false)
+		return c.sendHTTP(ctx, op, msg, true)
 	}
 	return c.send(ctx, op, msg)
 }

--- a/protocol/chainlib/chainproxy/rpcclient/client.go
+++ b/protocol/chainlib/chainproxy/rpcclient/client.go
@@ -272,7 +272,7 @@ func (c *Client) SetHeader(key, value string) {
 //
 // The result must be a pointer so that package json can unmarshal into it. You
 // can also pass nil, in which case the result is ignored.
-func (c *Client) CallContext(ctx context.Context, id json.RawMessage, method string, params interface{}) (*JsonrpcMessage, error) {
+func (c *Client) CallContext(ctx context.Context, id json.RawMessage, method string, params interface{}, isJsonRPC bool) (*JsonrpcMessage, error) {
 	var msg *JsonrpcMessage
 	var err error
 	switch p := params.(type) {
@@ -293,7 +293,7 @@ func (c *Client) CallContext(ctx context.Context, id json.RawMessage, method str
 	op := &requestOp{ids: []json.RawMessage{msg.ID}, resp: make(chan *JsonrpcMessage, 1)}
 
 	if c.isHTTP {
-		err = c.sendHTTP(ctx, op, msg)
+		err = c.sendHTTP(ctx, op, msg, isJsonRPC)
 	} else {
 		err = c.send(ctx, op, msg)
 	}
@@ -389,7 +389,7 @@ func (c *Client) Notify(ctx context.Context, method string, args ...interface{})
 	msg.ID = nil
 
 	if c.isHTTP {
-		return c.sendHTTP(ctx, op, msg)
+		return c.sendHTTP(ctx, op, msg, false)
 	}
 	return c.send(ctx, op, msg)
 }

--- a/protocol/chainlib/chainproxy/rpcclient/http.go
+++ b/protocol/chainlib/chainproxy/rpcclient/http.go
@@ -163,7 +163,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*Jsonr
 	if !ok {
 		return fmt.Errorf("sendBatchHTTP - c.writeConn.(*httpConn) - type assertion failed, type:" + fmt.Sprintf("%s", c.writeConn))
 	}
-	respBody, err := hc.doRequest(ctx, msgs, false)
+	respBody, err := hc.doRequest(ctx, msgs, true)
 	if err != nil {
 		return err
 	}

--- a/protocol/chainlib/chainproxy/rpcclient/http.go
+++ b/protocol/chainlib/chainproxy/rpcclient/http.go
@@ -200,6 +200,12 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}, isJsonRPC bo
 	if err != nil {
 		return nil, err
 	}
+
+	err = ValidateStatusCodes(resp.StatusCode)
+	if err != nil {
+		return nil, err
+	}
+
 	if isJsonRPC && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		var buf bytes.Buffer
 		var body []byte
@@ -214,6 +220,13 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}, isJsonRPC bo
 		}
 	}
 	return resp.Body, nil
+}
+
+func ValidateStatusCodes(statusCode int) error {
+	if statusCode == 504 || statusCode == 429 {
+		return utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: statusCode})
+	}
+	return nil
 }
 
 // httpServerConn turns a HTTP connection into a Conn.

--- a/protocol/chainlib/chainproxy/rpcclient/http.go
+++ b/protocol/chainlib/chainproxy/rpcclient/http.go
@@ -139,12 +139,12 @@ func DialHTTP(endpoint string) (*Client, error) {
 	return DialHTTPWithClient(endpoint, new(http.Client))
 }
 
-func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {
+func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}, isJsonRPC bool) error {
 	hc, ok := c.writeConn.(*httpConn)
 	if !ok {
 		return fmt.Errorf("sendHTTP - c.writeConn.(*httpConn) - type assertion failed" + fmt.Sprintf("%s", c.writeConn))
 	}
-	respBody, err := hc.doRequest(ctx, msg)
+	respBody, err := hc.doRequest(ctx, msg, isJsonRPC)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*Jsonr
 	if !ok {
 		return fmt.Errorf("sendBatchHTTP - c.writeConn.(*httpConn) - type assertion failed, type:" + fmt.Sprintf("%s", c.writeConn))
 	}
-	respBody, err := hc.doRequest(ctx, msgs)
+	respBody, err := hc.doRequest(ctx, msgs, false)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*Jsonr
 	return nil
 }
 
-func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadCloser, error) {
+func (hc *httpConn) doRequest(ctx context.Context, msg interface{}, isJsonRPC bool) (io.ReadCloser, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if isJsonRPC && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		var buf bytes.Buffer
 		var body []byte
 		if _, err := buf.ReadFrom(resp.Body); err == nil {

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -463,7 +463,7 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 		cp.NodeUrl.SetIpForwardingIfNecessary(ctx, rpc.SetHeader)
 		connectCtx, cancel := cp.NodeUrl.LowerContextTimeout(ctx, relayTimeout)
 		defer cancel()
-		rpcMessage, err = rpc.CallContext(connectCtx, nodeMessage.ID, nodeMessage.Method, nodeMessage.Params)
+		rpcMessage, err = rpc.CallContext(connectCtx, nodeMessage.ID, nodeMessage.Method, nodeMessage.Params, true)
 		if err != nil {
 			// Validate if the error is related to the provider connection to the node or it is a valid error
 			// in case the error is valid (e.g. bad input parameters) the error will return in the form of a valid error reply

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -484,19 +484,6 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 			return nil, "", nil, utils.LavaFormatError("jsonRPC error", err, utils.Attribute{Key: "GUID", Value: ctx})
 		}
 		replyMsg = *replyMessage
-
-		reqId, idErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessage.ID)
-		if idErr != nil {
-			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
-		}
-		respId, idErr := rpcInterfaceMessages.IdFromRawMessage(replyMsg.ID)
-		if idErr != nil {
-			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
-		}
-
-		if reqId != respId {
-			return nil, "", nil, utils.LavaFormatError("jsonRPC ID mismatch error", err, utils.Attribute{Key: "GUID", Value: ctx})
-		}
 	}
 
 	retData, err := json.Marshal(replyMsg)

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -61,6 +61,13 @@ func (geh *genericErrorHandler) handleCodeErrors(ctx context.Context, code codes
 	return nil
 }
 
+func (geh *genericErrorHandler) HandleStatusError(statusCode int) error {
+	if statusCode == 504 || statusCode == 429 {
+		return utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: statusCode})
+	}
+	return nil
+}
+
 type RestErrorHandler struct{ genericErrorHandler }
 
 // Validating if the error is related to the provider connection or not
@@ -94,4 +101,5 @@ func (geh *GRPCErrorHandler) HandleNodeError(ctx context.Context, nodeError erro
 
 type ErrorHandler interface {
 	HandleNodeError(context.Context, error) error
+	HandleStatusError(int) error
 }

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lavanet/lava/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/lavanet/lava/protocol/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -62,10 +63,7 @@ func (geh *genericErrorHandler) handleCodeErrors(ctx context.Context, code codes
 }
 
 func (geh *genericErrorHandler) HandleStatusError(statusCode int) error {
-	if statusCode == 504 || statusCode == 429 {
-		return utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: statusCode})
-	}
-	return nil
+	return rpcclient.ValidateStatusCodes(statusCode)
 }
 
 type RestErrorHandler struct{ genericErrorHandler }

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -456,7 +456,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		Metadata: convertToMetadataMapOfSlices(res.Header),
 	}
 
-	// checkin if rest reply data is in json format
+	// checking if rest reply data is in json format
 	var jsonData map[string]interface{}
 	err = json.Unmarshal(reply.Data, &jsonData)
 	if err != nil {

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -441,8 +441,8 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		defer res.Body.Close()
 	}
 
-	if res.StatusCode == 504 || res.StatusCode == 429 {
-		utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode})
+	err = rcp.HandleStatusError(res.StatusCode)
+	if err != nil {
 		return nil, "", nil, err
 	}
 

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -458,7 +458,7 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 
 	// checkin if rest reply data is in json format
 	var jsonData map[string]interface{}
-	err = json.Unmarshal([]byte(reply.Data), &jsonData)
+	err = json.Unmarshal(reply.Data, &jsonData)
 	if err != nil {
 		return nil, "", nil, utils.LavaFormatError("Rest reply is not in json format", err, utils.Attribute{Key: "reply.Data", Value: reply.Data})
 	}

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -3,6 +3,7 @@ package chainlib
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -449,5 +450,13 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		Data:     body,
 		Metadata: convertToMetadataMapOfSlices(res.Header),
 	}
+
+	// checkin if rest reply data is in json format
+	var jsonData map[string]interface{}
+	err = json.Unmarshal([]byte(reply.Data), &jsonData)
+	if err != nil {
+		return nil, "", nil, utils.LavaFormatError("Rest reply is not in json format", err, utils.Attribute{Key: "reply.Data", Value: reply.Data})
+	}
+
 	return reply, "", nil, nil
 }

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -441,6 +441,11 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		defer res.Body.Close()
 	}
 
+	if res.StatusCode == 504 || res.StatusCode == 429 {
+		utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode})
+		return nil, "", nil, err
+	}
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, "", nil, err

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -528,6 +528,11 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 		defer res.Body.Close()
 	}
 
+	if res.StatusCode == 504 || res.StatusCode == 429 {
+		utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode})
+		return nil, "", nil, err
+	}
+
 	// read the response body
 	body, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -603,15 +603,8 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 	var replyMsg *rpcInterfaceMessages.RPCResponse
 	// the error check here would only wrap errors not from the rpc
 	if err != nil {
-		id, idErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessage.ID)
-		if idErr != nil {
-			return nil, "", nil, utils.LavaFormatError("Failed parsing ID when getting rpc error", idErr)
-		}
-		replyMsg = &rpcInterfaceMessages.RPCResponse{
-			JSONRPC: nodeMessage.Version,
-			ID:      id,
-			Error:   rpcInterfaceMessages.ConvertErrorToRPCError(err.Error(), -1), // TODO: extract code from error status / message
-		}
+		utils.LavaFormatDebug("received an error from SendNodeMsg", utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "error", Value: err})
+		return nil, "", nil, err
 	} else {
 		replyMessage, err = rpcInterfaceMessages.ConvertTendermintMsg(rpcMessage)
 		if err != nil {
@@ -619,6 +612,18 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		}
 
 		replyMsg = replyMessage
+
+		reqId, idErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessage.ID)
+		if idErr != nil {
+			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
+		}
+		respId, idErr := rpcInterfaceMessages.IdFromRawMessage(rpcMessage.ID)
+		if idErr != nil {
+			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
+		}
+		if reqId != respId {
+			return nil, "", nil, utils.LavaFormatError("tendermintRPC ID mismatch error", err, utils.Attribute{Key: "GUID", Value: ctx})
+		}
 	}
 
 	// marshal the jsonrpc message to json

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -544,6 +544,13 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 		Data: body,
 	}
 
+	// checking if rest reply data is in json format
+	var jsonData map[string]interface{}
+	err = json.Unmarshal(reply.Data, &jsonData)
+	if err != nil {
+		return nil, "", nil, utils.LavaFormatError("Tendermint URI reply is not in json format", err, utils.Attribute{Key: "reply.Data", Value: reply.Data})
+	}
+
 	return reply, "", nil, nil
 }
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -617,18 +617,6 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		}
 
 		replyMsg = replyMessage
-
-		reqId, idErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessage.ID)
-		if idErr != nil {
-			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
-		}
-		respId, idErr := rpcInterfaceMessages.IdFromRawMessage(rpcMessage.ID)
-		if idErr != nil {
-			return nil, "", nil, utils.LavaFormatError("Failed parsing ID", idErr)
-		}
-		if reqId != respId {
-			return nil, "", nil, utils.LavaFormatError("tendermintRPC ID mismatch error", err, utils.Attribute{Key: "GUID", Value: ctx})
-		}
 	}
 
 	// marshal the jsonrpc message to json

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -528,8 +528,8 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 		defer res.Body.Close()
 	}
 
-	if res.StatusCode == 504 || res.StatusCode == 429 {
-		utils.LavaFormatError("Received invalid status code", nil, utils.Attribute{Key: "Status Code", Value: res.StatusCode})
+	err = cp.HandleStatusError(res.StatusCode)
+	if err != nil {
 		return nil, "", nil, err
 	}
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -602,7 +602,7 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 		connectCtx, cancel := cp.NodeUrl.LowerContextTimeout(ctx, relayTimeout)
 		defer cancel()
 		// perform the rpc call
-		rpcMessage, err = rpc.CallContext(connectCtx, nodeMessage.ID, nodeMessage.Method, nodeMessage.Params)
+		rpcMessage, err = rpc.CallContext(connectCtx, nodeMessage.ID, nodeMessage.Method, nodeMessage.Params, false)
 		if err != nil {
 			// Validate if the error is related to the provider connection to the node or it is a valid error
 			// in case the error is valid (e.g. bad input parameters) the error will return in the form of a valid error reply

--- a/protocol/rpcprovider/reliabilitymanager/reliability_manager_test.go
+++ b/protocol/rpcprovider/reliabilitymanager/reliability_manager_test.go
@@ -176,7 +176,7 @@ func TestFullFlowReliabilityConflict(t *testing.T) {
 	providerDR_sk, providerDR_address := ts.Providers[1].SK, ts.Providers[1].Addr
 	unwrapedCtx := sdk.UnwrapSDKContext(ts.Ctx)
 	epoch := int64(ts.Keepers.Epochstorage.GetEpochStart(unwrapedCtx))
-	replyDataBuf := []byte("REPLY-STUB")
+	replyDataBuf := []byte(`{"reply": "REPLY-STUB"}`)
 	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle the incoming request and provide the desired response
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
**Changelog**

- Added a check for response status codes 504 and 429 in REST and Tendermint URI calls. (Note: For JSON-RPC and Tendermint-RPC, this is already handled by the doRequest function in http.go).
- Implemented a JSON format validation for all REST API responses.
- Introduced an ID verification step for both JSON-RPC and Tendermint-RPC.

**Manual Testing**

- Conducted tests by sending requests to a server configured to always return status codes 504 and 429. Verified that the new status code checks are operational.
- Reviewed provider logs and confirmed that for successful relay transactions, no errors were generated due to JSON formatting issues or ID discrepancies.
