### PR TITLE
Helm improvements

### DIFF
--- a/helm/provider/templates/deployment.yaml
+++ b/helm/provider/templates/deployment.yaml
@@ -172,9 +172,7 @@ spec:
                 - --from
                 - {{ include "provider.keyname" . | quote }}
                 - --endpoints
-                {{- range .Values.supportedChainIds }}
-                - "{{ $endpoint }}:443,{{ . }}"
-                {{- end }}
+                - "{{- range .Values.supportedChainIds -}}{{ $.Values.endpoint }}:443,{{ . }} {{ end }}"
             {{- toYaml (unset .Values.defaultLivenessProbe "enabled") | nindent 12 }}
           {{ else if .Values.customLivenessProbe.enabled }}
           livenessProbe:
@@ -198,9 +196,7 @@ spec:
                 - --from
                 - {{ include "provider.keyname" . | quote }}
                 - --endpoints
-                {{- range .Values.supportedChainIds }}
-                - "{{ $endpoint }}:443,{{ . }}"
-                {{- end }}
+                - "{{- range .Values.supportedChainIds -}}{{ $.Values.endpoint }}:443,{{ . }} {{ end }}"
             {{- toYaml (unset .Values.defaultReadinessProbe "enabled") | nindent 12 }}
           {{ else if .Values.customReadinessProbe.enabled }}
           readinessProbe:

--- a/helm/provider/templates/deployment.yaml
+++ b/helm/provider/templates/deployment.yaml
@@ -29,8 +29,9 @@ spec:
       {{- include "provider.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/provider/values.yaml
+++ b/helm/provider/values.yaml
@@ -129,7 +129,7 @@ env: []
 # image to deploy
 image:
   repository: us-central1-docker.pkg.dev/lavanet-public/images/lavad
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: latest
 
 # port to expose the node on


### PR DESCRIPTION
1. When using the `latest` tag, `pullPolicy` should be set to `Always` to avoid image caching. Overall using `latest` is not recommended and it's better to use a particular pinned version
2. Added checksum for the configmap so that the pod restarts when the configmap is changed
3. Fixed syntax for probe cmd which was not working correctly