### PR TITLE
CNS-886-ignore-dualstaking-hooks-gas-consumption

### DIFF
--- a/x/dualstaking/keeper/delegate.go
+++ b/x/dualstaking/keeper/delegate.go
@@ -571,11 +571,11 @@ func (k Keeper) UnbondUniformProviders(ctx sdk.Context, delegator string, amount
 }
 
 // returns the difference between validators delegations and provider delegation (validators-providers)
-func (k Keeper) VerifyDelegatorBalance(ctx sdk.Context, delAddr sdk.AccAddress) (math.Int, error) {
+func (k Keeper) VerifyDelegatorBalance(ctx sdk.Context, delAddr sdk.AccAddress) (math.Int, int, error) {
 	nextEpoch := k.epochstorageKeeper.GetCurrentNextEpoch(ctx)
 	providers, err := k.GetDelegatorProviders(ctx, delAddr.String(), nextEpoch)
 	if err != nil {
-		return math.ZeroInt(), err
+		return math.ZeroInt(), 0, err
 	}
 
 	sumProviderDelegations := sdk.ZeroInt()
@@ -595,5 +595,5 @@ func (k Keeper) VerifyDelegatorBalance(ctx sdk.Context, delAddr sdk.AccAddress) 
 		}
 	}
 
-	return sumValidatorDelegations.Sub(sumProviderDelegations), nil
+	return sumValidatorDelegations.Sub(sumProviderDelegations), len(providers), nil
 }

--- a/x/dualstaking/keeper/helpers_test.go
+++ b/x/dualstaking/keeper/helpers_test.go
@@ -108,7 +108,7 @@ func (ts *tester) getStakeEntry(provider sdk.AccAddress, chainID string) epochst
 func (ts *tester) verifyDelegatorsBalance() {
 	accounts := ts.AccountsMap()
 	for key, account := range accounts {
-		diff, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, account.Addr)
+		diff, _, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, account.Addr)
 		require.Nil(ts.T, err)
 		require.True(ts.T, diff.IsZero(), "delegator balance is not 0", key)
 	}

--- a/x/dualstaking/keeper/hooks.go
+++ b/x/dualstaking/keeper/hooks.go
@@ -47,6 +47,14 @@ func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAd
 // create new delegation period record
 // add description
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	originalGas := ctx.GasMeter().GasConsumed()
+	defer func() {
+		endGas := ctx.GasMeter().GasConsumed()
+		if endGas > originalGas {
+			ctx.GasMeter().RefundGas(endGas-originalGas, "refund hooks gas")
+		}
+	}()
+
 	if h.k.GetDisableDualstakingHook(ctx) {
 		return nil
 	}

--- a/x/dualstaking/keeper/hooks.go
+++ b/x/dualstaking/keeper/hooks.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -62,7 +63,9 @@ func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, 
 		return nil
 	}
 
-	diff, providers, err := h.k.VerifyDelegatorBalance(ctx, delAddr)
+	var diff math.Int
+	var err error
+	diff, providers, err = h.k.VerifyDelegatorBalance(ctx, delAddr)
 	if err != nil {
 		return err
 	}

--- a/x/dualstaking/keeper/hooks_test.go
+++ b/x/dualstaking/keeper/hooks_test.go
@@ -231,7 +231,7 @@ func TestUnbondUniformProviders(t *testing.T) {
 		}
 	}
 
-	diff, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
+	diff, _, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
 	require.NoError(t, err)
 	require.True(t, diff.IsZero())
 }
@@ -271,7 +271,7 @@ func TestValidatorSlash(t *testing.T) {
 	require.Equal(t, amount.Sub(expectedTokensToBurn), res.Delegations[0].Amount.Amount)
 
 	// sanity check: verify that provider-validator delegations are equal
-	diff, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, valAcc.Addr)
+	diff, _, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, valAcc.Addr)
 	require.NoError(t, err)
 	require.True(t, diff.IsZero())
 }
@@ -359,7 +359,7 @@ func TestValidatorAndProvidersSlash(t *testing.T) {
 	_, err = ts.TxDualstakingRedelegate(delegator, providers[0], providers[1], ts.spec.Index, ts.spec.Index, sdk.NewCoin(ts.TokenDenom(), consensusPowerTokens.MulRaw(5)))
 	require.NoError(t, err)
 	ts.AdvanceEpoch() // apply redelegation
-	diff, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
+	diff, _, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
 	require.NoError(t, err)
 	require.True(t, diff.IsZero())
 
@@ -367,7 +367,7 @@ func TestValidatorAndProvidersSlash(t *testing.T) {
 	_, err = ts.TxDualstakingUnbond(delegator, providers[2], ts.spec.Index, sdk.NewCoin(ts.TokenDenom(), consensusPowerTokens.MulRaw(5)))
 	require.NoError(t, err)
 	ts.AdvanceEpoch() // apply unbond
-	diff, err = ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
+	diff, _, err = ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
 	require.NoError(t, err)
 	require.True(t, diff.IsZero())
 	expectedValidatorTokens = expectedValidatorTokens.Sub(consensusPowerTokens.MulRaw(5))
@@ -415,7 +415,7 @@ func TestValidatorAndProvidersSlash(t *testing.T) {
 	require.Equal(t, sdk.OneDec().Sub(fraction).MulInt(consensusPowerTokens.MulRaw(245)).TruncateInt(), totalDelegations)
 
 	// verify once again that the delegator's delegations balance is preserved
-	diff, err = ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
+	diff, _, err = ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegatorAcc.Addr)
 	require.NoError(t, err)
 	require.Equal(t, sdk.OneInt(), diff)
 }
@@ -451,7 +451,7 @@ func TestCancelUnbond(t *testing.T) {
 	_, err = ts.TxCancelUnbondValidator(delegator, validator, unbondBlock, sdk.NewCoin(ts.TokenDenom(), sdk.NewInt(50)))
 	require.NoError(t, err)
 
-	diff, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegator.Addr)
+	diff, _, err := ts.Keepers.Dualstaking.VerifyDelegatorBalance(ts.Ctx, delegator.Addr)
 	require.NoError(t, err)
 	require.True(t, diff.IsZero())
 }

--- a/x/dualstaking/keeper/migrations.go
+++ b/x/dualstaking/keeper/migrations.go
@@ -223,7 +223,7 @@ func (m Migrator) VerifyDelegationsBalance(ctx sdk.Context) error {
 
 	// verify delegations balance for each delegator
 	for _, d := range delegators {
-		diff, err := m.keeper.VerifyDelegatorBalance(ctx, d)
+		diff, _, err := m.keeper.VerifyDelegatorBalance(ctx, d)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
to test this i created a new validator (this is the same as delegate)

Gas before the change:
gas_used: "227102"
gas_wanted: "320769"

Gas after the change:
gas_used: "169884"
gas_wanted: "234942"