### PR TITLE
feat: PRT-adding relay debug headers

### DIFF
--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -25,6 +25,7 @@ const (
 	PROVIDER_LATEST_BLOCK_HEADER_NAME               = "Provider-Latest-Block"
 	GUID_HEADER_NAME                                = "Lava-Guid"
 	ERRORED_PROVIDERS_HEADER_NAME                   = "Lava-Errored-Providers"
+	REPORTED_PROVIDERS_HEADER_NAME                  = "Lava-Reported-Providers"
 	// these headers need to be lowercase
 	BLOCK_PROVIDERS_ADDRESSES_HEADER_NAME = "lava-providers-block"
 	RELAY_TIMEOUT_HEADER_NAME             = "lava-relay-timeout"

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -24,12 +24,13 @@ const (
 	RETRY_COUNT_HEADER_NAME                         = "Lava-Retries"
 	PROVIDER_LATEST_BLOCK_HEADER_NAME               = "Provider-Latest-Block"
 	GUID_HEADER_NAME                                = "Lava-Guid"
+	ERRORED_PROVIDERS_HEADER_NAME                   = "Lava-Errored-Providers"
 	// these headers need to be lowercase
 	BLOCK_PROVIDERS_ADDRESSES_HEADER_NAME = "lava-providers-block"
 	RELAY_TIMEOUT_HEADER_NAME             = "lava-relay-timeout"
 	EXTENSION_OVERRIDE_HEADER_NAME        = "lava-extension"
 	FORCE_CACHE_REFRESH_HEADER_NAME       = "lava-force-cache-refresh"
-	LAVA_DEBUG                            = "lava-debug"
+	LAVA_DEBUG                            = "lava-debug-relay"
 	// send http request to /lava/health to see if the process is up - (ret code 200)
 	DEFAULT_HEALTH_PATH                                       = "/lava/health"
 	MAXIMUM_ALLOWED_TIMEOUT_EXTEND_MULTIPLIER_BY_THE_CONSUMER = 4

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -31,7 +31,7 @@ const (
 	RELAY_TIMEOUT_HEADER_NAME             = "lava-relay-timeout"
 	EXTENSION_OVERRIDE_HEADER_NAME        = "lava-extension"
 	FORCE_CACHE_REFRESH_HEADER_NAME       = "lava-force-cache-refresh"
-	LAVA_DEBUG                            = "lava-debug-relay"
+	LAVA_DEBUG_RELAY                      = "lava-debug-relay"
 	// send http request to /lava/health to see if the process is up - (ret code 200)
 	DEFAULT_HEALTH_PATH                                       = "/lava/health"
 	MAXIMUM_ALLOWED_TIMEOUT_EXTEND_MULTIPLIER_BY_THE_CONSUMER = 4

--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -195,6 +195,7 @@ func (up *UsedProviders) GetErroredProviders() map[string]struct{} {
 	defer up.lock.RUnlock()
 	return up.erroredProviders
 }
+
 func (up *UsedProviders) GetUnwantedProvidersToSend() map[string]struct{} {
 	if up == nil {
 		return map[string]struct{}{}

--- a/protocol/lavasession/used_providers.go
+++ b/protocol/lavasession/used_providers.go
@@ -23,7 +23,7 @@ func NewUsedProviders(directiveHeaders map[string]string) *UsedProviders {
 			}
 		}
 	}
-	return &UsedProviders{providers: map[string]struct{}{}, unwantedProviders: unwantedProviders, blockOnSyncLoss: map[string]struct{}{}}
+	return &UsedProviders{providers: map[string]struct{}{}, unwantedProviders: unwantedProviders, blockOnSyncLoss: map[string]struct{}{}, erroredProviders: map[string]struct{}{}}
 }
 
 type UsedProviders struct {
@@ -31,6 +31,7 @@ type UsedProviders struct {
 	providers           map[string]struct{}
 	selecting           bool
 	unwantedProviders   map[string]struct{}
+	erroredProviders    map[string]struct{} // providers who returned protocol errors (used to debug relays for now)
 	blockOnSyncLoss     map[string]struct{}
 	sessionsLatestBatch int
 }
@@ -100,6 +101,7 @@ func (up *UsedProviders) RemoveUsed(provider string, err error) {
 	up.lock.Lock()
 	defer up.lock.Unlock()
 	if err != nil {
+		up.erroredProviders[provider] = struct{}{}
 		if shouldRetryWithThisError(err) {
 			_, ok := up.blockOnSyncLoss[provider]
 			if !ok && IsSessionSyncLoss(err) {
@@ -185,6 +187,14 @@ func (up *UsedProviders) tryLockSelection() bool {
 	return false
 }
 
+func (up *UsedProviders) GetErroredProviders() map[string]struct{} {
+	if up == nil {
+		return map[string]struct{}{}
+	}
+	up.lock.RLock()
+	defer up.lock.RUnlock()
+	return up.erroredProviders
+}
 func (up *UsedProviders) GetUnwantedProvidersToSend() map[string]struct{} {
 	if up == nil {
 		return map[string]struct{}{}

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -3,6 +3,7 @@ package rpcconsumer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -274,7 +275,7 @@ func (rpccs *RPCConsumerServer) SendRelay(
 	// asynchronously sends data reliability if necessary
 
 	// remove lava directive headers
-	metadata, directiveHeaders := rpccs.LavaDirectiveHeaders(metadata)
+	metadata, directiveHeaders, debugRelay := rpccs.LavaDirectiveHeaders(metadata)
 	relaySentTime := time.Now()
 	chainMessage, err := rpccs.chainParser.ParseMsg(url, []byte(req), connectionType, metadata, rpccs.getExtensionsFromDirectiveHeaders(directiveHeaders))
 	if err != nil {
@@ -316,7 +317,7 @@ func (rpccs *RPCConsumerServer) SendRelay(
 	}
 
 	returnedResult, err := relayProcessor.ProcessingResult()
-	rpccs.appendHeadersToRelayResult(ctx, returnedResult, relayProcessor.ProtocolErrors())
+	rpccs.appendHeadersToRelayResult(ctx, returnedResult, relayProcessor.ProtocolErrors(), relayProcessor, debugRelay)
 	if err != nil {
 		return returnedResult, utils.LavaFormatError("failed processing responses from providers", err, utils.Attribute{Key: "GUID", Value: ctx}, utils.LogAttr("endpoint", rpccs.listenEndpoint.Key()))
 	}
@@ -965,9 +966,10 @@ func (rpccs *RPCConsumerServer) getProcessingTimeout(chainMessage chainlib.Chain
 	return processingTimeout, relayTimeout
 }
 
-func (rpccs *RPCConsumerServer) LavaDirectiveHeaders(metadata []pairingtypes.Metadata) ([]pairingtypes.Metadata, map[string]string) {
+func (rpccs *RPCConsumerServer) LavaDirectiveHeaders(metadata []pairingtypes.Metadata) ([]pairingtypes.Metadata, map[string]string, bool) {
 	metadataRet := []pairingtypes.Metadata{}
 	headerDirectives := map[string]string{}
+	lavaDebugRelay := false
 	for _, metaElement := range metadata {
 		name := strings.ToLower(metaElement.Name)
 		switch name {
@@ -975,13 +977,14 @@ func (rpccs *RPCConsumerServer) LavaDirectiveHeaders(metadata []pairingtypes.Met
 		case common.RELAY_TIMEOUT_HEADER_NAME:
 		case common.EXTENSION_OVERRIDE_HEADER_NAME:
 		case common.FORCE_CACHE_REFRESH_HEADER_NAME:
-		case common.LAVA_DEBUG:
 			headerDirectives[name] = metaElement.Value
+		case common.LAVA_DEBUG:
+			lavaDebugRelay = true
 		default:
 			metadataRet = append(metadataRet, metaElement)
 		}
 	}
-	return metadataRet, headerDirectives
+	return metadataRet, headerDirectives, lavaDebugRelay
 }
 
 func (rpccs *RPCConsumerServer) getExtensionsFromDirectiveHeaders(directiveHeaders map[string]string) extensionslib.ExtensionInfo {
@@ -1014,7 +1017,7 @@ func (rpccs *RPCConsumerServer) HandleDirectiveHeadersForMessage(chainMessage ch
 	chainMessage.SetForceCacheRefresh(ok)
 }
 
-func (rpccs *RPCConsumerServer) appendHeadersToRelayResult(ctx context.Context, relayResult *common.RelayResult, protocolErrors uint64) {
+func (rpccs *RPCConsumerServer) appendHeadersToRelayResult(ctx context.Context, relayResult *common.RelayResult, protocolErrors uint64, relayProcessor *RelayProcessor, debugRelays bool) {
 	if relayResult == nil {
 		return
 	}
@@ -1068,6 +1071,27 @@ func (rpccs *RPCConsumerServer) appendHeadersToRelayResult(ctx context.Context, 
 		}
 		relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, extensionMD)
 	}
+
+	if debugRelays {
+		erroredProviders := relayProcessor.GetUsedProviders().GetErroredProviders()
+		if len(erroredProviders) > 0 {
+			erroredProvidersArray := make([]string, len(erroredProviders))
+			idx := 0
+			for providerAddress := range erroredProviders {
+				erroredProvidersArray[idx] = providerAddress
+				idx++
+			}
+			erroredProvidersString := fmt.Sprintf("%v", erroredProvidersArray)
+			erroredProvidersMD := pairingtypes.Metadata{
+				Name:  common.ERRORED_PROVIDERS_HEADER_NAME,
+				Value: erroredProvidersString,
+			}
+			relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, erroredProvidersMD)
+		}
+
+		currentReportedProviders := rpccs.consumerSessionManager.GetReportedProviders(uint64(relayResult.Request.RelaySession.Epoch))
+	}
+
 	relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, metadataReply...)
 }
 

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -1090,6 +1090,18 @@ func (rpccs *RPCConsumerServer) appendHeadersToRelayResult(ctx context.Context, 
 		}
 
 		currentReportedProviders := rpccs.consumerSessionManager.GetReportedProviders(uint64(relayResult.Request.RelaySession.Epoch))
+		if len(currentReportedProviders) > 0 {
+			reportedProvidersArray := make([]string, len(currentReportedProviders))
+			for idx, providerAddress := range currentReportedProviders {
+				reportedProvidersArray[idx] = providerAddress.Address
+			}
+			reportedProvidersString := fmt.Sprintf("%v", reportedProvidersArray)
+			reportedProvidersMD := pairingtypes.Metadata{
+				Name:  common.REPORTED_PROVIDERS_HEADER_NAME,
+				Value: reportedProvidersString,
+			}
+			relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, reportedProvidersMD)
+		}
 	}
 
 	relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, metadataReply...)

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -978,7 +978,7 @@ func (rpccs *RPCConsumerServer) LavaDirectiveHeaders(metadata []pairingtypes.Met
 		case common.EXTENSION_OVERRIDE_HEADER_NAME:
 		case common.FORCE_CACHE_REFRESH_HEADER_NAME:
 			headerDirectives[name] = metaElement.Value
-		case common.LAVA_DEBUG:
+		case common.LAVA_DEBUG_RELAY:
 			lavaDebugRelay = true
 		default:
 			metadataRet = append(metadataRet, metaElement)

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
@@ -79,9 +79,9 @@ $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer3 --chain
 
 wait_next_block
 
-# screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
-# 127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
-# $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug --from user1 --chain-id lava --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
+screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
+127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
+$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level debug --from user1 --chain-id lava --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
 
 echo "--- setting up screens done ---"
 screen -ls

--- a/testutil/e2e/allowedErrorList.go
+++ b/testutil/e2e/allowedErrorList.go
@@ -12,8 +12,9 @@ var allowedErrors = map[string]string{
 }
 
 var allowedErrorsDuringEmergencyMode = map[string]string{
-	"connection refused":       "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
-	"connection reset by peer": "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
+	"connection refused":           "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
+	"connection reset by peer":     "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
+	"Failed Querying EpochDetails": "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
 }
 
 var allowedErrorsPaymentE2E = map[string]string{

--- a/testutil/e2e/paymentE2E.go
+++ b/testutil/e2e/paymentE2E.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/lavanet/lava/cmd/lavad/cmd"
 	commonconsts "github.com/lavanet/lava/testutil/common/consts"
+	e2esdk "github.com/lavanet/lava/testutil/e2e/sdk"
 	"github.com/lavanet/lava/utils"
 	dualstakingTypes "github.com/lavanet/lava/x/dualstaking/types"
 	epochStorageTypes "github.com/lavanet/lava/x/epochstorage/types"
@@ -283,7 +283,7 @@ func runPaymentE2E(timeout time.Duration) {
 		protocolPath: gopath + lavapPath,
 		lavadArgs:    "--geolocation 1 --log_level debug",
 		consumerArgs: " --allow-insecure-provider-dialing",
-		logs:         make(map[string]*bytes.Buffer),
+		logs:         make(map[string]*e2esdk.SafeBuffer),
 		commands:     make(map[string]*exec.Cmd),
 		providerType: make(map[string][]epochStorageTypes.Endpoint),
 		logPath:      protocolLogsFolder,

--- a/testutil/e2e/sdkE2E.go
+++ b/testutil/e2e/sdkE2E.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"go/build"
@@ -96,7 +95,7 @@ func runSDKE2E(timeout time.Duration) {
 		protocolPath: gopath + "/bin/lavap",
 		lavadArgs:    "--geolocation 1 --log_level debug",
 		consumerArgs: " --allow-insecure-provider-dialing",
-		logs:         make(map[string]*bytes.Buffer),
+		logs:         make(map[string]*sdk.SafeBuffer),
 		commands:     make(map[string]*exec.Cmd),
 		providerType: make(map[string][]epochStorageTypes.Endpoint),
 		logPath:      sdkLogsFolder,
@@ -148,7 +147,7 @@ func runSDKE2E(timeout time.Duration) {
 	lt.startLavaProviders(ctx)
 
 	// Test SDK
-	lt.logs["01_sdkTest"] = new(bytes.Buffer)
+	lt.logs["01_sdkTest"] = &sdk.SafeBuffer{}
 	sdk.RunSDKTests(ctx, grpcConn, privateKey, publicKey, lt.logs["01_sdkTest"], "7070")
 
 	// Emergency mode tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tracking of providers that returned protocol errors.

- **Bug Fixes**
  - Added a new error message "Failed Querying EpochDetails" to allowed errors during emergency mode.

- **Refactor**
  - Replaced `bytes.Buffer` with `SafeBuffer` for safe concurrent buffer operations in logs across multiple files.

- **Chores**
  - Updated debug relay handling in `RPCConsumerServer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->