### PR TITLE
CNS-923: added local cache for validate pairing

### DIFF
--- a/x/pairing/keeper/msg_server_relay_payment.go
+++ b/x/pairing/keeper/msg_server_relay_payment.go
@@ -178,7 +178,7 @@ func (k msgServer) RelayPayment(goCtx context.Context, msg *types.MsgRelayPaymen
 
 		// generate validate pairing cache key with CuTrackerKey() to reuse code (doesn't relate to CU tracking at all)
 		validatePairingKey := subscriptiontypes.CuTrackerKey(clientAddr.String(), relay.Provider, relay.SpecId)
-		providers := []epochstoragetypes.StakeEntry{}
+		var providers []epochstoragetypes.StakeEntry
 		allowedCU := uint64(0)
 		pairingData, ok := validatePairingCache[validatePairingKey]
 		if ok {

--- a/x/pairing/keeper/msg_server_relay_payment.go
+++ b/x/pairing/keeper/msg_server_relay_payment.go
@@ -316,6 +316,10 @@ func (k msgServer) RelayPayment(goCtx context.Context, msg *types.MsgRelayPaymen
 	}
 	utils.LogLavaEvent(ctx, logger, types.LatestBlocksReportEventName, latestBlockReports, "New LatestBlocks Report for provider")
 
+	// consume constant gas (dependent on the number of relays)
+	ctx.GasMeter().RefundGas(ctx.GasMeter().GasConsumed(), "")
+	ctx.GasMeter().ConsumeGas(uint64(10000+100000*len(msg.Relays)), "")
+
 	return &types.MsgRelayPaymentResponse{RejectedRelays: rejected_relays}, nil
 }
 


### PR DESCRIPTION
When iterating over relays, instead of validating the pairing for each relay, we keep track of the validated provider-consumer-spec trio in a local map and skip the validation if it was already validated in a previous relay