### PR TITLE
CNS-756: fix queries support for --height flag

### DIFF
--- a/cmd/lavad/cmd/genaccounts.go
+++ b/cmd/lavad/cmd/genaccounts.go
@@ -37,7 +37,10 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 			cdc := clientCtx.Codec
 
 			serverCtx := server.GetServerContextFromCmd(cmd)

--- a/x/conflict/client/cli/query_conflict_vote.go
+++ b/x/conflict/client/cli/query_conflict_vote.go
@@ -14,7 +14,10 @@ func CmdListConflictVote() *cobra.Command {
 		Use:   "list-conflict-vote",
 		Short: "list all ConflictVote",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowConflictVote() *cobra.Command {
 		Short: "shows a ConflictVote",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/conflict/client/cli/query_consumer_conflicts.go
+++ b/x/conflict/client/cli/query_consumer_conflicts.go
@@ -13,7 +13,10 @@ func CmdConsumerConflicts() *cobra.Command {
 		Short: "Gets a consumer's active conflict list",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/conflict/client/cli/query_params.go
+++ b/x/conflict/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/conflict/client/cli/query_provider_conflicts.go
+++ b/x/conflict/client/cli/query_provider_conflicts.go
@@ -13,7 +13,10 @@ func CmdProviderConflicts() *cobra.Command {
 		Short: "Queries a provider's conflict list (ones that the provider was reported in and ones that the provider needs to vote)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/downtime/client/cli/query.go
+++ b/x/downtime/client/cli/query.go
@@ -23,7 +23,10 @@ func CmdQueryParams() *cobra.Command {
 		Use:   "params",
 		Short: "Query downtime module params",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 			queryClient := v1.NewQueryClient(clientCtx)
 			resp, err := queryClient.QueryParams(cmd.Context(), &v1.QueryParamsRequest{})
 			if err != nil {
@@ -45,7 +48,10 @@ func CmdQueryDowntime() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 			queryClient := v1.NewQueryClient(clientCtx)
 			resp, err := queryClient.QueryDowntime(cmd.Context(), &v1.QueryDowntimeRequest{
 				EpochStartBlock: start,

--- a/x/epochstorage/client/cli/query_epoch_details.go
+++ b/x/epochstorage/client/cli/query_epoch_details.go
@@ -15,7 +15,10 @@ func CmdShowEpochDetails() *cobra.Command {
 		Short: "shows epochDetails",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/epochstorage/client/cli/query_fixated_params.go
+++ b/x/epochstorage/client/cli/query_fixated_params.go
@@ -14,7 +14,10 @@ func CmdListFixatedParams() *cobra.Command {
 		Use:   "list-fixated-params",
 		Short: "list all fixatedParams",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowFixatedParams() *cobra.Command {
 		Short: "shows a fixatedParams",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/epochstorage/client/cli/query_params.go
+++ b/x/epochstorage/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/epochstorage/client/cli/query_stake_storage.go
+++ b/x/epochstorage/client/cli/query_stake_storage.go
@@ -14,7 +14,10 @@ func CmdListStakeStorage() *cobra.Command {
 		Use:   "list-stake-storage",
 		Short: "list all StakeStorage",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowStakeStorage() *cobra.Command {
 		Short: "shows a StakeStorage",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/pairing/client/cli/query_epoch_payments.go
+++ b/x/pairing/client/cli/query_epoch_payments.go
@@ -14,7 +14,10 @@ func CmdListEpochPayments() *cobra.Command {
 		Use:   "list-epoch-payments",
 		Short: "list all EpochPayments",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowEpochPayments() *cobra.Command {
 		Short: "shows a EpochPayments",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/pairing/client/cli/query_params.go
+++ b/x/pairing/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/pairing/client/cli/query_provider_payment_storage.go
+++ b/x/pairing/client/cli/query_provider_payment_storage.go
@@ -14,7 +14,10 @@ func CmdListProviderPaymentStorage() *cobra.Command {
 		Use:   "list-provider-payment-storage",
 		Short: "list all ProviderPaymentStorage",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowProviderPaymentStorage() *cobra.Command {
 		Short: "shows a ProviderPaymentStorage",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/pairing/client/cli/query_unique_payment_storage_client_provider.go
+++ b/x/pairing/client/cli/query_unique_payment_storage_client_provider.go
@@ -14,7 +14,10 @@ func CmdListUniquePaymentStorageClientProvider() *cobra.Command {
 		Use:   "list-unique-payment-storage-client-provider",
 		Short: "list all UniquePaymentStorageClientProvider",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -48,7 +51,10 @@ func CmdShowUniquePaymentStorageClientProvider() *cobra.Command {
 		Short: "shows a UniquePaymentStorageClientProvider",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/plans/client/cli/query_params.go
+++ b/x/plans/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/projects/client/cli/query_params.go
+++ b/x/projects/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/protocol/client/cli/query_params.go
+++ b/x/protocol/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/spec/client/cli/query_params.go
+++ b/x/spec/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/spec/client/cli/query_spec.go
+++ b/x/spec/client/cli/query_spec.go
@@ -16,7 +16,10 @@ func CmdListSpec() *cobra.Command {
 		Use:   "list-spec",
 		Short: "list all Spec",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -59,7 +62,10 @@ func CmdShowSpec() *cobra.Command {
 		Short: "shows a Spec",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/subscription/client/cli/query_params.go
+++ b/x/subscription/client/cli/query_params.go
@@ -15,7 +15,10 @@ func CmdQueryParams() *cobra.Command {
 		Short: "shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 


### PR DESCRIPTION
To allow the --height flag to work, I replaced all GetClientContextFromCmd with GetClientQueryContext