### PR TITLE
fix: adding missing cosmos methods

### DIFF
--- a/cookbook/specs/spec_add_cosmossdk.json
+++ b/cookbook/specs/spec_add_cosmossdk.json
@@ -845,6 +845,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "/cosmos/consensus/v1/params",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "/cosmos/distribution/v1beta1/community_pool",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -1475,6 +1493,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "/cosmos/params/v1beta1/subspaces",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "/cosmos/slashing/v1beta1/params",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -1901,6 +1937,24 @@
                                         "0"
                                     ],
                                     "parser_func": "PARSE_DICTIONARY_OR_ORDERED"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/cosmos/upgrade/v1beta1/authority",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
                                 },
                                 "compute_units": 10,
                                 "enabled": true,

--- a/cookbook/specs/spec_add_cosmoswasm.json
+++ b/cookbook/specs/spec_add_cosmoswasm.json
@@ -207,6 +207,24 @@
                                     "stateful": 0
                                 },
                                 "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/cosmwasm/wasm/v1/contracts/creator/{creator_address}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        ""
+                                    ],
+                                    "parser_func": "EMPTY"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             }
                         ],
                         "headers": [],

--- a/cookbook/specs/spec_add_ibc.json
+++ b/cookbook/specs/spec_add_ibc.json
@@ -281,6 +281,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/next_sequence_send",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        ""
+                                    ],
+                                    "parser_func": "EMPTY"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/packet_acknowledgements",
                                 "block_parsing": {
                                     "parser_arg": [


### PR DESCRIPTION
I'm working on an Injective spec right now, and I noticed that some of the APIs listed in their docs are not in the cosmos specs. I double checked the cosmos repos and I found the methods Injective uses.

Cosmos repo links to added methods:

https://github.com/cosmos/ibc-go/blob/cf68eed722589ebfda122035a48303772a681ce6/proto/ibc/core/channel/v1/query.proto#L106

https://github.com/CosmWasm/wasmd/blob/e5260f03a0ffe5f4d069078b550e5c47f15c1394/proto/cosmwasm/wasm/v1/query.proto#L73

https://github.com/cosmos/cosmos-sdk/blob/2100a73dcea634ce914977dbddb4991a020ee345/proto/cosmos/upgrade/v1beta1/query.proto#L43

https://github.com/cosmos/cosmos-sdk/blob/2100a73dcea634ce914977dbddb4991a020ee345/proto/cosmos/params/v1beta1/query.proto#L23

https://github.com/cosmos/cosmos-sdk/blob/2100a73dcea634ce914977dbddb4991a020ee345/proto/cosmos/consensus/v1/query.proto#L14