### PR TITLE
CNS-907: string validation fixes

### DIFF
--- a/common/types/ascii.go
+++ b/common/types/ascii.go
@@ -29,6 +29,18 @@ func isCharDisallowed(c rune, disallowedChars []rune) bool {
 	return false
 }
 
+func isASCII(r rune) bool {
+	if r > 127 || !unicode.IsLetter(r) {
+		return false
+	}
+
+	return true
+}
+
+func isLowercaseASCII(r rune) bool {
+	return r >= 'a' && r <= 'z'
+}
+
 // Validates name strings.
 // Current policy:
 //
@@ -44,6 +56,10 @@ func ValidateString(s string, restrictType charRestrictionEnum, disallowedChars 
 		return false
 	}
 
+	if restrictType == INDEX_RESTRICTIONS && len(s) == 0 {
+		return false
+	}
+
 	// Character check
 	for _, r := range s {
 		if disallowedChars != nil && isCharDisallowed(r, disallowedChars) {
@@ -53,15 +69,15 @@ func ValidateString(s string, restrictType charRestrictionEnum, disallowedChars 
 			case NAME_RESTRICTIONS:
 				if r == ',' {
 					return false
-				} else if !unicode.IsLower(r) && r != ' ' && r != '_' && !unicode.IsDigit(r) {
+				} else if !isLowercaseASCII(r) && r != ' ' && r != '_' && !unicode.IsDigit(r) {
 					return false
 				}
 			case DESCRIPTION_RESTRICTIONS:
-				if !unicode.IsLetter(r) && r != ' ' && r != '_' && !unicode.IsDigit(r) {
+				if !isASCII(r) && r != ' ' && r != '_' && !unicode.IsDigit(r) {
 					return false
 				}
 			case INDEX_RESTRICTIONS:
-				if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+				if !isASCII(r) && !unicode.IsDigit(r) {
 					return false
 				}
 			}

--- a/common/types/ascii_test.go
+++ b/common/types/ascii_test.go
@@ -20,8 +20,29 @@ func TestStringValidation(t *testing.T) {
 		{"valid_name_with_underscore", "hel_lo", NAME_RESTRICTIONS, nil, true},
 		{"valid_name_with_digit", "hel2lo", NAME_RESTRICTIONS, nil, true},
 		{"invalid_name_not_lowercase", "hEllo", NAME_RESTRICTIONS, nil, false},
-		{"invalid_name_not_ascii", "he¢llo", NAME_RESTRICTIONS, nil, false},
+		{"invalid_name_not_ascii", "heあllo", NAME_RESTRICTIONS, nil, false},
 		{"invalid_name_with_disallowed_char", "heallo", NAME_RESTRICTIONS, []rune{'a'}, false},
+		{"invalid_empty_name", "", NAME_RESTRICTIONS, nil, false},
+
+		// description restrictions tests
+		{"valid_desc", "hello", DESCRIPTION_RESTRICTIONS, nil, true},
+		{"valid_desc_with_space", "hel lo", DESCRIPTION_RESTRICTIONS, nil, true},
+		{"valid_desc_with_underscore", "hel_lo", DESCRIPTION_RESTRICTIONS, nil, true},
+		{"valid_desc_with_digit", "hel2lo", DESCRIPTION_RESTRICTIONS, nil, true},
+		{"valid_desc_not_lowercase", "hEllo", DESCRIPTION_RESTRICTIONS, nil, true},
+		{"invalid_desc_not_ascii", "heあllo", DESCRIPTION_RESTRICTIONS, nil, false},
+		{"invalid_desc_with_disallowed_char", "heallo", DESCRIPTION_RESTRICTIONS, []rune{'a'}, false},
+		{"invalid_empty_desc", "", DESCRIPTION_RESTRICTIONS, nil, false},
+
+		// index restrictions tests
+		{"valid_index", "hello", INDEX_RESTRICTIONS, nil, true},
+		{"invalid_index_with_space", "hel lo", INDEX_RESTRICTIONS, nil, false},
+		{"invalid_index_with_underscore", "hel_lo", INDEX_RESTRICTIONS, nil, false},
+		{"valid_index_with_digit", "hel2lo", INDEX_RESTRICTIONS, nil, true},
+		{"valid_index_not_lowercase", "hEllo", INDEX_RESTRICTIONS, nil, true},
+		{"invalid_index_not_ascii", "heあllo", INDEX_RESTRICTIONS, nil, false},
+		{"invalid_index_with_disallowed_char", "heallo", INDEX_RESTRICTIONS, []rune{'a'}, false},
+		{"invalid_empty_index", "", INDEX_RESTRICTIONS, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fixed the following:
unicode.IsLetter doesn’t check if a given char is an ascii char, so non-ascii chars (e.g., あ, 漢) can pass [this check](https://github.com/lavanet/lava/blob/c3d7d35987adbd384fd75148ffdab96b12dc6cd0/common/types/ascii.go#L60), and [this condition](https://github.com/lavanet/lava/blob/c3d7d35987adbd384fd75148ffdab96b12dc6cd0/common/types/ascii.go#L36) isn’t met. Additionally, it seems like the index can be empty unlike name and description.