### PR TITLE
fix: PRT - Fix failing E2E on emergency mode

### DIFF
--- a/testutil/e2e/allowedErrorList.go
+++ b/testutil/e2e/allowedErrorList.go
@@ -13,6 +13,7 @@ var allowedErrors = map[string]string{
 
 var allowedErrorsDuringEmergencyMode = map[string]string{
 	"connection refused":           "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
+	"Connection refused":           "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
 	"connection reset by peer":     "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
 	"Failed Querying EpochDetails": "Connection to tendermint port sometimes can happen as we shut down the node and we try to fetch info during emergency mode",
 }


### PR DESCRIPTION
There is already, `"connection refused"` in `allowedErrorsDuringEmergencyMode`, but now that the `"Connection refused"` is added as reason to errors when disconnecting the node,  as can be seen in this error log:
`ERR Provider Side Failed Sending Message, Reason: Connection refused`, `"Connection refused"` needed to be added as well.