### PR TITLE
fix: define `--delegate-limit` var

### DIFF
--- a/scripts/test_spec_full.sh
+++ b/scripts/test_spec_full.sh
@@ -88,6 +88,7 @@ if [ "$dry" = false ]; then
     sleep 4
 
     PROVIDERSTAKE="500000000000ulava"
+    DELEGATE_LIMIT="0ulava"
 
     # do not change this port without modifying the input_yaml
     PROVIDER1_LISTENER="127.0.0.1:2220"
@@ -97,7 +98,7 @@ if [ "$dry" = false ]; then
     for index in ${index_list[@]}
     do
         echo "Processing index: $index"
-        lavad tx pairing stake-provider "$index" $PROVIDERSTAKE "$PROVIDER1_LISTENER,1" 1 $(operator_address) -y --from servicer1 --delegate-limit $STAKE --provider-moniker "provider-$index" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+        lavad tx pairing stake-provider "$index" $PROVIDERSTAKE "$PROVIDER1_LISTENER,1" 1 $(operator_address) -y --from servicer1 --delegate-limit $DELEGATE_LIMIT  --provider-moniker "provider-$index" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
         wait_next_block
     done
 


### PR DESCRIPTION
## What does this PR do? 
Fix error `Error: accepts 5 arg(s), received 6` when `spect_test_full.sh` run 

The $STAKE var is undefined, this PR defines var for `delegate-limit`, also `--delegate-limit`  can't be removed from the command, because cli rising error that this param is required