### PR TITLE
feat: Add Scroll Spec

### DIFF
--- a/cookbook/specs/spec_add_scroll.json
+++ b/cookbook/specs/spec_add_scroll.json
@@ -1,0 +1,118 @@
+{
+    "proposal": {
+        "title": "Add Specs: Scroll",
+        "description": "Adding new specification support for relaying Scroll zkEVM data on Lava",
+        "specs": [
+            {
+                "index": "SCRLL",
+                "name": "scroll mainnet",
+                "enabled": true,
+                "imports": [
+                    "ETH1"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 1,
+                "blocks_in_finalization_proof": 3,
+                "average_block_time": 3000,
+                "allowed_block_lag_for_qos_sync": 3,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x82750"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 4100000
+                                    },
+                                    {
+                                        "extension": "archive",
+                                        "expected_value": "0x0"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 4000000
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": "SCRLLS",
+                "name": "scroll sepolia testnet",
+                "enabled": true,
+                "imports": [
+                    "SCRLL"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 1,
+                "blocks_in_finalization_proof": 3,
+                "average_block_time": 3000,
+                "allowed_block_lag_for_qos_sync": 3,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x8274f"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "deposit": "10000000ulava"
+}

--- a/cookbook/specs/spec_add_scroll.json
+++ b/cookbook/specs/spec_add_scroll.json
@@ -47,7 +47,7 @@
                                 "name": "pruning",
                                 "values": [
                                     {
-                                        "latest_distance": 4100000
+                                        "latest_distance": 3100000
                                     },
                                     {
                                         "extension": "archive",
@@ -61,7 +61,7 @@
                                 "name": "archive",
                                 "cu_multiplier": 5,
                                 "rule": {
-                                    "block": 4000000
+                                    "block": 3000000
                                 }
                             }
                         ]

--- a/cookbook/specs/spec_add_scroll.json
+++ b/cookbook/specs/spec_add_scroll.json
@@ -4,7 +4,7 @@
         "description": "Adding new specification support for relaying Scroll zkEVM data on Lava",
         "specs": [
             {
-                "index": "SCRLL",
+                "index": "SCROLL",
                 "name": "scroll mainnet",
                 "enabled": true,
                 "imports": [
@@ -69,11 +69,11 @@
                 ]
             },
             {
-                "index": "SCRLLS",
+                "index": "SCROLLS",
                 "name": "scroll sepolia testnet",
                 "enabled": true,
                 "imports": [
-                    "SCRLL"
+                    "SCROLL"
                 ],
                 "reliability_threshold": 268435455,
                 "data_reliability_enabled": true,


### PR DESCRIPTION
Does this look good? From what I can tell Scroll doesn't have any custom RPC methods on top of the Ethereum EVM spec.

Testing command:
```
./scripts/test_spec_full.sh cookbook/specs/spec_add_scroll.json jsonrpc https://rpc.scroll.io jsonrpc https://sepolia-rpc.scroll.io
```