### PR TITLE
CNS-610: Add tx capabilities without the protocol

### DIFF
--- a/scripts/init_chain_commands.sh
+++ b/scripts/init_chain_commands.sh
@@ -53,4 +53,6 @@ lavad tx dualstaking delegate $(lavad keys show servicer2 -a) ETH1 $PROVIDERSTAK
 wait_count_blocks 1
 lavad tx dualstaking delegate $(lavad keys show servicer3 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 
+if [[ "$1" != "--skip-providers" ]]; then
 . ${__dir}/setup_providers.sh
+fi

--- a/scripts/simulate_reward_payment.sh
+++ b/scripts/simulate_reward_payment.sh
@@ -1,60 +1,7 @@
 #!/bin/bash 
 
 echo "Executing init_chain_commands"
-
-__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source $__dir/useful_commands.sh
-. ${__dir}/vars/variables.sh
-# Making sure old screens are not running
-echo "current vote number $(latest_vote)"
-killall screen
-screen -wipe
-GASPRICE="0.000000001ulava"
-
-# ,./cookbook/specs/spec_add_mantle.json
-lavad tx gov submit-legacy-proposal spec-add ./cookbook/specs/spec_add_ibc.json,./cookbook/specs/spec_add_cosmoswasm.json,./cookbook/specs/spec_add_cosmossdk.json,./cookbook/specs/spec_add_cosmossdk_45.json,./cookbook/specs/spec_add_cosmossdk_full.json,./cookbook/specs/spec_add_ethereum.json,./cookbook/specs/spec_add_cosmoshub.json,./cookbook/specs/spec_add_lava.json,./cookbook/specs/spec_add_osmosis.json,./cookbook/specs/spec_add_fantom.json,./cookbook/specs/spec_add_celo.json,./cookbook/specs/spec_add_optimism.json,./cookbook/specs/spec_add_arbitrum.json,./cookbook/specs/spec_add_starknet.json,./cookbook/specs/spec_add_aptos.json,./cookbook/specs/spec_add_juno.json,./cookbook/specs/spec_add_polygon.json,./cookbook/specs/spec_add_evmos.json,./cookbook/specs/spec_add_base.json,./cookbook/specs/spec_add_canto.json,./cookbook/specs/spec_add_sui.json,./cookbook/specs/spec_add_solana.json,./cookbook/specs/spec_add_bsc.json,./cookbook/specs/spec_add_axelar.json,./cookbook/specs/spec_add_avalanche.json,./cookbook/specs/spec_add_fvm.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
-wait_count_blocks 2
-echo "submitted first proposal"
-echo "latest vote2: $(latest_vote)"
-lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
-wait_count_blocks 4
-echo "voted on first proposal"
-sleep 4
-lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/default.json,./cookbook/plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_count_blocks 2
-lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_count_blocks 4
-
-CLIENTSTAKE="500000000000ulava"
-PROVIDERSTAKE="500000000000ulava"
-
-PROVIDER1_LISTENER="127.0.0.1:2221"
-PROVIDER2_LISTENER="127.0.0.1:2222"
-PROVIDER3_LISTENER="127.0.0.1:2223"
-
-sleep 4
-
-lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_count_blocks 2
-lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-lavad tx  subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-# lavad tx project set-policy $(lavad keys show user1 -a)-admin ./cookbook/projects/policy_all_chains_with_addon.yml -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-
-# MANTLE
-CHAINS="ETH1,GTH1,COS3,FTM250,CELO,LAV1,COS4,ALFAJORES,ARB1,ARBN,APT1,STRK,JUN1,COS5,POLYGON1,EVMOS,OPTM,BASET,CANTO,SUIT,SOLANA,BSC,AXELAR,AVAX,FVM"
-# stake providers on all chains
-lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER1_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer1 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER2_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer2 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER3_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer3 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-
-# we need to wait for the next epoch for the stake to take action.
-sleep_until_next_epoch
-
-lavad tx dualstaking delegate $(lavad keys show servicer1 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_count_blocks 1
-lavad tx dualstaking delegate $(lavad keys show servicer2 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_count_blocks 1
-lavad tx dualstaking delegate $(lavad keys show servicer3 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+./scripts/init_chain_commands.sh --skip-providers
 
 # Step 1: Get the balance of servicer1
 initial_balance=$(lavad q bank balances $(lavad keys show servicer1 -a))

--- a/scripts/simulate_reward_payment.sh
+++ b/scripts/simulate_reward_payment.sh
@@ -1,0 +1,78 @@
+#!/bin/bash 
+
+echo "Executing init_chain_commands"
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $__dir/useful_commands.sh
+. ${__dir}/vars/variables.sh
+# Making sure old screens are not running
+echo "current vote number $(latest_vote)"
+killall screen
+screen -wipe
+GASPRICE="0.000000001ulava"
+
+# ,./cookbook/specs/spec_add_mantle.json
+lavad tx gov submit-legacy-proposal spec-add ./cookbook/specs/spec_add_ibc.json,./cookbook/specs/spec_add_cosmoswasm.json,./cookbook/specs/spec_add_cosmossdk.json,./cookbook/specs/spec_add_cosmossdk_45.json,./cookbook/specs/spec_add_cosmossdk_full.json,./cookbook/specs/spec_add_ethereum.json,./cookbook/specs/spec_add_cosmoshub.json,./cookbook/specs/spec_add_lava.json,./cookbook/specs/spec_add_osmosis.json,./cookbook/specs/spec_add_fantom.json,./cookbook/specs/spec_add_celo.json,./cookbook/specs/spec_add_optimism.json,./cookbook/specs/spec_add_arbitrum.json,./cookbook/specs/spec_add_starknet.json,./cookbook/specs/spec_add_aptos.json,./cookbook/specs/spec_add_juno.json,./cookbook/specs/spec_add_polygon.json,./cookbook/specs/spec_add_evmos.json,./cookbook/specs/spec_add_base.json,./cookbook/specs/spec_add_canto.json,./cookbook/specs/spec_add_sui.json,./cookbook/specs/spec_add_solana.json,./cookbook/specs/spec_add_bsc.json,./cookbook/specs/spec_add_axelar.json,./cookbook/specs/spec_add_avalanche.json,./cookbook/specs/spec_add_fvm.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
+wait_count_blocks 2
+echo "submitted first proposal"
+echo "latest vote2: $(latest_vote)"
+lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
+wait_count_blocks 4
+echo "voted on first proposal"
+sleep 4
+lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/default.json,./cookbook/plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_count_blocks 2
+lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_count_blocks 4
+
+CLIENTSTAKE="500000000000ulava"
+PROVIDERSTAKE="500000000000ulava"
+
+PROVIDER1_LISTENER="127.0.0.1:2221"
+PROVIDER2_LISTENER="127.0.0.1:2222"
+PROVIDER3_LISTENER="127.0.0.1:2223"
+
+sleep 4
+
+lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_count_blocks 2
+lavad tx gov vote $(latest_vote) yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx  subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+# lavad tx project set-policy $(lavad keys show user1 -a)-admin ./cookbook/projects/policy_all_chains_with_addon.yml -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+# MANTLE
+CHAINS="ETH1,GTH1,COS3,FTM250,CELO,LAV1,COS4,ALFAJORES,ARB1,ARBN,APT1,STRK,JUN1,COS5,POLYGON1,EVMOS,OPTM,BASET,CANTO,SUIT,SOLANA,BSC,AXELAR,AVAX,FVM"
+# stake providers on all chains
+lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER1_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer1 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER2_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer2 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad tx pairing bulk-stake-provider $CHAINS $PROVIDERSTAKE "$PROVIDER3_LISTENER,1" 1 -y --delegate-commission 50 --delegate-limit $PROVIDERSTAKE --from servicer3 --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+# we need to wait for the next epoch for the stake to take action.
+sleep_until_next_epoch
+
+lavad tx dualstaking delegate $(lavad keys show servicer1 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_count_blocks 1
+lavad tx dualstaking delegate $(lavad keys show servicer2 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_count_blocks 1
+lavad tx dualstaking delegate $(lavad keys show servicer3 -a) ETH1 $PROVIDERSTAKE -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+# Step 1: Get the balance of servicer1
+initial_balance=$(lavad q bank balances $(lavad keys show servicer1 -a))
+echo "Initial Balance of servicer1: $initial_balance"
+initial_value=$(echo "$initial_balance" | awk -F\" '/amount: / {print $2}')
+
+# Step 2: Run simulate tx
+lavad tx pairing simulate-relay-payment user1 LAV1 --from servicer1 --cu-amount 200 --gas-prices 0.00001ulava --gas-adjustment "1.5" --gas "auto" --relay-num 5 --yes
+sleep 2
+
+# Step 3: Check the balance again
+final_balance=$(lavad q bank balances $(lavad keys show servicer1 -a))
+echo "Final Balance of servicer1: $final_balance"
+final_value=$(echo "$final_balance" | awk -F\" '/amount: / {print $2}')
+
+if (( final_value > initial_value )); then
+    echo "Success: Final balance is greater than the initial balance"
+else
+    echo "Error: Final balance is not greater than the initial balance"
+    exit 1
+fi

--- a/x/pairing/client/cli/tx.go
+++ b/x/pairing/client/cli/tx.go
@@ -41,6 +41,8 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdFreeze())
 	cmd.AddCommand(CmdUnfreeze())
 	cmd.AddCommand(CmdModifyProvider())
+	cmd.AddCommand(CmdSimulateRelayPayment())
+
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -61,10 +62,10 @@ func CmdSimulateRelayPayment() *cobra.Command {
 			fmt.Println("SIM cuAmount: ", cuAmount)
 
 			// Session ID
-			sessionId := uint64(0)
+			sessionId := uint64(time.Now().UnixNano())
 
 			// Provider
-			providerAddr, _ := cmd.Flags().GetString(flags.FlagFrom)
+			providerAddr := clientCtx.GetFromAddress().String()
 			fmt.Println("SIM providerAddr: ", providerAddr)
 
 			// Relay Num

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -197,7 +196,6 @@ func extractEpoch(clientCtx client.Context, epochValue uint64) (epoch int64, err
 		return 0, err
 	}
 	latestBlockHeight := status.SyncInfo.LatestBlockHeight
-	fmt.Println("latestBlockHeight: ", latestBlockHeight)
 
 	epoch = calculateEpochFromBlockHeight(latestBlockHeight)
 	return epoch, nil

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -110,7 +110,7 @@ func CmdSimulateRelayPayment() *cobra.Command {
 			msg := types.NewMsgRelayPayment(
 				clientCtx.GetFromAddress().String(),
 				relaySessions,
-				"",
+				"Simulation for RelayPayment",
 			)
 			utils.LavaFormatInfo("Message Data ", utils.Attribute{Key: "msg", Value: msg})
 

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lavanet/lava/x/pairing/types"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+const (
+	QoSValuesFlag = "qos-values"
+	CuAmountFlag  = "cu-amount"
+)
+
+func CmdSimulateRelayPayment() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "simulate-relay-payment [consumer-key] [spec-id]",
+		Short: "Create & broadcast message relayPayment for simulation",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Extract arguments
+			// consumerKey := args[0]
+			specId := args[1]
+
+			// CU
+			cuAmount, err := cmd.Flags().GetUint64("cu-amount")
+			if err != nil {
+				return err
+			}
+
+			// Session ID
+			sessionId := uint64(0)
+
+			// Provider
+			providerAddr, _ := cmd.Flags().GetString(flags.FlagFrom)
+
+			// Relay Num
+			relayNum := uint64(0)
+
+			// Create RelaySession
+			relaySession := &types.RelaySession{
+				SpecId:    specId,
+				SessionId: sessionId,
+				CuSum:     cuAmount,
+				Provider:  providerAddr,
+				RelayNum:  relayNum,
+			}
+
+			msg := types.NewMsgRelayPayment(
+				clientCtx.GetFromAddress().String(),
+				[]*types.RelaySession{relaySession},
+				"",
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	cmd.MarkFlagRequired(flags.FlagFrom)
+	cmd.Flags().StringSlice(QoSValuesFlag, []string{"1", "1", "1"}, "QoS values: latency, availability, sync scores")
+	cmd.Flags().Uint64(CuAmountFlag, 0, "CU serviced by the provider")
+
+	return cmd
+}

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -99,7 +99,7 @@ func CmdSimulateRelayPayment() *cobra.Command {
 
 				sig, err := sigs.Sign(privKey, *relaySession)
 				if err != nil {
-					return err // consider whether you want to return or continue to the next iteration
+					return err
 				}
 				// Set Sig
 				relaySession.Sig = sig

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -123,8 +123,7 @@ func CmdSimulateRelayPayment() *cobra.Command {
 
 	flags.AddTxFlagsToCmd(cmd)
 	cmd.MarkFlagRequired(flags.FlagFrom)
-	cmd.Flags().Uint64(CuAmountFlag, 0, "CU serviced by the provider")
-	cmd.MarkFlagRequired(CuAmountFlag)
+	cmd.Flags().Uint64(CuAmountFlag, 1, "CU serviced by the provider")
 	cmd.Flags().Uint64(RelayNumFlag, 1, "Number of relays")
 	cmd.Flags().StringSlice(QoSValuesFlag, []string{"1", "1", "1"}, "QoS values: latency, availability, sync scores")
 	cmd.Flags().Uint64(EpochFlag, 0, "Epoch value to be used. If not set, it will be queried from the chain.")

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/utils/sigs"
+	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cobra"
 )
@@ -191,18 +192,12 @@ func extractEpoch(clientCtx client.Context, epochValue uint64) (epoch int64, err
 	if epochValue != 0 {
 		return int64(epochValue), nil
 	}
-	status, err := clientCtx.Client.Status(context.Background())
+	ctx := context.Background()
+	epochStorageQuerier := epochstoragetypes.NewQueryClient(clientCtx)
+	params := &epochstoragetypes.QueryGetEpochDetailsRequest{}
+	epochDetails, err := epochStorageQuerier.EpochDetails(ctx, params)
 	if err != nil {
-		return 0, err
+		return int64(0), err
 	}
-	latestBlockHeight := status.SyncInfo.LatestBlockHeight
-
-	epoch = calculateEpochFromBlockHeight(latestBlockHeight)
-	return epoch, nil
-}
-
-func calculateEpochFromBlockHeight(blockHeight int64) int64 {
-	epochSize := int64(20)
-	remainder := blockHeight % epochSize
-	return blockHeight - remainder
+	return int64(epochDetails.EpochDetails.StartBlock), nil
 }

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -192,10 +192,9 @@ func extractEpoch(clientCtx client.Context, epochValue uint64) (epoch int64, err
 	if epochValue != 0 {
 		return int64(epochValue), nil
 	}
-	ctx := context.Background()
 	epochStorageQuerier := epochstoragetypes.NewQueryClient(clientCtx)
 	params := &epochstoragetypes.QueryGetEpochDetailsRequest{}
-	epochDetails, err := epochStorageQuerier.EpochDetails(ctx, params)
+	epochDetails, err := epochStorageQuerier.EpochDetails(context.Background(), params)
 	if err != nil {
 		return int64(0), err
 	}

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -86,7 +86,6 @@ func CmdSimulateRelayPayment() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println("clientCtx.Height: ", clientCtx.Height)
 			epoch, err := extractEpoch(clientCtx, epochValue)
 			if err != nil {
 				return err
@@ -94,7 +93,7 @@ func CmdSimulateRelayPayment() *cobra.Command {
 			fmt.Println("SIM epoch: ", epoch)
 
 			// Create RelaySession
-			relaySession := newRelaySession(specId, sessionId, cuAmount, providerAddr, relayNum, qosReport, 20, clientCtx.ChainID)
+			relaySession := newRelaySession(specId, sessionId, cuAmount, providerAddr, relayNum, qosReport, epoch, clientCtx.ChainID)
 			fmt.Println("SIM relaySession before sig: ", relaySession)
 
 			sig, err := sigs.Sign(privKey, *relaySession)


### PR DESCRIPTION
<h2>Description</h2>
This PR implements a CLI command for simulating reward payment operation without the need for bootstrapping providers. It creates`RelaySession` object, wraps it into a message and sends it to network.

**Example Command:**
 `lavad tx pairing simulate-relay-payment user1 LAV1 --from servicer1 --cu-amount 222 --gas-prices 0.00001ulava --gas-adjustment "1.5" --gas "auto" --relay-num 50 --yes`

<h2>Automatization</h2>
`simulate_reward_payment.sh` script does the following :

- Executes the `init_chain_commands.sh` script **without initializing providers.**
- Retrieves and displays the initial balance of the `servicer1` provider.
- Runs the CLI command to simulate reward payment.
- Fetches and displays the final balance of `servicer1`.
- Compares the initial and final balances, and prompts a success message if the final balance is greater than the initial balance, and an error message otherwise.