### PR TITLE
[PRT-926] Enable named params in tendermint

### DIFF
--- a/ecosystem/lava-sdk/src/chainlib/base_chain_parser.ts
+++ b/ecosystem/lava-sdk/src/chainlib/base_chain_parser.ts
@@ -23,7 +23,7 @@ export const HeadersPassSend = Header.HeaderType.PASS_SEND;
  */
 export interface SendRelayOptions {
   method: string; // Required: The RPC method to be called
-  params: Array<any>; // Required: An array of parameters to be passed to the RPC method
+  params: Array<any> | Record<string, any>; // Required: An array of parameters to be passed to the RPC method
   id?: number | string; // Optional: The ID of the relay. If not specified, it is set to a random number.
   chainId?: string; // Optional: The chain id to send the request to, if only one chain is initialized it will be chosen by default
   metadata?: Metadata[]; // Optional: Headers to be sent with the request.

--- a/testutil/e2e/sdk/tests/tendermintrpc_chainid_fetch.ts
+++ b/testutil/e2e/sdk/tests/tendermintrpc_chainid_fetch.ts
@@ -1,4 +1,4 @@
-const { LavaSDK } = require("../../../../ecosystem/lava-sdk/bin/src/sdk/sdk");
+import { LavaSDK } from "../../../../ecosystem/lava-sdk/bin/src/sdk/sdk";
 
 async function main() {
     // Initialize Lava SDK

--- a/testutil/e2e/sdk/tests/tendermintrpc_named_params.ts
+++ b/testutil/e2e/sdk/tests/tendermintrpc_named_params.ts
@@ -1,0 +1,41 @@
+import { LavaSDK } from "../../../../ecosystem/lava-sdk/bin/src/sdk/sdk";
+
+async function main() {
+    // Initialize Lava SDK
+    const lavaSDKTendermint = await LavaSDK.create({
+        privateKey: process.env.PRIVATE_KEY,
+        chainIds: "LAV1",
+        lavaChainId:"lava",
+        pairingListConfig:process.env.PAIRING_LIST,
+        allowInsecureTransport: true,
+        logLevel: "debug",
+    }).catch(e => {
+        throw new Error(" ERR [tendermintrpc_named_params] failed setting lava-sdk tendermint test");
+    });
+
+    const blockHeight = 1
+
+    const block = await lavaSDKTendermint.sendRelay({
+        method: "block",
+        params: { height: blockHeight },
+    }).catch(e => {
+        throw new Error(` ERR [tendermintrpc_named_params] failed fetching block using tendermint named params`);
+    });
+
+    // Validate block number
+    if (block.result.block.header.height != blockHeight) {
+        throw new Error(" ERR [tendermintrpc_named_params] Block number is not equal to the fetched block");
+    }else{
+        console.log("[tendermintrpc_named_params] Success: Fetching Lava block using tendermintrpc named params passed");
+    }
+}
+
+(async () => {
+    try {
+        await main();
+        process.exit(0);
+    } catch (error) {
+        console.error(" ERR [tendermintrpc_chainid_fetch] "+error.message);
+        process.exit(1);
+    }
+})();

--- a/testutil/e2e/sdk/tests/tendermintrpc_named_params.ts
+++ b/testutil/e2e/sdk/tests/tendermintrpc_named_params.ts
@@ -13,7 +13,7 @@ async function main() {
         throw new Error(" ERR [tendermintrpc_named_params] failed setting lava-sdk tendermint test");
     });
 
-    const blockHeight = 1
+    const blockHeight = "1"
 
     const block = await lavaSDKTendermint.sendRelay({
         method: "block",


### PR DESCRIPTION
Add support for tendemint named params in SDK.

Manual test:
```
  const cosmosHub = await LavaSDK.create({
    // private key with an active subscription
    privateKey:
      <PrivKey>,

    // chainID for Cosmos Hub
    chainIds: "LAV1",

    // geolocation 1 for North america - geolocation 2 for Europe providers
    // default value is 1
    geolocation: "1",

    pairingListConfig: "pairingList.json",

    lavaChainId: "lava",

    logLevel: "debug",

    allowInsecureTransport: true,
  });

  // Get abci_info

  const info = await cosmosHub.sendRelay({
    method: "block",
    params: { height: "100" },
  });

  console.log("Info:", info);
```