### PR TITLE
CNS-843: delegations bug fix

### DIFF
--- a/x/dualstaking/keeper/delegate.go
+++ b/x/dualstaking/keeper/delegate.go
@@ -534,6 +534,7 @@ func (k Keeper) UnbondUniformProviders(ctx sdk.Context, delegator string, amount
 		if delegations[i].Amount.Amount.LT(amountToDeduct) {
 			unbondAmount[key] = delegations[i].Amount
 			amount = amount.Sub(delegations[i].Amount)
+			delegations[i].Amount.Amount = sdk.ZeroInt()
 		} else {
 			coinToDeduct := sdk.NewCoin(delegations[i].Amount.Denom, amountToDeduct)
 			unbondAmount[key] = coinToDeduct


### PR DESCRIPTION
The following PR fixes the following bug:

The `delegations[i].Amount` is not reset to 0 if `delegations[i].Amount.Amount.LT.(amountToDeduct)` holds [here](https://github.com/lavanet/lava/blob/36fce686791af2648c97676cf176603a9b420edb/x/dualstaking/keeper/delegate.go#L534) , we suggesting setting `delegations[i].Amount = 0` as it could be used later when [here](https://github.com/lavanet/lava/blob/36fce686791af2648c97676cf176603a9b420edb/x/dualstaking/keeper/delegate.go#L552) are leftovers here.