### PR TITLE
fix: estimate rewards query returns wrong estimations

### DIFF
--- a/x/rewards/keeper/iprpc.go
+++ b/x/rewards/keeper/iprpc.go
@@ -174,9 +174,9 @@ func (k Keeper) distributeIprpcRewards(ctx sdk.Context, iprpcReward types.IprpcR
 				continue
 			}
 			// calculate provider IPRPC reward
-			providerIprpcReward := specFund.Fund.MulInt(sdk.NewIntFromUint64(providerCU.CU)).QuoInt(sdk.NewIntFromUint64(specCu.TotalCu))
+			providerAndDelegatorsIprpcReward := specFund.Fund.MulInt(sdk.NewIntFromUint64(providerCU.CU)).QuoInt(sdk.NewIntFromUint64(specCu.TotalCu))
 
-			UsedRewardTemp := UsedReward.Add(providerIprpcReward...)
+			UsedRewardTemp := UsedReward.Add(providerAndDelegatorsIprpcReward...)
 			if UsedReward.IsAnyGT(specFund.Fund) {
 				utils.LavaFormatError("failed to send iprpc rewards to provider", fmt.Errorf("tried to send more rewards than funded"), utils.LogAttr("provider", providerCU))
 				break
@@ -184,12 +184,17 @@ func (k Keeper) distributeIprpcRewards(ctx sdk.Context, iprpcReward types.IprpcR
 			UsedReward = UsedRewardTemp
 
 			// reward the provider
-			providerOnlyReward, err := k.dualstakingKeeper.RewardProvidersAndDelegators(ctx, providerCU.Provider, specFund.Spec, providerIprpcReward, string(types.IprpcPoolName), false, false, false)
+			providerReward, err := k.dualstakingKeeper.RewardProvidersAndDelegators(ctx, providerCU.Provider, specFund.Spec, providerAndDelegatorsIprpcReward, string(types.IprpcPoolName), false, false, false)
 			if err != nil {
 				// failed sending the rewards, add the claimable rewards to the leftovers that will be transferred to the community pool
-				utils.LavaFormatPanic("failed to send iprpc rewards to provider", err, utils.LogAttr("provider", providerCU))
+				utils.LavaFormatError("failed to send iprpc rewards to provider", err,
+					utils.LogAttr("provider", providerCU.Provider),
+					utils.LogAttr("chain_id", specFund.Spec),
+					utils.LogAttr("provider_and_delegators_reward", providerAndDelegatorsIprpcReward.String()),
+					utils.LogAttr("provider_reward", providerReward.String()),
+				)
 			}
-			details[providerCU.Provider] = fmt.Sprintf("cu: %d reward: %s", providerCU.CU, providerOnlyReward.String())
+			details[providerCU.Provider] = fmt.Sprintf("cu: %d reward: %s", providerCU.CU, providerAndDelegatorsIprpcReward.String())
 		}
 		details["total_cu"] = strconv.FormatUint(specCu.TotalCu, 10)
 		details["total_reward"] = specFund.Fund.String()

--- a/x/rewards/keeper/iprpc.go
+++ b/x/rewards/keeper/iprpc.go
@@ -194,7 +194,8 @@ func (k Keeper) distributeIprpcRewards(ctx sdk.Context, iprpcReward types.IprpcR
 					utils.LogAttr("provider_reward", providerReward.String()),
 				)
 			}
-			details[providerCU.Provider] = fmt.Sprintf("cu: %d reward: %s", providerCU.CU, providerAndDelegatorsIprpcReward.String())
+			details[providerCU.Provider] = fmt.Sprintf("cu: %d reward: %s", providerCU.CU, providerReward.String())
+			details[providerCU.Provider+"_delegators"] = providerAndDelegatorsIprpcReward.Sub(providerReward...).String()
 		}
 		details["total_cu"] = strconv.FormatUint(specCu.TotalCu, 10)
 		details["total_reward"] = specFund.Fund.String()

