### PR TITLE
CNS-848: when staking, add to delegate total past delegations

### DIFF
--- a/x/dualstaking/keeper/hooks_test.go
+++ b/x/dualstaking/keeper/hooks_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -528,5 +529,133 @@ func TestNotRoundedShares(t *testing.T) {
 	ts.Keepers.StakingKeeper.SetDelegation(ts.Ctx, stakingtypes.NewDelegation(delegatorAcc.Addr, sdk.ValAddress(validatorAcc.Addr), shares))
 
 	_, err = ts.TxDualstakingDelegate(delegator, provider, ts.spec.Index, sdk.NewCoin(ts.TokenDenom(), delAmount))
+	require.NoError(t, err)
+}
+
+// TestUndelegateProvider checks for a bug that when a provider unstakes, its delegations are not
+// transferred to the empty provider. If the bug persists, this unit test fails
+func TestUndelegateProvider(t *testing.T) {
+	ts := newTester(t)
+	ts.addValidators(2)
+	err := ts.addProviders(5)
+	require.NoError(t, err)
+	ts.addClients(2)
+
+	// create validator and providers
+	validator, _ := ts.GetAccount(common.VALIDATOR, 0)
+	amount := sdk.NewIntFromUint64(9999)
+	ts.TxCreateValidator(validator, amount)
+
+	validator2, _ := ts.GetAccount(common.VALIDATOR, 1)
+	amount2 := sdk.NewIntFromUint64(9998)
+	ts.TxCreateValidator(validator2, amount2)
+
+	delegatorAcc1, _ := ts.GetAccount(common.CONSUMER, 0)
+	_, err = ts.TxDelegateValidator(delegatorAcc1, validator, sdk.NewInt(9999))
+	require.NoError(t, err)
+
+	delegatorAcc2, _ := ts.GetAccount(common.CONSUMER, 1)
+	_, err = ts.TxDelegateValidator(delegatorAcc2, validator, sdk.NewInt(9998))
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		provider, _ := ts.GetAccount(common.PROVIDER, i)
+		err := ts.StakeProvider(provider.Addr.String(), ts.spec, amount.Int64())
+		require.NoError(t, err)
+	}
+
+	providerAcct, provider := ts.GetAccount(common.PROVIDER, 0)
+
+	// delegator1 redelegates 9999 to the provider
+	_, err = ts.TxDualstakingRedelegate(delegatorAcc1.Addr.String(),
+		dualstakingtypes.EMPTY_PROVIDER,
+		provider,
+		dualstakingtypes.EMPTY_PROVIDER_CHAINID,
+		ts.spec.Index,
+		sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(9999)))
+	require.NoError(t, err)
+
+	ts.AdvanceEpoch()
+
+	res2, err := ts.QueryDualstakingProviderDelegators(provider, true)
+	require.NoError(t, err)
+	fmt.Println("Delegation of Provider before provider is removed", res2)
+
+	unstakeHoldBlocks := ts.Keepers.Epochstorage.UnstakeHoldBlocks(ts.Ctx, ts.BlockHeight())
+	unstakeHoldBlocksStatic := ts.Keepers.Epochstorage.UnstakeHoldBlocksStatic(ts.Ctx, ts.BlockHeight())
+
+	_, err = ts.TxPairingUnstakeProvider(provider, ts.spec.Index)
+	require.NoError(t, err)
+
+	ts.AdvanceBlocks(unstakeHoldBlocks)
+
+	_, found, _ := ts.Keepers.Epochstorage.UnstakeEntryByAddress(ts.Ctx, providerAcct.Addr)
+	require.True(t, found)
+
+	ts.AdvanceBlocks(unstakeHoldBlocksStatic - unstakeHoldBlocks)
+
+	// checking that provider can't be found
+	_, found, _ = ts.Keepers.Epochstorage.UnstakeEntryByAddress(ts.Ctx, providerAcct.Addr)
+	require.False(t, found)
+
+	ts.AdvanceEpoch()
+
+	_, found, _ = ts.Keepers.Epochstorage.GetStakeEntryByAddressCurrent(ts.Ctx, ts.spec.Index, providerAcct.Addr)
+	require.False(t, found)
+
+	// delegation of the removed provider
+	// the provider is removed but the delegation is still remained
+	res2, err = ts.QueryDualstakingProviderDelegators(provider, true)
+	require.NoError(t, err)
+	fmt.Println("Delegation of Provider after provider is removed", res2)
+
+	// stake provider again
+	err = ts.StakeProvider(providerAcct.Addr.String(), ts.spec, sdk.NewIntFromUint64(1000).Int64())
+	require.NoError(t, err)
+
+	stakeEntry, found, _ := ts.Keepers.Epochstorage.GetStakeEntryByAddressCurrent(ts.Ctx, ts.spec.Index, providerAcct.Addr)
+	require.True(t, found)
+	fmt.Println("Stake entry of re-staked provider", stakeEntry.String())
+
+	// delegator1 should be able to redelegate back to the empty provider
+	_, err = ts.TxDualstakingRedelegate(delegatorAcc1.Addr.String(),
+		provider,
+		dualstakingtypes.EMPTY_PROVIDER,
+		ts.spec.Index,
+		dualstakingtypes.EMPTY_PROVIDER_CHAINID,
+		sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(1)))
+	require.NoError(t, err)
+
+	stakeEntry, found, _ = ts.Keepers.Epochstorage.GetStakeEntryByAddressCurrent(ts.Ctx, ts.spec.Index, providerAcct.Addr)
+	require.True(t, found)
+	fmt.Println("Stake entry of re-staked provider after del1 9999 redelegation", stakeEntry.String())
+
+	// another one delegates to provider
+	// delegator2 delegates 9998 to the provider
+	_, err = ts.TxDualstakingRedelegate(delegatorAcc2.Addr.String(),
+		dualstakingtypes.EMPTY_PROVIDER,
+		provider,
+		dualstakingtypes.EMPTY_PROVIDER_CHAINID,
+		ts.spec.Index,
+		sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(9998)))
+	require.NoError(t, err)
+
+	// delegator 1 can only redelegate 9998 to Empty Provider
+	ts.AdvanceEpoch()
+
+	_, err = ts.TxDualstakingRedelegate(delegatorAcc1.Addr.String(),
+		provider,
+		dualstakingtypes.EMPTY_PROVIDER,
+		ts.spec.Index,
+		dualstakingtypes.EMPTY_PROVIDER_CHAINID,
+		sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(9999)))
+	require.Error(t, err)
+
+	_, err = ts.TxDualstakingRedelegate(delegatorAcc1.Addr.String(),
+		provider,
+		dualstakingtypes.EMPTY_PROVIDER,
+		ts.spec.Index,
+		dualstakingtypes.EMPTY_PROVIDER_CHAINID,
+		sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(9998)))
 	require.NoError(t, err)
 }

