### PR TITLE
feat: Added show-provider-address-in-metrics flag for provider metrics

### DIFF
--- a/protocol/metrics/consumer_metrics_manager.go
+++ b/protocol/metrics/consumer_metrics_manager.go
@@ -547,7 +547,7 @@ func (pme *ConsumerMetricsManager) UpdateHealthCheckStatus(status bool) {
 	atomic.StoreUint64(&pme.endpointsHealthChecksOk, uint64(value))
 }
 
-func (pme *ConsumerMetricsManager) UpdateHealthcheckStatusBreakdown(chainId string, apiInterface string, status bool) {
+func (pme *ConsumerMetricsManager) UpdateHealthcheckStatusBreakdown(chainId, apiInterface string, status bool) {
 	if pme == nil {
 		return
 	}

--- a/protocol/metrics/mapped_labels_counter_vec.go
+++ b/protocol/metrics/mapped_labels_counter_vec.go
@@ -1,0 +1,42 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MappedLabelsCounterVec is a wrapper around prometheus.CounterVec that allows for setting labels dynamically.
+// We use if for the metrics that have a dynamic number of labels, based on flags given upon startup.
+type MappedLabelsCounterVec struct {
+	*prometheus.CounterVec
+	labels []string
+}
+
+type MappedLabelsCounterVecOpts struct {
+	Name   string
+	Help   string
+	Labels []string
+}
+
+func NewMappedLabelsCounterVec(opts MappedLabelsCounterVecOpts) *MappedLabelsCounterVec {
+	metric := &MappedLabelsCounterVec{
+		labels: opts.Labels,
+		CounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: opts.Name,
+			Help: opts.Help,
+		}, opts.Labels),
+	}
+
+	prometheus.MustRegister(metric.CounterVec)
+
+	return metric
+}
+
+func (mlgv *MappedLabelsCounterVec) getLabelValues(labelsWithValues map[string]string) []string {
+	labelValues := make([]string, len(mlgv.labels))
+	for i, label := range mlgv.labels {
+		labelValues[i] = labelsWithValues[label]
+	}
+	return labelValues
+}
+
+func (mlgv *MappedLabelsCounterVec) WithLabelValues(labelsWithValues map[string]string) prometheus.Counter {
+	return mlgv.CounterVec.WithLabelValues(mlgv.getLabelValues(labelsWithValues)...)
+}

--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -413,7 +413,7 @@ func (rpcp *RPCProvider) SetupEndpoint(ctx context.Context, rpcProviderEndpoint 
 	// chainTracker accepts a callback to be called on new blocks, we use this to call metrics update on a new block
 	recordMetricsOnNewBlock := func(blockFrom int64, blockTo int64, hash string) {
 		for block := blockFrom + 1; block <= blockTo; block++ {
-			rpcp.providerMetricsManager.SetLatestBlock(chainID, uint64(block))
+			rpcp.providerMetricsManager.SetLatestBlock(chainID, rpcProviderEndpoint.NetworkAddress.Address, uint64(block))
 		}
 	}
 	var chainFetcher chainlib.ChainFetcherIf
@@ -504,7 +504,7 @@ func (rpcp *RPCProvider) SetupEndpoint(ctx context.Context, rpcProviderEndpoint 
 		return utils.LavaFormatError("panic severity critical error, failed validating chain", err, utils.Attribute{Key: "rpcProviderEndpoint", Value: rpcProviderEndpoint})
 	}
 
-	providerMetrics := rpcp.providerMetricsManager.AddProviderMetrics(chainID, apiInterface)
+	providerMetrics := rpcp.providerMetricsManager.AddProviderMetrics(chainID, apiInterface, rpcProviderEndpoint.NetworkAddress.Address)
 
 	reliabilityManager := reliabilitymanager.NewReliabilityManager(chainTracker, rpcp.providerStateTracker, rpcp.addr.String(), chainRouter, chainParser)
 	rpcp.providerStateTracker.RegisterReliabilityManagerForVoteUpdates(ctx, reliabilityManager, rpcProviderEndpoint)
@@ -833,6 +833,7 @@ rpcprovider 127.0.0.1:3333 OSMOSIS tendermintrpc "wss://www.node-path.com:80,htt
 	cmdRPCProvider.Flags().String(common.UseStaticSpecFlag, "", "load offline spec provided path to spec file, used to test specs before they are proposed on chain, example for spec with inheritance: --use-static-spec ./specs/mainnet-1/specs/ibc.json,./specs/mainnet-1/specs/tendermint.json,./specs/mainnet-1/specs/cosmossdk.json,./specs/mainnet-1/specs/ethermint.json,./specs/mainnet-1/specs/ethereum.json,./specs/mainnet-1/specs/evmos.json")
 	cmdRPCProvider.Flags().Uint64(common.RateLimitRequestPerSecondFlag, 0, "Measuring the load relative to this number for feedback - per second - per chain - default unlimited. Given Y simultaneous relay calls, a value of X  and will measure Y/X load rate.")
 	cmdRPCProvider.Flags().BoolVar(&chainlib.AllowMissingApisByDefault, common.AllowMissingApisByDefaultFlagName, true, "allows missing apis to be proxied to the node by default, set false to block missing apis in the spec, might result in degraded performance if spec is misconfigured")
+	cmdRPCProvider.Flags().BoolVar(&metrics.ShowProviderEndpointInProviderMetrics, metrics.ShowProviderEndpointInMetricsFlagName, metrics.ShowProviderEndpointInProviderMetrics, "show provider endpoint in provider metrics")
 	common.AddRollingLogConfig(cmdRPCProvider)
 	return cmdRPCProvider
 }


### PR DESCRIPTION
* Added support for show-provider-address-in-metrics flag for Provider metrics
* Added provider endpoint metrics to `lava_provider_total_relays_serviced` and `lava_latest_block`