--- a/x/rewards/keeper/iprpc.go
+++ b/x/rewards/keeper/iprpc.go
@@ -217,31 +217,8 @@ func (k Keeper) SetLastRewardsBlock(ctx sdk.Context) error {
 	return k.lastRewardsBlock.Set(ctx, uint64(ctx.BlockHeight()))
 }
 
-// GetLastRewardsBlock returns the last block in which the IPRPC rewards
-// were distributed and the block height of 24 hours later.
+// GetLastRewardsBlock returns the last block in which the IPRPC rewards were distributed.
 // This is used by the subscription module's estimate-rewards query
-func (k Keeper) GetLastRewardsBlock(ctx sdk.Context) (rewardsDistributionBlock uint64, after24HoursBlock uint64, err error) {
-	// get the number of blocks in an epoch
-	epochBlocks, err := k.epochstorage.EpochBlocks(ctx, uint64(ctx.BlockHeight()))
-	if err != nil || epochBlocks == uint64(0) {
-		return 0, 0, utils.LavaFormatError("GetLastRewardsBlock: invalid EpochBlocks", err,
-			utils.LogAttr("epoch_blocks", epochBlocks),
-			utils.LogAttr("block", ctx.BlockHeight()),
-		)
-	}
-
-	// calculate 24 hours in blocks
-	blockTime := k.downtimeKeeper.GetParams(ctx).EpochDuration.Seconds() / float64(epochBlocks)
-	blocksIn24Hours := uint64(24 * 60 * 60 / blockTime)
-
-	// get the rewards distribution block
-	rewardsDistributionBlock, err = k.lastRewardsBlock.Get(ctx)
-	if err != nil {
-		return 0, 0, utils.LavaFormatError("GetLastRewardsBlock: cannot get last rewards block", err,
-			utils.LogAttr("epoch_blocks", epochBlocks),
-			utils.LogAttr("block", ctx.BlockHeight()),
-		)
-	}
-
-	return rewardsDistributionBlock, rewardsDistributionBlock + blocksIn24Hours, nil
+func (k Keeper) GetLastRewardsBlock(ctx sdk.Context) (rewardsDistributionBlock uint64, err error) {
+	return k.lastRewardsBlock.Get(ctx)
 }

--- a/x/rewards/keeper/providers.go
+++ b/x/rewards/keeper/providers.go
@@ -98,7 +98,8 @@ func (k Keeper) DistributeMonthlyBonusRewards(ctx sdk.Context) {
 						utils.LogAttr("provider_reward", providerReward.String()),
 					)
 				}
-				details[basepay.Provider] = fmt.Sprintf("cu: %d reward: %s", basepay.BasePay.TotalAdjusted, providerAndDelegatorsReward.String())
+				details[basepay.Provider] = fmt.Sprintf("cu: %d reward: %s", basepay.BasePay.TotalAdjusted, providerReward.String())
+				details[basepay.Provider+"_delegators"] = providerAndDelegatorsReward.Sub(providerReward...).String()
 			}
 
 			// count iprpc cu

--- a/x/rewards/keeper/providers.go
+++ b/x/rewards/keeper/providers.go
@@ -88,11 +88,17 @@ func (k Keeper) DistributeMonthlyBonusRewards(ctx sdk.Context) {
 					return
 				}
 				// now give the reward the provider contributor and delegators
-				providerOnlyReward, err := k.dualstakingKeeper.RewardProvidersAndDelegators(ctx, basepay.Provider, basepay.ChainId, sdk.NewCoins(sdk.NewCoin(k.stakingKeeper.BondDenom(ctx), reward)), string(types.ProviderRewardsDistributionPool), false, false, false)
+				providerAndDelegatorsReward := sdk.NewCoins(sdk.NewCoin(k.stakingKeeper.BondDenom(ctx), reward))
+				providerReward, err := k.dualstakingKeeper.RewardProvidersAndDelegators(ctx, basepay.Provider, basepay.ChainId, providerAndDelegatorsReward, string(types.ProviderRewardsDistributionPool), false, false, false)
 				if err != nil {
-					utils.LavaFormatError("failed to send bonus rewards to provider", err, utils.LogAttr("provider", basepay.Provider))
+					utils.LavaFormatError("failed to send bonus rewards to provider", err,
+						utils.LogAttr("provider", basepay.Provider),
+						utils.LogAttr("chain_id", basepay.ChainId),
+						utils.LogAttr("provider_and_delegators_reward", providerAndDelegatorsReward.String()),
+						utils.LogAttr("provider_reward", providerReward.String()),
+					)
 				}
