### PR TITLE
fix: use WriteBatch in BadgerDB to prevent "Txn is too big" errors

### DIFF
--- a/protocol/rpcprovider/rewardserver/badger_db.go
+++ b/protocol/rpcprovider/rewardserver/badger_db.go
@@ -48,19 +48,15 @@ func (mdb *BadgerDB) BatchSave(dbEntries []*DBEntry) error {
 }
 
 func (mdb *BadgerDB) saveAll() error {
-	err := mdb.db.Update(func(txn *badger.Txn) error {
-		for key, data := range mdb.rewards {
-			e := badger.NewEntry([]byte(key), data.data).WithTTL(data.remainingTtl())
-			err := txn.SetEntry(e)
-			if err != nil {
-				return err
-			}
+	wb := mdb.db.NewWriteBatch()
+	for key, data := range mdb.rewards {
+		e := badger.NewEntry([]byte(key), data.data).WithTTL(data.remainingTtl())
+		if err := wb.SetEntry(e); err != nil {
+			wb.Cancel()
+			return err
 		}
-
-		return nil
-	})
-
-	return err
+	}
+	return wb.Flush()
 }
 
 func (mdb *BadgerDB) FindOne(key string) (one []byte, err error) {

--- a/protocol/rpcprovider/rewardserver/badger_db_test.go
+++ b/protocol/rpcprovider/rewardserver/badger_db_test.go
@@ -1,0 +1,54 @@
+package rewardserver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBadgerDB_BatchSaveLargeTransaction(t *testing.T) {
+	// This test verifies that BatchSave handles a large number of entries
+	// that would exceed BadgerDB's single transaction size limit.
+	// Before the fix, this would fail with: "Txn is too big to fit into one request"
+	db := NewMemoryDB("specId").(*BadgerDB)
+	defer db.Close()
+
+	// Each entry has ~10KB of data. With default MemTableSize of 64MB,
+	// BadgerDB's max batch size is ~9.6MB (15% of MemTableSize).
+	// 2000 entries * 10KB = ~20MB, which exceeds the limit.
+	const (
+		numEntries = 2000
+		dataSize   = 10 * 1024 // 10KB per entry
+	)
+
+	entries := make([]*DBEntry, numEntries)
+	for i := range numEntries {
+		data := make([]byte, dataSize)
+		// Fill with non-zero data to ensure realistic size
+		for j := range data {
+			data[j] = byte(i % 256)
+		}
+		entries[i] = &DBEntry{
+			Key:  fmt.Sprintf("key-%d", i),
+			Data: data,
+			Ttl:  24 * time.Hour,
+		}
+	}
+
+	err := db.BatchSave(entries)
+	require.NoError(t, err)
+
+	// Verify all entries were persisted
+	all, err := db.FindAll()
+	require.NoError(t, err)
+	require.Equal(t, numEntries, len(all))
+
+	for i := range numEntries {
+		key := fmt.Sprintf("key-%d", i)
+		val, ok := all[key]
+		require.True(t, ok, "missing key: %s", key)
+		require.Equal(t, dataSize, len(val))
+	}
+}

--- a/protocol/rpcprovider/rewardserver/badger_db_test.go
+++ b/protocol/rpcprovider/rewardserver/badger_db_test.go
@@ -12,7 +12,8 @@ func TestBadgerDB_BatchSaveLargeTransaction(t *testing.T) {
 	// This test verifies that BatchSave handles a large number of entries
 	// that would exceed BadgerDB's single transaction size limit.
 	// Before the fix, this would fail with: "Txn is too big to fit into one request"
-	db := NewMemoryDB("specId").(*BadgerDB)
+	db, ok := NewMemoryDB("specId").(*BadgerDB)
+	require.True(t, ok)
 	defer db.Close()
 
 	// Each entry has ~10KB of data. With default MemTableSize of 64MB,

--- a/protocol/rpcprovider/rewardserver/reward_db.go
+++ b/protocol/rpcprovider/rewardserver/reward_db.go
@@ -83,18 +83,16 @@ func (rs *RewardDB) BatchSave(rewardEntities []*RewardEntity) (err error) {
 			if len(rewards) > batchSize {
 				// possible rewards is too big, try to save it in chunks
 				for i := 0; i < len(rewards); i += batchSize {
-					end := i + batchSize
-					if len(rewards) < i+batchSize {
-						end = len(rewards)
-					}
+					end := min(i+batchSize, len(rewards))
 					chunk := rewards[i:end]
 					err = db.BatchSave(chunk)
 					if err != nil {
 						return err
 					}
 				}
+			} else {
+				return err
 			}
-			return err
 		}
 	}
 

--- a/protocol/rpcprovider/rewardserver/reward_db_test.go
+++ b/protocol/rpcprovider/rewardserver/reward_db_test.go
@@ -184,6 +184,43 @@ func TestDeleteEpochRewards(t *testing.T) {
 	require.Equal(t, 0, len(rewards))
 }
 
+func TestSaveBatchLargePayload(t *testing.T) {
+	// This test verifies that BatchSave handles a large number of entries with
+	// large content hashes that would exceed BadgerDB's single transaction size limit.
+	// Before the fix, this would fail with: "Txn is too big to fit into one request"
+	db := rewardserver.NewMemoryDB("specId")
+	rs := rewardserver.NewRewardDB()
+	err := rs.AddDB(db)
+	require.NoError(t, err)
+
+	ctx := sdk.WrapSDKContext(sdk.NewContext(nil, tmproto.Header{}, false, nil))
+
+	const numEntries = 2000
+	// Use a large content hash to make each entry ~10KB, pushing the total
+	// batch well over BadgerDB's ~9.6MB transaction limit.
+	largeContentHash := make([]byte, 10*1024)
+
+	cpes := make([]*rewardserver.RewardEntity, numEntries)
+	for i := range numEntries {
+		proof := common.BuildRelayRequestWithSession(ctx, "providerAddr", largeContentHash, uint64(i+1), uint64(0), "specId", nil)
+		cpes[i] = &rewardserver.RewardEntity{
+			Epoch:        uint64(proof.Epoch),
+			ConsumerAddr: fmt.Sprintf("consumerAddr%d", i),
+			ConsumerKey:  fmt.Sprintf("consumerKey%d", i),
+			SessionId:    proof.SessionId,
+			Proof:        proof,
+		}
+	}
+
+	err = rs.BatchSave(cpes)
+	require.NoError(t, err)
+
+	rewards, err := rs.FindAll()
+	require.NoError(t, err)
+	// All entries share the same epoch, so there should be 1 epoch with all sessions
+	require.Equal(t, 1, len(rewards))
+}
+
 func TestRewardsWithTTL(t *testing.T) {
 	db := rewardserver.NewMemoryDB("spec")
 	// really really short TTL to make sure the rewards are not queryable


### PR DESCRIPTION
Replace single-transaction db.Update() with BadgerDB's WriteBatch in saveAll(), which automatically splits large writes across multiple transactions. This fixes providers seeing repeated "Txn is too big to fit into one request" errors when serving high relay volumes.

Also fix a bug in RewardDB.BatchSave where successful chunked saves still returned the original error due to a missing else branch.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage