### PR TITLE
feat: CNS-941: support address arguments from keyring

### DIFF
--- a/utils/address.go
+++ b/utils/address.go
@@ -1,10 +1,37 @@
 package utils
 
 import (
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func IsBech32Address(addr string) bool {
 	_, err := sdk.AccAddressFromBech32(addr)
 	return err == nil
+}
+
+// ParseCLIAddress is used to parse address arguments from CLI. If the address is Bech32
+// the function simply returns the argument. If it's not, it tries to fetch it from the keyring
+func ParseCLIAddress(clientCtx client.Context, address string) (string, error) {
+	if address == "" {
+		// empty address --> address = creator
+		address = clientCtx.GetFromAddress().String()
+	} else {
+		if IsBech32Address(address) {
+			return address, nil
+		}
+
+		// address is not a valid Bech32 address --> try to fetch from the keyring
+		keyringRecord, err := clientCtx.Keyring.Key(address)
+		if err != nil {
+			return "", err
+		}
+		addr, err := keyringRecord.GetAddress()
+		if err != nil {
+			return "", err
+		}
+		address = addr.String()
+
+	}
+	return address, nil
 }

--- a/utils/address.go
+++ b/utils/address.go
@@ -31,7 +31,6 @@ func ParseCLIAddress(clientCtx client.Context, address string) (string, error) {
 			return "", err
 		}
 		address = addr.String()
-
 	}
 	return address, nil
 }

--- a/x/conflict/client/cli/query_consumer_conflicts.go
+++ b/x/conflict/client/cli/query_consumer_conflicts.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/conflict/types"
 	"github.com/spf13/cobra"
 )
@@ -20,8 +21,12 @@ func CmdConsumerConflicts() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
+			consumer, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
 			params := &types.QueryConsumerConflictsRequest{
-				Consumer: args[0],
+				Consumer: consumer,
 			}
 
 			res, err := queryClient.ConsumerConflicts(cmd.Context(), params)

--- a/x/conflict/client/cli/query_provider_conflicts.go
+++ b/x/conflict/client/cli/query_provider_conflicts.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/conflict/types"
 	"github.com/spf13/cobra"
 )
@@ -20,8 +21,12 @@ func CmdProviderConflicts() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
+			provider, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
 			params := &types.QueryProviderConflictsRequest{
-				Provider: args[0],
+				Provider: provider,
 			}
 
 			res, err := queryClient.ProviderConflicts(cmd.Context(), params)

--- a/x/dualstaking/client/cli/query_delegator_providers.go
+++ b/x/dualstaking/client/cli/query_delegator_providers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 )
 