-				details[basepay.Provider] = fmt.Sprintf("cu: %d reward: %s", basepay.BasePay.TotalAdjusted, providerOnlyReward.String())
+				details[basepay.Provider] = fmt.Sprintf("cu: %d reward: %s", basepay.BasePay.TotalAdjusted, providerAndDelegatorsReward.String())
 			}
 
 			// count iprpc cu

--- a/x/rewards/keeper/providers_test.go
+++ b/x/rewards/keeper/providers_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -791,6 +792,7 @@ func TestEstimateRewardsQuery(t *testing.T) {
 				// advance ctx by a month and a day to make the delegation count
 				_, err := ts.TxDualstakingDelegate(consumer, provider, sdk.NewInt64Coin(ts.TokenDenom(), testStake/2))
 				require.NoError(t, err)
+				ts.AdvanceTimeHours(24 * 4 * time.Hour) // avoid troubling months like february
 				ts.AdvanceMonths(1)
 			}
 

--- a/x/subscription/README.md
+++ b/x/subscription/README.md
@@ -166,7 +166,7 @@ The subscription module supports the following queries:
 
 Note, the `Coin` type is from Cosmos-SDK (`cosmos.base.v1beta1.Coin`). From the CLI, use `100ulava` to assign a `Coin` argument.
 
-Also, note that the `estimated-provider-rewards` query might return a non-zero "recommended_block". Part of the calculated rewards are the IPRPC rewards. These IPRPC rewards estimation might be misleading in the first 24H since it's dependent on CU count, so the user should run the query again using the `--height` flag with the recommended_block.
+Also, note that the `estimated-provider-rewards` query might return a non-zero "recommended_block". Part of the calculated rewards are the IPRPC rewards. These IPRPC rewards estimation might be misleading in the first 24H since it's dependent on CU count, so the user should run the query again using the `--height` flag with the recommended_block. The recommended_block is the block in which the last IPRPC rewards were distributed, so it better represents the provider's standard rewards from IPRPC (assuming the provider's service is the same across the months).
 
 ## Transactions
 

--- a/x/subscription/keeper/cu_tracker.go
+++ b/x/subscription/keeper/cu_tracker.go
@@ -248,7 +248,8 @@ func (k Keeper) RewardAndResetCuTracker(ctx sdk.Context, cuTrackerTimerKeyBytes 
 				utils.LogAttr("provider_and_delegators_reward", providerAndDelegatorsReward.String()),
 			)
 		} else {
-			details[provider+" "+chainID] = fmt.Sprintf("cu: %d reward: %s", trackedCu, providerAndDelegatorsReward.String())
+			details[provider+" "+chainID] = fmt.Sprintf("cu: %d reward: %s", trackedCu, providerReward.String())
+			details[provider+" "+chainID+"_delegators"] = providerAndDelegatorsReward.Sub(providerReward...).String()
 		}
 	}
 

--- a/x/subscription/keeper/grpc_query_estimated_rewards.go
+++ b/x/subscription/keeper/grpc_query_estimated_rewards.go
@@ -68,7 +68,7 @@ func (k Keeper) EstimatedProviderRewards(goCtx context.Context, req *types.Query
 			trackedCuFactor = delegation.Amount.ToLegacyDec().QuoInt(totalDelegations)
 
 			// advance ctx by a month and a day to make the delegation count
-			ctx = ctx.WithBlockTime(ctx.BlockTime().AddDate(0, 1, 1))
+			ctx = ctx.WithBlockTime(ctx.BlockTime().AddDate(0, 0, 31))
 		}
 	}
 

