### PR TITLE
CNS-670: updated FVM spec

### DIFF
--- a/cookbook/specs/spec_add_fvm.json
+++ b/cookbook/specs/spec_add_fvm.json
@@ -107,24 +107,6 @@
                                 "extra_compute_units": 0
                             },
                             {
-                                "name": "Filecoin.ChainGetNode",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
                                 "name": "Filecoin.ChainGetParentMessages",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -185,24 +167,6 @@
                                         "latest"
                                     ],
                                     "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": true,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "Filecoin.ChainGetTipSetAfterHeight",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "0"
-                                    ],
-                                    "parser_func": "PARSE_BY_ARG"
                                 },
                                 "compute_units": 10,
                                 "enabled": true,
@@ -305,6 +269,42 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "Filecoin.ChainStatObj",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "Filecoin.ChainTipSetWeight",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "Filecoin.ClientQueryAsk",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -377,6 +377,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "Filecoin.GasEstimateMessageGas",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "Filecoin.MpoolGetNonce",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -414,6 +432,25 @@
                             },
                             {
                                 "name": "Filecoin.MpoolPush",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 1,
+                                    "hanging_api": true
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "Filecoin.MpoolSub",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"
@@ -487,6 +524,24 @@
                             },
                             {
                                 "name": "Filecoin.StateChangedActors",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "Filecoin.StateCirculatingSupply",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"
@@ -1225,6 +1280,42 @@
                             },
                             {
                                 "name": "Filecoin.StateVerifierStatus",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "Filecoin.StateWaitMsg",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "Filecoin.StateWaitMsgLimited",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"


### PR DESCRIPTION
Added:
Filecoin.ChainStatObj
Filecoin.ChainTipSetWeight
Filecoin.GasEstimateMessageGas
Filecoin.MpoolSub
Filecoin.StateCirculatingSupply
Filecoin.StateWaitMsg
Filecoin.StateWaitMsgLimited

Removed (deprecated):
Filecoin.ChainGetNode
Filecoin.ChainGetTipSetAfterHeight