### PR TITLE
feat: Add Manta Pacific Spec

### DIFF
--- a/cookbook/specs/spec_add_manta_pacific.json
+++ b/cookbook/specs/spec_add_manta_pacific.json
@@ -1,0 +1,118 @@
+{
+    "proposal": {
+        "title": "Add Specs: Manta Pacific",
+        "description": "Adding new specification support for relaying Manta Pacific data on Lava",
+        "specs": [
+            {
+                "index": "MANTAPACIFIC",
+                "name": "manta pacific mainnet",
+                "enabled": true,
+                "imports": [
+                    "ETH1"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 1,
+                "blocks_in_finalization_proof": 3,
+                "average_block_time": 10000,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0xa9"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "pruning",
+                                "values": [
+                                    {
+                                        "latest_distance": 1990000
+                                    },
+                                    {
+                                        "extension": "archive",
+                                        "expected_value": "0x0"
+                                    }
+                                ]
+                            }
+                        ],
+                        "extensions": [
+                            {
+                                "name": "archive",
+                                "cu_multiplier": 5,
+                                "rule": {
+                                    "block": 17040
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": "MANTAPACIFICT",
+                "name": "manta pacific testnet",
+                "enabled": true,
+                "imports": [
+                    "MANTAPACIFIC"
+                ],
+                "reliability_threshold": 268435455,
+                "data_reliability_enabled": true,
+                "block_distance_for_finalized_data": 1,
+                "blocks_in_finalization_proof": 3,
+                "average_block_time": 10000,
+                "allowed_block_lag_for_qos_sync": 2,
+                "shares": 1,
+                "min_stake_provider": {
+                    "denom": "ulava",
+                    "amount": "47500000000"
+                },
+                "api_collections": [
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "jsonrpc",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": ""
+                        },
+                        "apis": [],
+                        "headers": [],
+                        "inheritance_apis": [],
+                        "parse_directives": [],
+                        "verifications": [
+                            {
+                                "name": "chain-id",
+                                "values": [
+                                    {
+                                        "expected_value": "0x34816d"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "deposit": "10000000ulava"
+}


### PR DESCRIPTION
The full test worked just fine and from what I can tell Manta Pacific doesn't have any custom RPC methods on top of the Ethereum EVM spec.

Testing command:
```
./scripts/test_spec_full.sh cookbook/specs/spec_add_manta_pacific.json jsonrpc https://pacific-rpc.manta.network/http jsonrpc https://pacific-rpc.testnet.manta.network/http
```

FYI, it looks like there hasn't been a new block on the testnet in around a month, so there won't be any new block log lines.