### PR TITLE
CNS-669: Axelar missing APIs

### DIFF
--- a/cookbook/specs/spec_add_avalanche.json
+++ b/cookbook/specs/spec_add_avalanche.json
@@ -196,7 +196,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging" : true
+                                    "hanging_api" : true
                                 },
                                 "extra_compute_units": 0
                             }
@@ -229,7 +229,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging" : true
+                                    "hanging_api" : true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -502,7 +502,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging" : true
+                                    "hanging_api" : true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -699,7 +699,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging" : true
+                                    "hanging_api" : true
                                 },
                                 "extra_compute_units": 0
                             }

--- a/cookbook/specs/spec_add_avalanche.json
+++ b/cookbook/specs/spec_add_avalanche.json
@@ -195,7 +195,8 @@
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging" : true
                                 },
                                 "extra_compute_units": 0
                             }
@@ -227,7 +228,8 @@
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging" : true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -499,7 +501,8 @@
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging" : true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -695,7 +698,8 @@
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging" : true
                                 },
                                 "extra_compute_units": 0
                             }

--- a/cookbook/specs/spec_add_axelar.json
+++ b/cookbook/specs/spec_add_axelar.json
@@ -683,6 +683,800 @@
                     {
                         "enabled": true,
                         "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [
+                            {
+                                "name": "/axelar/axelarnet/add_cosmos_based_chain",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/call_contract",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/confirm_deposit",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/execute_pending_transfers",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/link",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/register_asset",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/register_fee_collector",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/retry_ibc_transfer",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/route_ibc_transfers",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/route_message",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/add_chain",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/confirm_deposit",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/confirm_gateway_tx",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/confirm_gateway_txs",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/confirm_token",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/confirm_transfer_key",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/create_burn_tokens",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/create_deploy_token",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/create_pending_transfers",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/create_transfer_operatorship",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/link",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/retry-failed-event",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/set_gateway",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/sign_commands",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/rotate_key",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/start_keygen",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/submit_pub_key",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/submit_signature",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/v1beta1/keygen_opt_in",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/v1beta1/keygen_opt_out",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/activate_chain",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/deactivate_chain",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/deregister_chain_maintainer",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/register_asset_fee",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/register_chain_maintainer",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/set_transfer_rate_limit",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/reward/refund_message",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/snapshot/deactivate_proxy",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/snapshot/register_proxy",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/tss/heartbeat",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/vote/vote",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": []
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
                             "api_interface": "grpc",
                             "internal_path": "",
                             "type": "",

--- a/cookbook/specs/spec_add_axelar.json
+++ b/cookbook/specs/spec_add_axelar.json
@@ -1611,6 +1611,63 @@
                                     "hanging": true
                                 },
                                 "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/permission/deregister_controller",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/permission/register_controller",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/permission/update_governance_key",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging": true
+                                },
+                                "extra_compute_units": 0
                             }
                         ],
                         "headers": [],

--- a/cookbook/specs/spec_add_axelar.json
+++ b/cookbook/specs/spec_add_axelar.json
@@ -1775,6 +1775,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "axelar.evm.v1beta1.QueryService/Command",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "axelar.evm.v1beta1.QueryService/ConfirmationHeight",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -1902,24 +1920,6 @@
                             },
                             {
                                 "name": "axelar.evm.v1beta1.QueryService/TokenInfo",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": true,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "axelar.evm.v1beta1.QueryService/Command",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"
@@ -2135,6 +2135,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "axelar.nexus.v1beta1.QueryService/Message",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "axelar.nexus.v1beta1.QueryService/RecipientAddress",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -2190,24 +2208,6 @@
                             },
                             {
                                 "name": "axelar.nexus.v1beta1.QueryService/TransfersForChain",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": true,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "axelar.nexus.v1beta1.QueryService/Message",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"

--- a/cookbook/specs/spec_add_axelar.json
+++ b/cookbook/specs/spec_add_axelar.json
@@ -664,6 +664,150 @@
                                     "stateful": 0
                                 },
                                 "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/axelarnet/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/evm/v1beta1/params/{chain}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/multisig/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/nexus/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/snapshot/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/tss/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/vote/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/axelar/permission/v1beta1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             }
                         ],
                         "headers": [],

--- a/cookbook/specs/spec_add_axelar.json
+++ b/cookbook/specs/spec_add_axelar.json
@@ -848,7 +848,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -867,7 +867,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -886,7 +886,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -905,7 +905,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -924,7 +924,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -943,7 +943,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -962,7 +962,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -981,7 +981,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1000,7 +1000,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1019,7 +1019,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1038,7 +1038,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1057,7 +1057,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1076,7 +1076,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1095,7 +1095,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1114,7 +1114,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1133,7 +1133,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1152,7 +1152,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1171,7 +1171,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1190,7 +1190,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1209,7 +1209,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1228,7 +1228,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1247,7 +1247,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1266,7 +1266,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1285,7 +1285,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1304,7 +1304,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1323,7 +1323,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1342,7 +1342,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1361,7 +1361,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1380,7 +1380,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1399,7 +1399,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1418,7 +1418,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1437,7 +1437,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1456,7 +1456,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1475,7 +1475,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1494,7 +1494,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1513,7 +1513,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1532,7 +1532,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1551,7 +1551,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1570,7 +1570,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1589,7 +1589,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1608,7 +1608,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1627,7 +1627,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1646,7 +1646,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },
@@ -1665,7 +1665,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             }

--- a/cookbook/specs/spec_add_fvm.json
+++ b/cookbook/specs/spec_add_fvm.json
@@ -427,7 +427,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },

--- a/cookbook/specs/spec_add_fvm.json
+++ b/cookbook/specs/spec_add_fvm.json
@@ -426,7 +426,8 @@
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging": true
                                 },
                                 "extra_compute_units": 0
                             },

--- a/cookbook/specs/spec_add_near.json
+++ b/cookbook/specs/spec_add_near.json
@@ -269,13 +269,13 @@
                                     ],
                                     "parser_func": "DEFAULT"
                                 },
-                                "compute_units": 100,
+                                "compute_units": 10,
                                 "enabled": true,
                                 "category": {
                                     "deterministic": false,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0,
+                                    "stateful": 1,
                                     "hanging_api": true
                                 },
                                 "extra_compute_units": 0

--- a/cookbook/specs/spec_add_solana.json
+++ b/cookbook/specs/spec_add_solana.json
@@ -945,7 +945,8 @@
                                     "deterministic": true,
                                     "local": false,
                                     "subscription": false,
-                                    "stateful": 0
+                                    "stateful": 1,
+                                    "hanging": true
                                 },
                                 "extra_compute_units": 0
                             },

--- a/cookbook/specs/spec_add_solana.json
+++ b/cookbook/specs/spec_add_solana.json
@@ -946,7 +946,7 @@
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 1,
-                                    "hanging": true
+                                    "hanging_api": true
                                 },
                                 "extra_compute_units": 0
                             },


### PR DESCRIPTION
Added the following APIs to Axelar:

POST
/axelar/permission/deregister_controller
/axelar/permission/register_controller
/axelar/permission/update_governance_key

GET
/axelar/axelarnet/v1beta1/params
/axelar/evm/v1beta1/params/{chain}
/axelar/multisig/v1beta1/params
/axelar/nexus/v1beta1/params
/axelar/snapshot/v1beta1/params
/axelar/tss/v1beta1/params
/axelar/vote/v1beta1/params
/axelar/permission/v1beta1/params

Also fixed the "hanging_api" field in some specs