### PR TITLE
test: PRT: Add tests for addons and extensions after spec update

### DIFF
--- a/protocol/chainlib/jsonRPC_test.go
+++ b/protocol/chainlib/jsonRPC_test.go
@@ -507,3 +507,163 @@ func TestJsonRpcInternalPathsMultipleVersionsAvalanche(t *testing.T) {
 		}
 	}
 }
+
+func TestJsonRPC_SpecUpdateWithAddons(t *testing.T) {
+	// create a new instance of RestChainParser
+	apip, err := NewJrpcChainParser()
+	if err != nil {
+		t.Errorf("Error creating RestChainParser: %v", err)
+	}
+
+	// set the spec
+	spec := spectypes.Spec{
+		Enabled:                       true,
+		ReliabilityThreshold:          10,
+		AllowedBlockLagForQosSync:     11,
+		AverageBlockTime:              12000,
+		BlockDistanceForFinalizedData: 13,
+		BlocksInFinalizationProof:     14,
+		ApiCollections: []*spectypes.ApiCollection{
+			{
+				Enabled: true,
+				CollectionData: spectypes.CollectionData{
+					ApiInterface: "jsonrpc",
+					InternalPath: "",
+					Type:         "POST",
+					AddOn:        "debug",
+				},
+				Apis: []*spectypes.Api{
+					{
+						Enabled: true,
+						Name:    "foo",
+					},
+				},
+			},
+		},
+	}
+
+	// Set the spec for the first time
+	apip.SetSpec(spec)
+
+	// At first, addon should be disabled
+	require.False(t, apip.allowedAddons["debug"])
+
+	// Setting the spec again, for sanity check
+	apip.SetSpec(spec)
+
+	// Sanity check that addon still disabled
+	require.False(t, apip.allowedAddons["debug"])
+
+	// Allow the addon
+	apip.SetPolicyFromAddonAndExtensionMap(map[string]struct{}{
+		"debug": {},
+	})
+
+	// Sanity check
+	require.True(t, apip.allowedAddons["debug"])
+
+	// Set the spec again
+	apip.SetSpec(spec)
+
+	// Should stay the same
+	require.True(t, apip.allowedAddons["debug"])
+
+	// Disallow the addon
+	apip.SetPolicyFromAddonAndExtensionMap(map[string]struct{}{})
+
+	// Sanity check
+	require.False(t, apip.allowedAddons["debug"])
+
+	// Set the spec again
+	apip.SetSpec(spec)
+
+	// Should stay the same
+	require.False(t, apip.allowedAddons["debug"])
+}
+
+func TestJsonRPC_SpecUpdateWithExtensions(t *testing.T) {
+	// create a new instance of RestChainParser
+	apip, err := NewJrpcChainParser()
+	if err != nil {
+		t.Errorf("Error creating RestChainParser: %v", err)
+	}
+
+	// set the spec
+	spec := spectypes.Spec{
+		Enabled:                       true,
+		ReliabilityThreshold:          10,
+		AllowedBlockLagForQosSync:     11,
+		AverageBlockTime:              12000,
+		BlockDistanceForFinalizedData: 13,
+		BlocksInFinalizationProof:     14,
+		ApiCollections: []*spectypes.ApiCollection{
+			{
+				Enabled: true,
+				CollectionData: spectypes.CollectionData{
+					ApiInterface: "jsonrpc",
+					InternalPath: "",
+					Type:         "POST",
+					AddOn:        "",
+				},
+				Extensions: []*spectypes.Extension{
+					{
+						Name: "archive",
+						Rule: &spectypes.Rule{
+							Block: 123,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	extensionKey := extensionslib.ExtensionKey{
+		Extension:      "archive",
+		ConnectionType: "POST",
+		InternalPath:   "",
+		Addon:          "",
+	}
+
+	isExtensionConfigured := func() bool {
+		_, isConfigured := apip.extensionParser.GetConfiguredExtensions()[extensionKey]
+		return isConfigured
+	}
+
+	// Set the spec for the first time
+	apip.SetSpec(spec)
+
+	// At first, extension should not be configured
+	require.False(t, isExtensionConfigured())
+
+	// Setting the spec again, for sanity check
+	apip.SetSpec(spec)
+
+	// Sanity check that extension is still not configured
+	require.False(t, isExtensionConfigured())
+
+	// Allow the extension
+	apip.SetPolicyFromAddonAndExtensionMap(map[string]struct{}{
+		"archive": {},
+	})
+
+	// Sanity check
+	require.True(t, isExtensionConfigured())
+
+	// Set the spec again
+	apip.SetSpec(spec)
+
+	// Should stay the same
+	require.True(t, isExtensionConfigured())
+
+	// Disallow the extension
+	apip.SetPolicyFromAddonAndExtensionMap(map[string]struct{}{})
+
+	// Sanity check
+	require.False(t, isExtensionConfigured())
+
+	// Set the spec again
+	apip.SetSpec(spec)
+
+	// Should stay the same
+	require.False(t, isExtensionConfigured())
+}


### PR DESCRIPTION
This PR adds two new tests:
1. `TestJsonRPC_SpecUpdateWithAddons` - To test that the add-ons policy stays the same after a spec update
2. `TestJsonRPC_SpecUpdateWithExtensions` - To test that the extensions policy stays the same after a spec update