### PR TITLE
chore: PRT - Update go version to match toolchain rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lavanet/lava/v4
 
-go 1.23
+go 1.23.3
 
 require (
 	github.com/99designs/keyring v1.2.1 // indirect


### PR DESCRIPTION
See https://go.dev/doc/toolchain#version and https://github.com/lavanet/lava/security/code-scanning/tools/CodeQL/status/configurations/automatic/b56e7b9b62399faea59c45e7aba6c1da3b91f6b87643b640a033ac5c72b73b8b