### PR TITLE
fix  docs.go

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -19,25 +19,50 @@ var staticFiles embed.FS
 //go:embed template
 var templateFiles embed.FS
 
-func RegisterOpenAPIService(appName string, rtr *mux.Router) {
-	rtr.Handle(apiFilePath, http.FileServer(http.FS(staticFiles)))
-	rtr.HandleFunc("/", handler(appName))
+func RegisterOpenAPIService(appName string, rtr *mux.Router) error {
+	if err := registerStaticFiles(rtr); err != nil {
+		return err
+	}
+	if err := registerTemplateHandler(appName, rtr); err != nil {
+		return err
+	}
+	return nil
 }
 
-// openapi handler returns a handler that serves the openapi documentation
-func handler(title string) http.HandlerFunc {
+func registerStaticFiles(rtr *mux.Router) error {
+	rtr.Handle(apiFilePath, http.FileServer(http.FS(staticFiles)))
+	return nil
+}
+
+func registerTemplateHandler(appName string, rtr *mux.Router) error {
+	t, err := parseTemplates()
+	if err != nil {
+		return err
+	}
+	rtr.HandleFunc("/", handler(t, appName))
+	return nil
+}
+
+func parseTemplates() (*httptemplate.Template, error) {
 	t, err := httptemplate.ParseFS(templateFiles, indexTemplatePath)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
+	return t, nil
+}
 
+func handler(t *httptemplate.Template, title string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		t.Execute(w, struct {
+		data := struct {
 			Title string
 			URL   string
 		}{
-			title,
-			apiFilePath,
-		})
+			Title: title,
+			URL:   apiFilePath,
+		}
+		if err := t.Execute(w, data); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}
 }
+


### PR DESCRIPTION
Hello
Changes Made
RegisterOpenAPIService Function: This now handles registering both the static files and the template handler, returning an error if any part fails.
registerStaticFiles Function: Encapsulates the logic for handling static files.
registerTemplateHandler Function: Handles the template registration and parsing, returning an error if it occurs.
parseTemplates Function: Separates the template parsing logic, making it easier to test and modify.
Error Handling in handler Function: Uses http.Error to respond with a 500 status code in case of template execution errors instead of panicking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling during the registration of static files and template handlers.
	- Added modular helper functions for static file management and template rendering.

- **Bug Fixes**
	- Enhanced error propagation to prevent application crashes due to unhandled errors.

- **Refactor**
	- Updated function signatures for better flexibility and reusability in handling templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->