### PR TITLE
feat: Update Base spec to include new Sepolia testnet

### DIFF
--- a/cookbook/specs/spec_add_base.json
+++ b/cookbook/specs/spec_add_base.json
@@ -111,6 +111,50 @@
                         ]
                     }
                 ]
+            },
+            {
+                "index": "BASES",
+                "name": "base sepolia testnet",
+                "enabled": true,
+                "imports": [
+                    "BASE"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 1,
+                "blocks_in_finalization_proof": 1,
+                "average_block_time": 2000,
+                "allowed_block_lag_for_qos_sync": 5,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x14a34"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     },


### PR DESCRIPTION
Testing command was successful:
```
./scripts/test_spec_full.sh cookbook/specs/spec_add_base.json jsonrpc https://mainnet.base.org jsonrpc https://goerli.base.org jsonrpc https://sepolia.base.org
```