### PR TITLE
CNS-816: limit project keys

### DIFF
--- a/x/projects/keeper/creation.go
+++ b/x/projects/keeper/creation.go
@@ -68,6 +68,15 @@ func (k Keeper) CreateAdminProject(ctx sdk.Context, subAddr string, plan plantyp
 func (k Keeper) CreateProject(ctx sdk.Context, subAddr string, projectData types.ProjectData, plan plantypes.Plan) error {
 	ctxBlock := uint64(ctx.BlockHeight())
 
+	if len(projectData.ProjectKeys) > types.MAX_KEYS_AMOUNT {
+		return utils.LavaFormatWarning("create project failed", fmt.Errorf("max number of keys for project exceeded"),
+			utils.LogAttr("project", projectData.Name),
+			utils.LogAttr("block", ctxBlock),
+			utils.LogAttr("project_keys_amount", len(projectData.ProjectKeys)),
+			utils.LogAttr("max_keys_allowed", types.MAX_KEYS_AMOUNT),
+		)
+	}
+
 	// project creation takes effect retroactively at the beginning of the current epoch
 	epoch, _, err := k.epochstorageKeeper.GetEpochStartForBlock(ctx, ctxBlock)
 	if err != nil {

--- a/x/projects/keeper/project.go
+++ b/x/projects/keeper/project.go
@@ -80,6 +80,17 @@ func (k Keeper) AddKeysToProject(ctx sdk.Context, projectID, adminKey string, pr
 		)
 	}
 
+	if len(project.ProjectKeys)+len(projectKeys) > types.MAX_KEYS_AMOUNT {
+		return utils.LavaFormatWarning("failed to add keys", fmt.Errorf("max number of keys for project exceeded"),
+			utils.LogAttr("project", projectID),
+			utils.LogAttr("block", ctxBlock),
+			utils.LogAttr("admin_key", adminKey),
+			utils.LogAttr("current_project_keys_amount", len(project.ProjectKeys)),
+			utils.LogAttr("keys_to_add_amount", len(projectKeys)),
+			utils.LogAttr("max_keys_allowed", types.MAX_KEYS_AMOUNT),
+		)
+	}
+
 	// note that realBlockNextEpoch is expected to always be at epoch boundaries (except
 	// perhaps the first epoch of deploying this version, but that's ephemeral)
 

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1257,4 +1258,55 @@ func TestPendingProject(t *testing.T) {
 	devRes, err = ts.QueryProjectDeveloper(sub)
 	require.NoError(t, err)
 	require.Nil(t, devRes.PendingProject)
+}
+
+// TestMaxKeysInProject tests that the max amount of keys in project is enforced as expected
+// scenarios:
+// 1. add keys to existing project and try to exceed max amount
+// 2. delete one key (from project with max keys) and make sure you can add one more key
+// 3. try to create a project with more keys than max to begin with
+func TestMaxKeysInProject(t *testing.T) {
+	ts := newTester(t)
+	ts.SetupAccounts(1, types.MAX_KEYS_AMOUNT+1, 0)
+
+	// create dummy keys
+	var dummyKeys []types.ProjectKey
+	for i := 1; i <= types.MAX_KEYS_AMOUNT+1; i++ {
+		_, admin := ts.Account("adm" + strconv.Itoa(i))
+		dummyKeys = append(dummyKeys, types.ProjectAdminKey(admin))
+	}
+
+	// buy subscription. has one key (auto-generated admin key)
+	_, sub := ts.Account("sub1")
+	_, err := ts.TxSubscriptionBuy(sub, sub, "free", 1, false, false)
+	require.NoError(t, err)
+	res, err := ts.QueryProjectDeveloper(sub)
+	require.NoError(t, err)
+	proj := res.Project
+
+	// try adding more keys than allowed at once (should fail - one key too much)
+	err = ts.TxProjectAddKeys(proj.Index, sub, dummyKeys...)
+	require.Error(t, err)
+
+	// add MAX_KEYS_AMOUNT-1, should succeed
+	err = ts.TxProjectAddKeys(proj.Index, sub, dummyKeys[2:]...)
+	require.NoError(t, err)
+
+	// delete key and immediately try to add key - should fail since deletion is applied on next epoch
+	err = ts.TxProjectDelKeys(proj.Index, sub, dummyKeys[2])
+	require.NoError(t, err)
+	err = ts.TxProjectAddKeys(proj.Index, sub, dummyKeys[0])
+	require.Error(t, err)
+
+	// wait an epoch and add the previosly added key, should succeed
+	ts.AdvanceEpoch()
+	err = ts.TxProjectAddKeys(proj.Index, sub, dummyKeys[2])
+	require.NoError(t, err)
+
+	// try to add a new project with more keys than allowed, should fail
+	err = ts.TxSubscriptionAddProject(sub, types.ProjectData{
+		Name:        "dummy",
+		ProjectKeys: dummyKeys,
+	})
+	require.Error(t, err)
 }

--- a/x/projects/types/types.go
+++ b/x/projects/types/types.go
@@ -2,6 +2,7 @@ package types
 
 const (
 	MAX_PROJECT_NAME_LEN = 50
+	MAX_KEYS_AMOUNT      = 10
 )
 
 // set policy enum


### PR DESCRIPTION
In this PR, I've limited the number of project keys a project can hold in all times. Defined as a constant (current value = 10).