--- a/x/pairing/keeper/staking.go
+++ b/x/pairing/keeper/staking.go
@@ -145,12 +145,19 @@ func (k Keeper) StakeNewEntry(ctx sdk.Context, validator, creator, chainID strin
 
 	// if there are registered delegations to the provider, count them in the delegateTotal
 	delegateTotal := sdk.ZeroInt()
-	epoch := k.epochStorageKeeper.GetEpochStart(ctx)
-	delegations, err := k.dualstakingKeeper.GetProviderDelegators(ctx, senderAddr.String(), epoch)
+	nextEpoch, err := k.epochStorageKeeper.GetNextEpoch(ctx, uint64(ctx.BlockHeight()))
+	if err != nil {
+		utils.LavaFormatWarning("cannot get next epoch to count past delegations", err,
+			utils.LogAttr("provider", senderAddr.String()),
+			utils.LogAttr("block", nextEpoch),
+		)
+	}
+
+	delegations, err := k.dualstakingKeeper.GetProviderDelegators(ctx, senderAddr.String(), nextEpoch)
 	if err != nil {
 		utils.LavaFormatWarning("cannot get provider's delegators", err,
 			utils.LogAttr("provider", senderAddr.String()),
-			utils.LogAttr("block", epoch),
+			utils.LogAttr("block", nextEpoch),
 		)
 	}
 

--- a/x/pairing/keeper/staking.go
+++ b/x/pairing/keeper/staking.go
@@ -147,7 +147,7 @@ func (k Keeper) StakeNewEntry(ctx sdk.Context, validator, creator, chainID strin
 	delegateTotal := sdk.ZeroInt()
 	nextEpoch, err := k.epochStorageKeeper.GetNextEpoch(ctx, uint64(ctx.BlockHeight()))
 	if err != nil {
-		utils.LavaFormatWarning("cannot get next epoch to count past delegations", err,
+		return utils.LavaFormatWarning("cannot get next epoch to count past delegations", err,
 			utils.LogAttr("provider", senderAddr.String()),
 			utils.LogAttr("block", nextEpoch),
 		)

--- a/x/pairing/types/expected_keepers.go
+++ b/x/pairing/types/expected_keepers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	v1 "github.com/lavanet/lava/x/downtime/v1"
+	dualstakingtypes "github.com/lavanet/lava/x/dualstaking/types"
 	epochstoragetypes "github.com/lavanet/lava/x/epochstorage/types"
 	fixationstoretypes "github.com/lavanet/lava/x/fixationstore/types"
 	planstypes "github.com/lavanet/lava/x/plans/types"
@@ -105,6 +106,7 @@ type DualstakingKeeper interface {
 	RewardProvidersAndDelegators(ctx sdk.Context, providerAddr sdk.AccAddress, chainID string, totalReward math.Int, senderModule string, calcOnlyProvider bool, calcOnlyDelegators bool, calcOnlyContributer bool) (providerReward math.Int, totalRewards math.Int, err error)
 	DelegateFull(ctx sdk.Context, delegator string, validator string, provider string, chainID string, amount sdk.Coin) error
 	UnbondFull(ctx sdk.Context, delegator string, validator string, provider string, chainID string, amount sdk.Coin, unstake bool) error
+	GetProviderDelegators(ctx sdk.Context, provider string, epoch uint64) ([]dualstakingtypes.Delegation, error)
 }
 
 type FixationStoreKeeper interface {


### PR DESCRIPTION
Fix a bug in which when a provider unstakes and then re-stakes, we didn't consider past delegations to it.

Now, when a provider stakes, we check the delegationFS for existing delegations and add it to its DelegateTotal field