### PR TITLE
feat: use jq instead of yq

### DIFF
--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -74,11 +74,11 @@ check_go_version() {
 # Function to find the latest vote
 latest_vote() {
   # Check if jq is not installed
-  if ! command_exists yq; then
-      echo "yq not found. Please install yq using the init_install.sh script or manually."
+  if ! command_exists jq; then
+      echo "jq not found. Please install jq using the init_install.sh script or manually."
       exit 1
   fi
-  lavad q gov proposals 2> /dev/null | yq eval '.proposals[].id'  | wc -l
+  lavad q gov proposals --output=json 2> /dev/null | jq '.proposals[].id' | wc -l
 }
 
 create_health_config() {


### PR DESCRIPTION
# Relpace yq by jq 

 yq is redundant we can use only jq, also there is a strange error if we have already installed yq with `apt install`, which is confusing 

