### PR TITLE
fix: PRT - tendermintrpc spec update - non deterministic queries

### DIFF
--- a/cookbook/specs/tendermint.json
+++ b/cookbook/specs/tendermint.json
@@ -139,7 +139,7 @@
                                 "compute_units": 10,
                                 "enabled": true,
                                 "category": {
-                                    "deterministic": true,
+                                    "deterministic": false,
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 0
@@ -474,7 +474,7 @@
                                 "compute_units": 10,
                                 "enabled": true,
                                 "category": {
-                                    "deterministic": true,
+                                    "deterministic": false,
                                     "local": false,
                                     "subscription": false,
                                     "stateful": 0

--- a/protocol/lavaprotocol/request_builder.go
+++ b/protocol/lavaprotocol/request_builder.go
@@ -151,7 +151,14 @@ func compareRelaysFindConflict(ctx context.Context, reply1 pairingtypes.RelayRep
 	}
 
 	// they have different data! report!
-	utils.LavaFormatWarning("Simulation: DataReliability detected mismatching results, Reporting...", nil, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: "Data0", Value: string(reply1.Data)}, utils.Attribute{Key: "Data1", Value: reply2.Data})
+	utils.LavaFormatWarning("Simulation: DataReliability detected mismatching results, Reporting...", nil,
+		utils.LogAttr("GUID", ctx),
+		utils.LogAttr("Request0", request1.RelayData),
+		utils.LogAttr("Data0", string(reply1.Data)),
+		utils.LogAttr("Request1", request2.RelayData),
+		utils.LogAttr("Data1", string(reply2.Data)),
+	)
+
 	responseConflict = &conflicttypes.ResponseConflict{
 		ConflictRelayData0: conflictconstruct.ConstructConflictRelayData(&reply1, &request1),
 		ConflictRelayData1: conflictconstruct.ConstructConflictRelayData(&reply2, &request2),


### PR DESCRIPTION
The discrepancy we found was in the in the log field of the tendermint's object called `ResponseDeliverTx` which is part of the `block_results` , `tx` and `broadcast_tx_commit` queries.

The discrepancy is in the timestamp, most likely because of different time zones. 

Our hypothesis is that the log field is no coming from on-chain data, and being calculated on spot. 
Adding a timestamp to it results in discrepancy in the results.
