### PR TITLE
fix: CNS-974: remove modify-provider limitation of reducing stake

### DIFF
--- a/x/pairing/client/cli/tx_modify_provider.go
+++ b/x/pairing/client/cli/tx_modify_provider.go
@@ -118,9 +118,6 @@ func CmdModifyProvider() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if providerEntry.Stake.Amount.GT(newStake.Amount) {
-					return utils.LavaFormatError("can't reduce provider stake", nil, utils.Attribute{Key: "current", Value: providerEntry.Stake}, utils.Attribute{Key: "requested", Value: providerEntry.Stake})
-				}
 				providerEntry.Stake = newStake
 			}
 			var geolocation int32


### PR DESCRIPTION
In this PR I deleted the limitation of reducing stake using the `modify-provider` TX. This was legacy code that was written when stake could not be partly reduced, so it's not relevant anymore.