@@ -18,9 +19,12 @@ func CmdQueryDelegatorProviders() *cobra.Command {
 		Short: "shows all the providers the delegator delegated to",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			delegator := args[0]
 
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			delegator, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/dualstaking/client/cli/query_delegator_providers.go
+++ b/x/dualstaking/client/cli/query_delegator_providers.go
@@ -19,7 +19,6 @@ func CmdQueryDelegatorProviders() *cobra.Command {
 		Short: "shows all the providers the delegator delegated to",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err

--- a/x/dualstaking/client/cli/query_delegator_rewards.go
+++ b/x/dualstaking/client/cli/query_delegator_rewards.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 )
 
@@ -22,7 +23,6 @@ func CmdQueryDelegatorRewards() *cobra.Command {
 		Can be more specific using the optional --provider and --chain-id flags`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			delegator := args[0]
 			var provider, chainID string
 
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -32,12 +32,20 @@ func CmdQueryDelegatorRewards() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
+			delegator, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+
 			// check if the command includes --provider
 			providerFlag := cmd.Flags().Lookup(providerFlagName)
 			if providerFlag == nil {
 				return fmt.Errorf("%s flag wasn't found", providerFlagName)
 			}
-			provider = providerFlag.Value.String()
+			provider, err = utils.ParseCLIAddress(clientCtx, providerFlag.Value.String())
+			if err != nil {
+				return err
+			}
 
 			// check if the command includes --chain-id
 			chainIDFlag := cmd.Flags().Lookup(chainIDFlagName)

--- a/x/dualstaking/client/cli/query_provider_delegators.go
+++ b/x/dualstaking/client/cli/query_provider_delegators.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 )
 
@@ -16,9 +17,11 @@ func CmdQueryProviderDelegators() *cobra.Command {
 		Short: "shows all the delegators of a specific provider",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			provider := args[0]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			provider, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/dualstaking/client/cli/tx_claim_rewards.go
+++ b/x/dualstaking/client/cli/tx_claim_rewards.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 	"github.com/spf13/cobra"
 )
@@ -18,14 +19,17 @@ func CmdClaimRewards() *cobra.Command {
 		Short: "claim rewards from delegations. Optionally can claim rewards from a specific provider",
 		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			var provider string
-			if len(args) > 0 {
-				provider = args[0]
-			}
-
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
+			}
+
+			var provider string
+			if len(args) > 0 {
+				provider, err = utils.ParseCLIAddress(clientCtx, args[0])
+				if err != nil {
+					return err
+				}
 			}
 
 			msg := types.NewMsgClaimRewards(

--- a/x/dualstaking/client/cli/tx_delegate.go
+++ b/x/dualstaking/client/cli/tx_delegate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 	"github.com/spf13/cobra"
 )
@@ -17,8 +18,8 @@ var _ = strconv.Itoa(0)
 
 func CmdDelegate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delegate provider chain-id validator amount",
-		Short: "delegate to a validator and provider",
+		Use:   "delegate [provider] [chain-id] [validator] [amount]",
+		Short: "delegate to a validator and provider using dualstaking",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -26,7 +27,11 @@ func CmdDelegate() *cobra.Command {
 				return err
 			}
 
-			argProvider := args[0]
+			argProvider, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+
 			argChainID := args[1]
 			argvalidator := args[2]
 			argAmount, err := sdk.ParseCoinNormalized(args[3])

--- a/x/dualstaking/client/cli/tx_redelegate.go
+++ b/x/dualstaking/client/cli/tx_redelegate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 	"github.com/spf13/cobra"
 )
@@ -19,16 +20,22 @@ func CmdRedelegate() *cobra.Command {
 		Short: "redelegate from one provider to another provider",
 		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			argFromProvider := args[0]
-			argFromChainID := args[1]
-			argToProvider := args[2]
-			argToChainID := args[3]
-			argAmount, err := sdk.ParseCoinNormalized(args[4])
+			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			argFromProvider, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+			argFromChainID := args[1]
+			argToProvider, err := utils.ParseCLIAddress(clientCtx, args[2])
+			if err != nil {
+				return err
+			}
+			argToChainID := args[3]
+			argAmount, err := sdk.ParseCoinNormalized(args[4])
 			if err != nil {
 				return err
 			}

--- a/x/dualstaking/client/cli/tx_unbond.go
+++ b/x/dualstaking/client/cli/tx_unbond.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/dualstaking/types"
 	"github.com/spf13/cobra"
 )
@@ -19,15 +20,18 @@ func CmdUnbond() *cobra.Command {
 		Short: "unbond from a provider",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			argValidator := args[0]
-			argProvider := args[1]
-			argChainID := args[2]
-			argAmount, err := sdk.ParseCoinNormalized(args[3])
+			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			argValidator := args[0]
+			argProvider, err := utils.ParseCLIAddress(clientCtx, args[1])
+			if err != nil {
+				return err
+			}
+			argChainID := args[2]
+			argAmount, err := sdk.ParseCoinNormalized(args[3])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_account_info.go
+++ b/x/pairing/client/cli/query_account_info.go
@@ -50,7 +50,10 @@ func CmdAccountInfo() *cobra.Command {
 				}
 				address = addressAccount.String()
 			} else {
-				address = args[0]
+				address, err = utils.ParseCLIAddress(clientCtx, args[0])
+				if err != nil {
+					return err
+				}
 			}
 			specQuerier := spectypes.NewQueryClient(clientCtx)
 			ctx := context.Background()

--- a/x/pairing/client/cli/query_debug_query.go
+++ b/x/pairing/client/cli/query_debug_query.go
@@ -11,6 +11,7 @@ import (
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	commontypes "github.com/lavanet/lava/common/types"
+	"github.com/lavanet/lava/utils"
 	dualstakingtypes "github.com/lavanet/lava/x/dualstaking/types"
 	"github.com/lavanet/lava/x/pairing/types"
 	rewardstypes "github.com/lavanet/lava/x/rewards/types"
@@ -30,7 +31,11 @@ func CmdDebugQuery() *cobra.Command {
 				return err
 			}
 
-			provider := args[0]
+			provider, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+
 			chainID := args[1]
 			ctx := context.Background()
 

--- a/x/pairing/client/cli/query_effective_policy.go
+++ b/x/pairing/client/cli/query_effective_policy.go
@@ -16,10 +16,16 @@ func CmdEffectivePolicy() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			specID := args[0]
-
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
 			var address string
 			if len(args) > 1 {
-				address = args[1]
+				address, err = utils.ParseCLIAddress(clientCtx, args[1])
+				if err != nil {
+					return err
+				}
 			} else {
 				clientCtxForTx, err := client.GetClientQueryContext(cmd)
 				if err != nil {
@@ -38,10 +44,6 @@ func CmdEffectivePolicy() *cobra.Command {
 					return err
 				}
 				address = addressAccount.String()
-			}
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)

--- a/x/pairing/client/cli/query_get_pairing.go
+++ b/x/pairing/client/cli/query_get_pairing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +18,12 @@ func CmdGetPairing() *cobra.Command {
 		Short: "Query getPairing",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			reqChainID := args[0]
-			reqClient := args[1]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			reqChainID := args[0]
+			reqClient, err := utils.ParseCLIAddress(clientCtx, args[1])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_provider_monthly_payout.go
+++ b/x/pairing/client/cli/query_provider_monthly_payout.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cobra"
 )
@@ -14,9 +15,11 @@ func CmdProviderMonthlyPayout() *cobra.Command {
 		components (the amount of funds from each subscription + chain ID)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			provider := args[0]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			provider, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_sdk_pairing.go
+++ b/x/pairing/client/cli/query_sdk_pairing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cobra"
 )
@@ -18,9 +19,11 @@ func CmdSdkPairing() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqChainID := args[0]
-			reqClient := args[1]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			reqClient, err := utils.ParseCLIAddress(clientCtx, args[1])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_subscription_monthly_payout.go
+++ b/x/pairing/client/cli/query_subscription_monthly_payout.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cobra"
 )
@@ -14,9 +15,11 @@ func CmdSubscriptionMonthlyPayout() *cobra.Command {
 		is going to be paid to provider and its components (the amount of funds for each provider, ordered by chain ID)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			consumer := args[0]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			consumer, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_user_entry.go
+++ b/x/pairing/client/cli/query_user_entry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -18,13 +19,17 @@ func CmdUserMaxCu() *cobra.Command {
 		Short: "Query userEntry",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			reqAddress := args[0]
-			reqChainID := args[1]
-			reqBlock, err := cast.ToUint64E(args[2])
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
-			clientCtx, err := client.GetClientQueryContext(cmd)
+
+			reqAddress, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+			reqChainID := args[1]
+			reqBlock, err := cast.ToUint64E(args[2])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/query_verify_pairing.go
+++ b/x/pairing/client/cli/query_verify_pairing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/pairing/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -18,15 +19,22 @@ func CmdVerifyPairing() *cobra.Command {
 		Short: "Query verifyPairing",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			reqChainID := args[0]
-			reqClient := args[1]
-			reqProvider := args[2]
-			reqBlock, err := cast.ToUint64E(args[3])
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			clientCtx, err := client.GetClientQueryContext(cmd)
+			reqChainID := args[0]
+			reqClient, err := utils.ParseCLIAddress(clientCtx, args[1])
+			if err != nil {
+				return err
+			}
+
+			reqProvider, err := utils.ParseCLIAddress(clientCtx, args[2])
+			if err != nil {
+				return err
+			}
+			reqBlock, err := cast.ToUint64E(args[3])
 			if err != nil {
 				return err
 			}

--- a/x/pairing/client/cli/tx_simulate_relay_payment.go
+++ b/x/pairing/client/cli/tx_simulate_relay_payment.go
@@ -38,7 +38,10 @@ func CmdSimulateRelayPayment() *cobra.Command {
 			}
 
 			// Extract arguments
-			consumerAddress := args[0]
+			consumerAddress, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
 
 			keyName, err := sigs.GetKeyName(clientCtx.WithFrom(consumerAddress))
 			if err != nil {
@@ -156,9 +159,6 @@ func newRelaySession(
 }
 
 func extractQoSFlag(qosValues []string) (qosReport *types.QualityOfServiceReport, err error) {
-	if err != nil {
-		return nil, err
-	}
 	// Check if we have exactly 3 values
 	if len(qosValues) != 3 {
 		return nil, utils.LavaFormatError("expected 3 values for QoSValuesFlag", nil, utils.Attribute{Key: "QoSValues", Value: qosValues})

--- a/x/pairing/client/cli/tx_stake_provider.go
+++ b/x/pairing/client/cli/tx_stake_provider.go
@@ -158,7 +158,7 @@ func CmdBulkStakeProvider() *cobra.Command {
 				return err
 			}
 
-			handleBulk := func(cmd *cobra.Command, args []string, validator string) (msgs []sdk.Msg, err error) {
+			handleBulk := func(args []string, validator string) (msgs []sdk.Msg, err error) {
 				if len(args) != BULK_ARG_COUNT {
 					return nil, fmt.Errorf("invalid argument length %d should be %d", len(args), BULK_ARG_COUNT)
 				}
@@ -208,7 +208,7 @@ func CmdBulkStakeProvider() *cobra.Command {
 				if argRange+BULK_ARG_COUNT > len(args) {
 					return fmt.Errorf("invalid argument count %d > %d", argRange+BULK_ARG_COUNT, len(args))
 				}
-				newMsgs, err := handleBulk(cmd, args[argRange:argRange+BULK_ARG_COUNT], validator)
+				newMsgs, err := handleBulk(args[argRange:argRange+BULK_ARG_COUNT], validator)
 				if err != nil {
 					return err
 				}

--- a/x/projects/client/cli/query_developer.go
+++ b/x/projects/client/cli/query_developer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/projects/types"
 	"github.com/spf13/cobra"
 )
@@ -21,10 +22,14 @@ func CmdDeveloper() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			developer, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 
-			params := &types.QueryDeveloperRequest{Developer: args[0]}
+			params := &types.QueryDeveloperRequest{Developer: developer}
 
 			res, err := queryClient.Developer(cmd.Context(), params)
 			if err != nil {

--- a/x/rewards/client/cli/query_iprpc_provider_reward_estimation.go
+++ b/x/rewards/client/cli/query_iprpc_provider_reward_estimation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/rewards/types"
 	"github.com/spf13/cobra"
 )
@@ -24,8 +25,13 @@ func CmdQueryIprpcProviderRewardEstimation() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
+			provider, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+
 			params := &types.QueryIprpcProviderRewardEstimationRequest{
-				Provider: args[0],
+				Provider: provider,
 			}
 
 			res, err := queryClient.IprpcProviderRewardEstimation(cmd.Context(), params)

--- a/x/rewards/client/cli/query_iprpc_spec_reward.go
+++ b/x/rewards/client/cli/query_iprpc_spec_reward.go
@@ -13,7 +13,7 @@ var _ = strconv.Itoa(0)
 
 func CmdQueryIprpcSpecReward() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "iprpc-spec-reward {spec}",
+		Use:   "iprpc-spec-reward [chain-id]",
 		Short: "Query for IPRPC rewards for a specific spec. If no spec is given, all IPRPC rewards will be shown",
 		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/x/rewards/client/cli/query_provider_reward.go
+++ b/x/rewards/client/cli/query_provider_reward.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/rewards/types"
 	"github.com/spf13/cobra"
 )
@@ -29,9 +30,12 @@ func CmdQueryProviderReward() *cobra.Command {
 			if len(args) == 2 {
 				reqChainID = args[1]
 			}
-			reqProvider := args[0]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			reqProvider, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/subscription/client/cli/query_current.go
+++ b/x/subscription/client/cli/query_current.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,10 @@ func CmdCurrent() *cobra.Command {
 				return err
 			}
 
-			reqConsumer := args[0]
+			reqConsumer, err := utils.ParseCLIAddress(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
 
 			queryClient := types.NewQueryClient(clientCtx)
 

--- a/x/subscription/client/cli/query_list_projects.go
+++ b/x/subscription/client/cli/query_list_projects.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +18,12 @@ func CmdListProjects() *cobra.Command {
 		Short: "Query all the subscription's projects",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			reqSubscription := args[0]
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			reqSubscription, err := utils.ParseCLIAddress(clientCtx, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/subscription/client/cli/tx_auto_renewal.go
+++ b/x/subscription/client/cli/tx_auto_renewal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -64,9 +65,14 @@ lavad tx subscription auto-renewal false <subscription_consumer> --from <subscri
 				consumer = args[2]
 			}
 
+			parsedConsumer, err := utils.ParseCLIAddress(clientCtx, consumer)
+			if err != nil {
+				return err
+			}
+
 			msg := types.NewMsgAutoRenewal(
 				creator,
-				consumer,
+				parsedConsumer,
 				planIndex,
 				enabled,
 			)

--- a/x/subscription/client/cli/tx_buy.go
+++ b/x/subscription/client/cli/tx_buy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lavanet/lava/utils"
 	"github.com/lavanet/lava/x/subscription/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -42,7 +43,10 @@ If the plan index is the same as the consumer's current plan, it will extend the
 
 			argConsumer := creator
 			if len(args) >= 2 {
-				argConsumer = args[1]
+				argConsumer, err = utils.ParseCLIAddress(clientCtx, args[1])
+				if err != nil {
+					return err
+				}
 			}
 
 			argDuration := uint64(1)


### PR DESCRIPTION
In this PR I've added support for CLI address arguments from the keyring.
Assume the local keyring account `alice` is the alias for the address: `lava@1wjg247k64kmu7ljh0j67ey3n2lrjett4uy6gn0`.

Currently, if you wanted to run the `delegator-rewards` query, only this will work:
`lavad query dualstaking delegator-rewards lava@1wjg247k64kmu7ljh0j67ey3n2lrjett4uy6gn0`

Now, this will also work:
`lavad query dualstaking delegator-rewards alice`

Note that you can still put the explicit lava address as the argument and it'll still work