### PR TITLE
CNS-817: uncapped repeated fields

### DIFF
--- a/x/pairing/keeper/pairing_test.go
+++ b/x/pairing/keeper/pairing_test.go
@@ -2266,7 +2266,7 @@ func TestMaxEndpointPerGeolocationLimit(t *testing.T) {
 	var endpoints []epochstoragetypes.Endpoint
 	geolocations := []int32{planstypes.Geolocation_value["USE"], planstypes.Geolocation_value["EU"]}
 	for _, geo := range geolocations {
-		for i := 0; i < types.MAX_ENDPOINTS_AMOUNT_PER_GEO+1; i++ {
+		for i := 0; i < (2*types.MAX_ENDPOINTS_AMOUNT_PER_GEO)+1; i++ {
 			endpoint := epochstoragetypes.Endpoint{
 				IPPORT:        "123",
 				ApiInterfaces: []string{ts.spec.ApiCollections[0].CollectionData.ApiInterface},
@@ -2276,20 +2276,20 @@ func TestMaxEndpointPerGeolocationLimit(t *testing.T) {
 		}
 	}
 
-	// try staking with MAX_ENDPOINTS_AMOUNT_PER_GEO+1 endpoint in USE, should fail
+	// try staking with 2*MAX_ENDPOINTS_AMOUNT_PER_GEO+1 endpoint in USE, should fail
 	_, addr := ts.AddAccount(common.PROVIDER, 0, testStake)
 	err := ts.StakeProviderExtra(
 		addr,
 		ts.spec,
 		testStake/2,
-		endpoints[:types.MAX_ENDPOINTS_AMOUNT_PER_GEO+1],
+		endpoints[:(2*types.MAX_ENDPOINTS_AMOUNT_PER_GEO)+1],
 		geolocations[0],
 		"dummy_provider",
 	)
 	require.Error(t, err)
 
-	// try staking with MAX_ENDPOINTS_AMOUNT_PER_GEO-1 for USE and EU, should succeed
-	validEndpointsArray := endpoints[1 : len(endpoints)-1]
+	// try staking with MAX_ENDPOINTS_AMOUNT_PER_GEO*2 for USE and EU, should succeed
+	validEndpointsArray := endpoints[types.MAX_ENDPOINTS_AMOUNT_PER_GEO : 3*types.MAX_ENDPOINTS_AMOUNT_PER_GEO]
 	err = ts.StakeProviderExtra(
 		addr,
 		ts.spec,
@@ -2306,7 +2306,7 @@ func TestMaxEndpointPerGeolocationLimit(t *testing.T) {
 		addr,
 		ts.spec,
 		testStake/2,
-		endpoints[:types.MAX_ENDPOINTS_AMOUNT_PER_GEO+1],
+		endpoints[:(2*types.MAX_ENDPOINTS_AMOUNT_PER_GEO)+1],
 		geolocations[0],
 		"dummy_provider",
 	)

--- a/x/pairing/keeper/staking.go
+++ b/x/pairing/keeper/staking.go
@@ -56,6 +56,29 @@ func (k Keeper) StakeNewEntry(ctx sdk.Context, validator, creator, chainID strin
 			utils.Attribute{Key: "geolocation", Value: geolocation},
 		)
 	}
+
+	// validate there are no more than 5 endpoints per geolocation
+	endp_geo_hist := map[int32]int{}
+	for _, endp := range endpointsVerified {
+		counter, ok := endp_geo_hist[endp.Geolocation]
+		if !ok {
+			endp_geo_hist[endp.Geolocation] = 1
+		} else {
+			counter++
+			if counter > types.MAX_ENDPOINTS_AMOUNT_PER_GEO {
+				return utils.LavaFormatWarning("stake provider failed", fmt.Errorf("number of endpoint for geolocation exceeded limit"),
+					utils.LogAttr("creator", creator),
+					utils.LogAttr("chain_id", chainID),
+					utils.LogAttr("moniker", moniker),
+					utils.LogAttr("geolocation", planstypes.Geolocation_name[endp.Geolocation]),
+					utils.LogAttr("max_endpoints_allowed", types.MAX_ENDPOINTS_AMOUNT_PER_GEO),
+				)
+			} else {
+				endp_geo_hist[endp.Geolocation] = counter
+			}
+		}
+	}
+
 	// new staking takes effect from the next block
 	stakeAppliedBlock := uint64(ctx.BlockHeight()) + 1
 

--- a/x/pairing/keeper/staking.go
+++ b/x/pairing/keeper/staking.go
@@ -58,25 +58,14 @@ func (k Keeper) StakeNewEntry(ctx sdk.Context, validator, creator, chainID strin
 	}
 
 	// validate there are no more than 5 endpoints per geolocation
-	endp_geo_hist := map[int32]int{}
-	for _, endp := range endpointsVerified {
-		counter, ok := endp_geo_hist[endp.Geolocation]
-		if !ok {
-			endp_geo_hist[endp.Geolocation] = 1
-		} else {
-			counter++
-			if counter > types.MAX_ENDPOINTS_AMOUNT_PER_GEO {
-				return utils.LavaFormatWarning("stake provider failed", fmt.Errorf("number of endpoint for geolocation exceeded limit"),
-					utils.LogAttr("creator", creator),
-					utils.LogAttr("chain_id", chainID),
-					utils.LogAttr("moniker", moniker),
-					utils.LogAttr("geolocation", planstypes.Geolocation_name[endp.Geolocation]),
-					utils.LogAttr("max_endpoints_allowed", types.MAX_ENDPOINTS_AMOUNT_PER_GEO),
-				)
-			} else {
-				endp_geo_hist[endp.Geolocation] = counter
-			}
-		}
+	if len(endpoints) > len(planstypes.GetGeolocationsFromUint(geolocation))*types.MAX_ENDPOINTS_AMOUNT_PER_GEO {
+		return utils.LavaFormatWarning("stake provider failed", fmt.Errorf("number of endpoint for geolocation exceeded limit"),
+			utils.LogAttr("creator", creator),
+			utils.LogAttr("chain_id", chainID),
+			utils.LogAttr("moniker", moniker),
+			utils.LogAttr("geolocation", geolocation),
+			utils.LogAttr("max_endpoints_allowed", types.MAX_ENDPOINTS_AMOUNT_PER_GEO),
+		)
 	}
 
 	// new staking takes effect from the next block

--- a/x/pairing/types/types.go
+++ b/x/pairing/types/types.go
@@ -21,10 +21,11 @@ const (
 )
 
 const (
-	FlagMoniker         = "provider-moniker"
-	FlagCommission      = "delegate-commission"
-	FlagDelegationLimit = "delegate-limit"
-	MAX_LEN_MONIKER     = 50
+	FlagMoniker                  = "provider-moniker"
+	FlagCommission               = "delegate-commission"
+	FlagDelegationLimit          = "delegate-limit"
+	MAX_LEN_MONIKER              = 50
+	MAX_ENDPOINTS_AMOUNT_PER_GEO = 5 // max number of endpoints per geolocation for provider stake entry
 )
 
 // unresponsiveness consts

--- a/x/projects/keeper/msg_server_add_project_keys.go
+++ b/x/projects/keeper/msg_server_add_project_keys.go
@@ -18,13 +18,6 @@ func (k msgServer) AddKeys(goCtx context.Context, msg *types.MsgAddKeys) (*types
 		)
 	}
 
-	if len(msg.ProjectKeys) > types.MAX_KEYS_AMOUNT {
-		return nil, utils.LavaFormatWarning("cannot add project keys", fmt.Errorf("max number of keys exceeded"),
-			utils.LogAttr("project_keys_amount", len(msg.ProjectKeys)),
-			utils.LogAttr("max_keys_allowed", types.MAX_KEYS_AMOUNT),
-		)
-	}
-
 	for _, projectKey := range msg.GetProjectKeys() {
 		if !projectKey.IsTypeValid() {
 			return nil, utils.LavaFormatWarning(

--- a/x/projects/keeper/msg_server_add_project_keys.go
+++ b/x/projects/keeper/msg_server_add_project_keys.go
@@ -18,6 +18,13 @@ func (k msgServer) AddKeys(goCtx context.Context, msg *types.MsgAddKeys) (*types
 		)
 	}
 
+	if len(msg.ProjectKeys) > types.MAX_KEYS_AMOUNT {
+		return nil, utils.LavaFormatWarning("cannot add project keys", fmt.Errorf("max number of keys exceeded"),
+			utils.LogAttr("project_keys_amount", len(msg.ProjectKeys)),
+			utils.LogAttr("max_keys_allowed", types.MAX_KEYS_AMOUNT),
+		)
+	}
+
 	for _, projectKey := range msg.GetProjectKeys() {
 		if !projectKey.IsTypeValid() {
 			return nil, utils.LavaFormatWarning(

--- a/x/projects/keeper/msg_server_del_project_keys.go
+++ b/x/projects/keeper/msg_server_del_project_keys.go
@@ -18,6 +18,13 @@ func (k msgServer) DelKeys(goCtx context.Context, msg *types.MsgDelKeys) (*types
 		)
 	}
 
+	if len(msg.ProjectKeys) > types.MAX_KEYS_AMOUNT {
+		return nil, utils.LavaFormatWarning("cannot delete project keys", fmt.Errorf("max number of keys exceeded"),
+			utils.LogAttr("project_keys_amount", len(msg.ProjectKeys)),
+			utils.LogAttr("max_keys_allowed", types.MAX_KEYS_AMOUNT),
+		)
+	}
+
 	for _, projectKey := range msg.GetProjectKeys() {
 		if !projectKey.IsTypeValid() {
 			return nil, utils.LavaFormatWarning(

--- a/x/projects/keeper/project_test.go
+++ b/x/projects/keeper/project_test.go
@@ -1292,6 +1292,10 @@ func TestMaxKeysInProject(t *testing.T) {
 	err = ts.TxProjectAddKeys(proj.Index, sub, dummyKeys[2:]...)
 	require.NoError(t, err)
 
+	// try to delete more keys than allowed, should fail
+	err = ts.TxProjectDelKeys(proj.Index, sub, dummyKeys...)
+	require.Error(t, err)
+
 	// delete key and immediately try to add key - should fail since deletion is applied on next epoch
 	err = ts.TxProjectDelKeys(proj.Index, sub, dummyKeys[2])
 	require.NoError(t, err)


### PR DESCRIPTION
In this PR I capped the following TXs arguments:
- StakeProvider: max number of 5 endpoints per geolocation
- AddKeys/DelKeys: max number of 10 keys

All restrictions can be changed by changing the appropriate constant.
Note, other repeated fields in TXs were not changed as instructed by @Yaroms.