### PR TITLE
CNS-671: stabilizing unresponsive unit test

### DIFF
--- a/x/pairing/keeper/unresponsive_provider_test.go
+++ b/x/pairing/keeper/unresponsive_provider_test.go
@@ -73,6 +73,27 @@ func TestUnresponsivenessStressTest(t *testing.T) {
 		require.Nil(t, err)
 		providerIndex := rand.Intn(len(pairing.Providers))
 		providerAddress := pairing.Providers[providerIndex].Address
+		// NOTE: the following loop contains a random factor in it. We make sure that we pick
+		// a provider in random that is not one of the defined unresponsive providers
+		// If we did, we pick one of the providers in random again and check whether it's
+		// one of the unresponsive ones.
+		// With a large number of provider and a small number of unresponsive providers,
+		// this is very likely not to get stuck in an infinite loop
+		for {
+			isProviderUnresponsive := false
+			for _, unresponsiveProviderList := range unresponsiveDataList {
+				for _, unresponsiveProvider := range unresponsiveProviderList {
+					if providerAddress == unresponsiveProvider.Address {
+						isProviderUnresponsive = true
+					}
+				}
+			}
+			if !isProviderUnresponsive {
+				break
+			}
+			providerIndex = rand.Intn(len(pairing.Providers))
+			providerAddress = pairing.Providers[providerIndex].Address
+		}
 		providerSdkAddress, err := sdk.AccAddressFromBech32(providerAddress)
 		require.Nil(t, err)
 


### PR DESCRIPTION
In the unresponsive stress test, we had a random factor in which in some cases would cause the test to fail. The problem was (in general) that we picked some provider to be the test unresponsive provider and from time to time picked it to send a relay payment TX reporting on itself that it's unresponsive. This made it avoid punishment and fail the test.