### PR TITLE
Allow rpcconsumer skip hitting the cache store

### DIFF
--- a/protocol/chainlib/chain_message.go
+++ b/protocol/chainlib/chain_message.go
@@ -24,6 +24,7 @@ type baseChainMessageContainer struct {
 	apiCollection          *spectypes.ApiCollection
 	extensions             []*spectypes.Extension
 	timeoutOverride        time.Duration
+	forceCacheRefresh      bool
 }
 
 func (pm *baseChainMessageContainer) TimeoutOverride(override ...time.Duration) time.Duration {
@@ -31,6 +32,15 @@ func (pm *baseChainMessageContainer) TimeoutOverride(override ...time.Duration) 
 		pm.timeoutOverride = override[0]
 	}
 	return pm.timeoutOverride
+}
+
+func (pm *baseChainMessageContainer) SetForceCacheRefresh(force bool) bool {
+	pm.forceCacheRefresh = force
+	return pm.forceCacheRefresh
+}
+
+func (pm *baseChainMessageContainer) GetForceCacheRefresh() bool {
+	return pm.forceCacheRefresh
 }
 
 func (pm *baseChainMessageContainer) DisableErrorHandling() {

--- a/protocol/chainlib/chainlib.go
+++ b/protocol/chainlib/chainlib.go
@@ -76,6 +76,9 @@ type ChainMessage interface {
 	OverrideExtensions(extensionNames []string, extensionParser *extensionslib.ExtensionParser)
 	DisableErrorHandling()
 	TimeoutOverride(...time.Duration) time.Duration
+	GetForceCacheRefresh() bool
+	SetForceCacheRefresh(force bool) bool
+
 	ChainMessageForSend
 }
 

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -27,6 +27,7 @@ const (
 	BLOCK_PROVIDERS_ADDRESSES_HEADER_NAME = "lava-providers-block"
 	RELAY_TIMEOUT_HEADER_NAME             = "lava-relay-timeout"
 	EXTENSION_OVERRIDE_HEADER_NAME        = "lava-extension"
+	FORCE_CACHE_REFRESH_HEADER_NAME       = "lava-force-cache-refresh"
 	// send http request to /lava/health to see if the process is up - (ret code 200)
 	DEFAULT_HEALTH_PATH = "/lava/health"
 )


### PR DESCRIPTION
By appending a dedicated http header to requests -> lava-force-cache-refresh