### PR TITLE
fix: unlink cache unix socket

### DIFF
--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/lavanet/lava/protocol/chainlib/chainproxy"
@@ -85,24 +86,29 @@ func (cs *CacheServer) Serve(ctx context.Context,
 	var lis net.Listener
 	var err error
 	if strings.HasPrefix(listenAddr, unixPrefix) { // Unix socket
-		socketPath := strings.TrimPrefix(listenAddr, unixPrefix)
 
-		// err = syscall.Unlink(socketPath)
-		// if err != nil {
-		// 	// not really important if it fails
-		// 	utils.LavaFormatFatal("Unlink()", err)
-		// }
-
-		lis, err = net.Listen("unix", socketPath)
+		host, port, err := net.SplitHostPort(listenAddr)
 		if err != nil {
-			utils.LavaFormatFatal("Cache server failure setting up Unix socket listener: %v\n", err)
+			utils.LavaFormatFatal("Failed parse Unix socket: %v\n", err)
 			return
 		}
 
-		defer lis.Close()
+		syscall.Unlink(port)
+
+		addr, err := net.ResolveUnixAddr(host, port)
+		if err != nil {
+			utils.LavaFormatFatal("Failed to resolve unix socket address: %v\n", err)
+			return
+		}
+
+		lis, err = net.ListenUnix(host, addr)
+		if err != nil {
+			utils.LavaFormatFatal("Faild to listen to unix socket listener: %v\n", err)
+			return
+		}
 
 		// Set permissions for the Unix socket
-		err := os.Chmod(socketPath, 0o600)
+		err = os.Chmod(port, 0o600)
 		if err != nil {
 			utils.LavaFormatFatal("Failed to set permissions for Unix socket: %v\n", err)
 			return

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -86,11 +86,20 @@ func (cs *CacheServer) Serve(ctx context.Context,
 	var err error
 	if strings.HasPrefix(listenAddr, unixPrefix) { // Unix socket
 		socketPath := strings.TrimPrefix(listenAddr, unixPrefix)
+
+		// err = syscall.Unlink(socketPath)
+		// if err != nil {
+		// 	// not really important if it fails
+		// 	utils.LavaFormatFatal("Unlink()", err)
+		// }
+
 		lis, err = net.Listen("unix", socketPath)
 		if err != nil {
 			utils.LavaFormatFatal("Cache server failure setting up Unix socket listener: %v\n", err)
 			return
 		}
+
+		defer lis.Close()
 
 		// Set permissions for the Unix socket
 		err := os.Chmod(socketPath, 0o600)

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -89,7 +89,7 @@ func (cs *CacheServer) Serve(ctx context.Context,
 
 		host, port, err := net.SplitHostPort(listenAddr)
 		if err != nil {
-			utils.LavaFormatFatal("Failed parse Unix socket: %v\n", err)
+			utils.LavaFormatFatal("Failed to parse Unix socket: %v\n", err)
 			return
 		}
 

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -86,7 +86,6 @@ func (cs *CacheServer) Serve(ctx context.Context,
 	var lis net.Listener
 	var err error
 	if strings.HasPrefix(listenAddr, unixPrefix) { // Unix socket
-
 		host, port, err := net.SplitHostPort(listenAddr)
 		if err != nil {
 			utils.LavaFormatFatal("Failed to parse Unix socket: %v\n", err)

--- a/ecosystem/cache/server.go
+++ b/ecosystem/cache/server.go
@@ -88,7 +88,7 @@ func (cs *CacheServer) Serve(ctx context.Context,
 	if strings.HasPrefix(listenAddr, unixPrefix) { // Unix socket
 		host, port, err := net.SplitHostPort(listenAddr)
 		if err != nil {
-			utils.LavaFormatFatal("Failed to parse Unix socket: %v\n", err)
+			utils.LavaFormatFatal("Failed to parse unix socket, provide address in this format unix:/tmp/example.sock: %v\n", err)
 			return
 		}
 


### PR DESCRIPTION
# Description

When deploying the cache service on a machine that already had one running the error: `bind failed. Error: Address already in use`.  Unlike TCP the sock file must be cleaned out of the filesystem after service exit.

Using `syscall.unlink` before creating the new unix socket makes sure that the filesystem is clean when creating a new one. 
This also makes sure that no matter how the program existed the socket will always be deleted.
 
Also using `SplitHostPort` and `ResolveUnixAddr` to properly parse and initiate the unix socket.

## How this was tested? 
Aside from running locally, this was tested by coping the PR artifact to testing server, restarting the cache, then restarting it again and making sure IPRPC can reach it.

# Author Checklist

 - [x] This feature was tested
 - [x] Lint and tests passed locally 
 - [ ] This feature was documented