### PR TITLE
fix: handle multiple subscribe parse directives in spec-add

### DIFF
--- a/x/spec/keeper/spec_test.go
+++ b/x/spec/keeper/spec_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -813,6 +814,70 @@ func TestApiCollectionsExpandAndInheritance(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSolanaSpecAddMultipleSubscribe tests if the solana spec is expanded correctly
+// The Solana spec is special since it has multiple parse directives of subscribe and unsubscribe
+// unlike other specs that have strictly unique parse directives
+func TestSolanaSpecAddMultipleSubscribe(t *testing.T) {
+	ts := newTester(t)
+
+	// read solana spec from file
+	getToTopMostPath := "../../.././specs/mainnet-1/specs/"
+	specsFiles, err := getAllFilesInDirectory(getToTopMostPath)
+	require.NoError(t, err)
+	fileName := ""
+	for _, specFile := range specsFiles {
+		if strings.Contains(specFile, "solana.json") {
+			fileName = specFile
+			break
+		}
+	}
+	contents, err := os.ReadFile(fileName)
+	require.NoError(t, err)
+
+	// Parse contents of solana spec into a proposal
+	var proposal utils.SpecAddProposalJSON
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	err = decoder.Decode(&proposal)
+	require.NoError(t, err, fileName)
+
+	// Find the solana spec in the proposal
+	solanaSpec := types.Spec{}
+	for _, spec := range proposal.Proposal.Specs {
+		for _, apiCol := range spec.ApiCollections {
+			for _, parseDirective := range apiCol.ParseDirectives {
+				if parseDirective.FunctionTag == types.FUNCTION_TAG_SUBSCRIBE {
+					solanaSpec = spec
+					break
+				}
+			}
+		}
+	}
+
+	// Simulate the addspec proposal
+	err = ts.TxProposalAddSpecs(solanaSpec)
+	require.NoError(t, err)
+
+	// Check if the solana spec is added to the keeper
+	specs := ts.Keepers.Spec.GetAllSpec(ts.Ctx)
+	require.Equal(t, 1, len(specs))
+	require.Equal(t, solanaSpec.Index, specs[0].Index)
+
+	// Check if the solana spec is expanded correctly and has multiple parse directives of subscribe and unsubscribe
+	subscribeCount := 0
+	unsubscribeCount := 0
+	for _, apiCol := range specs[0].ApiCollections {
+		for _, parseDirective := range apiCol.ParseDirectives {
+			if parseDirective.FunctionTag == types.FUNCTION_TAG_SUBSCRIBE {
+				subscribeCount++
+			} else if parseDirective.FunctionTag == types.FUNCTION_TAG_UNSUBSCRIBE {
+				unsubscribeCount++
+			}
+		}
+	}
+	require.Greater(t, 2, subscribeCount)
+	require.Greater(t, 2, unsubscribeCount)
 }
 
 func TestSpecs(t *testing.T) {

--- a/x/spec/types/combinable.go
+++ b/x/spec/types/combinable.go
@@ -25,6 +25,10 @@ func (h *Header) Differeniator() string {
 }
 
 func (parsing *ParseDirective) Differeniator() string {
+	if parsing.FunctionTag == FUNCTION_TAG_SUBSCRIBE || parsing.FunctionTag == FUNCTION_TAG_UNSUBSCRIBE {
+		// handle subscribe and unsubscribe differently because they can be not unique (see solana spec)
+		return parsing.FunctionTag.String() + "_" + parsing.ApiName
+	}
 	return parsing.FunctionTag.String()
 }
 


### PR DESCRIPTION
# Description

Closes: #XXXX

Added a small fix to the spec-add proposal mechanism that will allow specs with multiple Subscribe and Unsubscribe parse directives to be added to the chain. This was needed because Solana has multiple subscription APIs.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage