### PR TITLE
CNS-844: call dualstaking ante handler + ante unit test

### DIFF
--- a/testutil/common/tester.go
+++ b/testutil/common/tester.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/utils/sigs"
 	"github.com/lavanet/lava/utils/slices"
+	dualstakingante "github.com/lavanet/lava/x/dualstaking/ante"
 	dualstakingtypes "github.com/lavanet/lava/x/dualstaking/types"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	fixationstoretypes "github.com/lavanet/lava/x/fixationstore/types"
@@ -654,6 +655,9 @@ func (ts *Tester) TxReDelegateValidator(delegator, fromValidator, toValidator si
 		sdk.ValAddress(toValidator.Addr),
 		sdk.NewCoin(ts.Keepers.StakingKeeper.BondDenom(ts.Ctx), amount),
 	)
+	rf := dualstakingante.NewRedelegationFlager(ts.Keepers.Dualstaking)
+	err := rf.DisableRedelegationHooks(ts.Ctx, []sdk.Msg{msg})
+	require.NoError(ts.T, err)
 	return ts.Servers.StakingServer.BeginRedelegate(ts.GoCtx, msg)
 }
 

--- a/x/dualstaking/ante/disable_redelegation_hooks.go
+++ b/x/dualstaking/ante/disable_redelegation_hooks.go
@@ -27,7 +27,7 @@ func (rf RedelegationFlager) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 		return ctx, err
 	}
 
-	err = rf.disableRedelegationHooks(ctx, msgs)
+	err = rf.DisableRedelegationHooks(ctx, msgs)
 	if err != nil {
 		return ctx, err
 	}
@@ -52,7 +52,7 @@ func (rf RedelegationFlager) unwrapAuthz(tx sdk.Tx) ([]sdk.Msg, error) {
 	return unwrappedMsgs, nil
 }
 
-func (rf RedelegationFlager) disableRedelegationHooks(ctx sdk.Context, msgs []sdk.Msg) error {
+func (rf RedelegationFlager) DisableRedelegationHooks(ctx sdk.Context, msgs []sdk.Msg) error {
 	redelegations := false
 	others := false
 	for _, msg := range msgs {

--- a/x/dualstaking/ante/disable_redelegation_hooks_test.go
+++ b/x/dualstaking/ante/disable_redelegation_hooks_test.go
@@ -1,0 +1,60 @@
+package ante_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	commontypes "github.com/lavanet/lava/common/types"
+	"github.com/lavanet/lava/testutil/common"
+	"github.com/lavanet/lava/x/dualstaking/ante"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDisableRedelegationHooks verifies that the DisableRedelegationHooks works as expected, i.e. disables
+// the dualstaking hooks only for redelegations message
+func TestDisableRedelegationHooks(t *testing.T) {
+	ts := *common.NewTester(t)
+	testCases := []struct {
+		msg               sdk.Msg
+		expectedFlagValue bool
+	}{
+		{newStakingRedelegateMsg(), true},
+		{newStakingDelegateMsg(), false},
+		{newStakingUndelegateMsg(), false},
+	}
+
+	rf := ante.NewRedelegationFlager(ts.Keepers.Dualstaking)
+
+	for _, testCase := range testCases {
+		err := rf.DisableRedelegationHooks(ts.Ctx, []sdk.Msg{testCase.msg})
+		require.NoError(t, err)
+		disableHooksFlag := ts.Keepers.Dualstaking.GetDisableDualstakingHook(ts.Ctx)
+		require.Equal(t, testCase.expectedFlagValue, disableHooksFlag)
+	}
+}
+
+func newStakingRedelegateMsg() *stakingtypes.MsgBeginRedelegate {
+	return stakingtypes.NewMsgBeginRedelegate(
+		sdk.AccAddress("del1"),
+		sdk.ValAddress("val1"),
+		sdk.ValAddress("val2"),
+		sdk.NewCoin(commontypes.TokenDenom, sdk.OneInt()),
+	)
+}
+
+func newStakingDelegateMsg() *stakingtypes.MsgDelegate {
+	return stakingtypes.NewMsgDelegate(
+		sdk.AccAddress("del1"),
+		sdk.ValAddress("val1"),
+		sdk.NewCoin(commontypes.TokenDenom, sdk.OneInt()),
+	)
+}
+
+func newStakingUndelegateMsg() *stakingtypes.MsgUndelegate {
+	return stakingtypes.NewMsgUndelegate(
+		sdk.AccAddress("del1"),
+		sdk.ValAddress("val1"),
+		sdk.NewCoin(commontypes.TokenDenom, sdk.OneInt()),
+	)
+}


### PR DESCRIPTION
The following PR fixes the following bug:

Tests call `msgServer` functions directly (e.g. `ts.TxReDelegateValidator` is a wrapper around `StakingServer.BeginRedelegate`). This means that any logic in anteHandlers will be bypassed, and test environments might not properly reflect actual tx execution states.

Note that the only ante handler in our code refers to the staking module's redelegate msg, so I fixed its wrapper specifically.