--- a/x/subscription/keeper/grpc_query_estimated_rewards.go
+++ b/x/subscription/keeper/grpc_query_estimated_rewards.go
@@ -142,7 +142,7 @@ func (k Keeper) EstimatedProviderRewards(goCtx context.Context, req *types.Query
 	if err != nil {
 		return nil, utils.LavaFormatError("failed to get last rewards block for provider rewards estimation", err)
 	}
-	res.RecommendedBlock = rewardsDistributionBlock
+	res.RecommendedBlock = rewardsDistributionBlock - 1
 
 	return &res, nil
 }

--- a/x/subscription/keeper/grpc_query_estimated_rewards.go
+++ b/x/subscription/keeper/grpc_query_estimated_rewards.go
@@ -256,7 +256,7 @@ func extractInfoFromSubscriptionEvent(event abci.Event, provider string) (eventR
 	eventRewardsInfo = map[string]sdk.DecCoins{}
 
 	for _, atr := range event.Attributes {
-		if strings.HasPrefix(atr.Key, provider) {
+		if strings.HasPrefix(atr.Key, provider) && !strings.Contains(atr.Key, "delegators") {
 			// extract chain ID
 			parts := strings.Split(atr.Key, " ")
 			if len(parts) != 2 {
@@ -333,7 +333,7 @@ func extractInfoFromIprpcAndBoostEvent(event abci.Event, provider string, source
 	eventRewardsInfo = map[string]sdk.DecCoins{}
 
 	for _, atr := range event.Attributes {
-		if strings.HasPrefix(atr.Key, provider) {
+		if strings.HasPrefix(atr.Key, provider) && !strings.Contains(atr.Key, "delegators") {
 			// extract provider reward
 			parts := strings.Split(atr.Value, " ")
 			if len(parts) != 4 {

--- a/x/subscription/keeper/grpc_query_estimated_rewards.go
+++ b/x/subscription/keeper/grpc_query_estimated_rewards.go
@@ -138,17 +138,11 @@ func (k Keeper) EstimatedProviderRewards(goCtx context.Context, req *types.Query
 	}
 
 	// get the last IPRPC rewards distribution block
-	// note: on error we simply leave RecommendedBlock to be zero since until the
-	// upcoming IPRPC rewards will be distributed (from the time this query is merged in main)
-	// there will be no LastRewardsBlock set
-	rewardsDistributionBlock, after24HoursBlock, err := k.rewardsKeeper.GetLastRewardsBlock(ctx)
-	if err == nil {
-		// if the query was sent within the first 24 hours of the month,
-		// make the recommended block be the rewards distribution block - 1
-		if uint64(ctx.BlockHeight()) <= after24HoursBlock {
-			res.RecommendedBlock = rewardsDistributionBlock - 1
-		}
+	rewardsDistributionBlock, err := k.rewardsKeeper.GetLastRewardsBlock(ctx)
+	if err != nil {
+		return nil, utils.LavaFormatError("failed to get last rewards block for provider rewards estimation", err)
 	}
+	res.RecommendedBlock = rewardsDistributionBlock
 
 	return &res, nil
 }

--- a/x/subscription/types/expected_keepers.go
+++ b/x/subscription/types/expected_keepers.go
@@ -94,7 +94,7 @@ type RewardsKeeper interface {
 	AllocationPoolMonthsLeft(ctx sdk.Context) int64
 	GetCommunityTax(ctx sdk.Context) math.LegacyDec
 	DistributeMonthlyBonusRewards(ctx sdk.Context)
-	GetLastRewardsBlock(ctx sdk.Context) (rewardsDistributionBlock uint64, after24HoursBlock uint64, err error)
+	GetLastRewardsBlock(ctx sdk.Context) (rewardsDistributionBlock uint64, err error)
 }
 
 type StakingKeeper interface {


### PR DESCRIPTION
# Description

Closes: #XXXX

The estimate rewards query uses the payment events to get the estimation for the providers rewards. The event emitted the provider's part only, leading to lower estimations of the provider's total rewards. Now, the query returns the total estimated reward before its division between the providers and its delegators.

Also, I changed the "recommended block" to always be the last IPRPC distribution block (and updated README)

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage