### PR TITLE
feat(rpcsmartrouter): add /debug/reset-scores endpoint for optimizer state reset

### DIFF
--- a/protocol/rpcconsumer/debug_server_test.go
+++ b/protocol/rpcconsumer/debug_server_test.go
@@ -28,6 +28,14 @@ func postTimeWarp(mux http.Handler, rawBody string) *httptest.ResponseRecorder {
 	return rr
 }
 
+// postResetScores sends a POST /debug/reset-scores request.
+func postResetScores(mux http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/debug/reset-scores", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
 // TestDebugTimeWarp_OffsetBoundaryValidation verifies that the /debug/time-warp handler
 // accepts and rejects offset values exactly as specified in the plan.
 //
@@ -174,3 +182,43 @@ func TestDebugTimeWarp_ErrorMessageContainsNewCeiling(t *testing.T) {
 		"old ceiling value must not appear in the error message after this PR")
 	require.Contains(t, rr.Body.String(), "24h")
 }
+
+func TestDebugResetScores_ReturnsJSON(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizers(), &offsetNano)
+
+	rr := postResetScores(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"reset":true`)
+	require.Contains(t, rr.Body.String(), `"chains_reset":0`)
+}
+
+func TestDebugResetScores_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizers(), &offsetNano)
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/reset-scores", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestDebugResetScores_DoesNotChangeOffset(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizers(), &offsetNano)
+
+	warpRR := postTimeWarp(mux, `{"offset_seconds":3600}`)
+	require.Equal(t, http.StatusOK, warpRR.Code)
+
+	resetRR := postResetScores(mux)
+	require.Equal(t, http.StatusOK, resetRR.Code)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/debug/time", nil)
+	getRR := httptest.NewRecorder()
+	mux.ServeHTTP(getRR, getReq)
+
+	require.Equal(t, http.StatusOK, getRR.Code)
+	require.Contains(t, getRR.Body.String(), `"offset_seconds":3600`)
+}
+

--- a/protocol/rpcconsumer/debug_server_test.go
+++ b/protocol/rpcconsumer/debug_server_test.go
@@ -221,4 +221,3 @@ func TestDebugResetScores_DoesNotChangeOffset(t *testing.T) {
 	require.Equal(t, http.StatusOK, getRR.Code)
 	require.Contains(t, getRR.Body.String(), `"offset_seconds":3600`)
 }
-

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -306,7 +306,8 @@ func (rpcc *RPCConsumer) Start(ctx context.Context, options *rpcConsumerStartOpt
 	return nil
 }
 
-// buildDebugMux constructs the /debug/time-warp and /debug/time HTTP handlers.
+// buildDebugMux constructs the /debug/time-warp, /debug/time, and /debug/reset-scores
+// HTTP handlers.
 //
 // The POST /debug/time-warp handler validates the requested offset (must be finite,
 // non-negative, and at most 24 h), stores it atomically in currentOffsetNano, and
@@ -396,6 +397,23 @@ func buildDebugMux(
 			now.UTC().Format(time.RFC3339),
 			effective.UTC().Format(time.RFC3339),
 			float64(nano)/float64(time.Second))
+	})
+
+	// POST /debug/reset-scores — clears optimizer score state without changing
+	// current time offset or NowFunc.
+	mux.HandleFunc("/debug/reset-scores", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		count := 0
+		optimizers.Range(func(chainID string, opt *provideroptimizer.ProviderOptimizer) bool {
+			opt.ResetState()
+			count++
+			return true
+		})
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d}`, count)
 	})
 
 	return mux

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -24,6 +24,13 @@ func postTimeWarpRouter(mux http.Handler, rawBody string) *httptest.ResponseReco
 	return rr
 }
 
+func postResetScoresRouter(mux http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/debug/reset-scores", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
 // TestDebugTimeWarp_SmartRouter_OffsetBoundaryValidation mirrors the rpcconsumer boundary
 // test for rpcsmartrouter — the handler is a verbatim copy and must enforce the same ceiling.
 func TestDebugTimeWarp_SmartRouter_OffsetBoundaryValidation(t *testing.T) {
@@ -74,3 +81,43 @@ func TestDebugTimeWarp_SmartRouter_ErrorMessageContainsNewCeiling(t *testing.T) 
 	require.NotContains(t, rr.Body.String(), "86340")
 	require.Contains(t, rr.Body.String(), "24h")
 }
+
+func TestDebugResetScores_SmartRouter_ReturnsJSON(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizersRouter(), &offsetNano)
+
+	rr := postResetScoresRouter(mux)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"reset":true`)
+	require.Contains(t, rr.Body.String(), `"chains_reset":0`)
+}
+
+func TestDebugResetScores_SmartRouter_MethodNotAllowed(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizersRouter(), &offsetNano)
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/reset-scores", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestDebugResetScores_SmartRouter_DoesNotChangeOffset(t *testing.T) {
+	var offsetNano atomic.Int64
+	mux := buildDebugMux(newEmptyOptimizersRouter(), &offsetNano)
+
+	warpRR := postTimeWarpRouter(mux, `{"offset_seconds":3600}`)
+	require.Equal(t, http.StatusOK, warpRR.Code)
+
+	resetRR := postResetScoresRouter(mux)
+	require.Equal(t, http.StatusOK, resetRR.Code)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/debug/time", nil)
+	getRR := httptest.NewRecorder()
+	mux.ServeHTTP(getRR, getReq)
+
+	require.Equal(t, http.StatusOK, getRR.Code)
+	require.Contains(t, getRR.Body.String(), `"offset_seconds":3600`)
+}
+

--- a/protocol/rpcsmartrouter/debug_server_test.go
+++ b/protocol/rpcsmartrouter/debug_server_test.go
@@ -120,4 +120,3 @@ func TestDebugResetScores_SmartRouter_DoesNotChangeOffset(t *testing.T) {
 	require.Equal(t, http.StatusOK, getRR.Code)
 	require.Contains(t, getRR.Body.String(), `"offset_seconds":3600`)
 }
-

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -332,7 +332,8 @@ func (rpsr *RPCSmartRouter) Start(ctx context.Context, options *rpcSmartRouterSt
 	return nil
 }
 
-// buildDebugMux constructs the /debug/time-warp and /debug/time HTTP handlers.
+// buildDebugMux constructs the /debug/time-warp, /debug/time, and
+// /debug/reset-scores HTTP handlers.
 //
 // See rpcconsumer.buildDebugMux for full documentation — this is an identical copy
 // scoped to the rpcsmartrouter package.
@@ -411,6 +412,23 @@ func buildDebugMux(
 			now.UTC().Format(time.RFC3339),
 			effective.UTC().Format(time.RFC3339),
 			float64(nano)/float64(time.Second))
+	})
+
+	// POST /debug/reset-scores — clears optimizer score state without changing
+	// current time offset or NowFunc.
+	mux.HandleFunc("/debug/reset-scores", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		count := 0
+		optimizers.Range(func(chainID string, opt *provideroptimizer.ProviderOptimizer) bool {
+			opt.ResetState()
+			count++
+			return true
+		})
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"reset":true,"chains_reset":%d}`, count)
 	})
 
 	return mux


### PR DESCRIPTION

Closes: #1565
# PR: Add `POST /debug/reset-scores` Debug Endpoint

## What this does

Adds a new debug HTTP endpoint, `POST /debug/reset-scores`, in both:

- `protocol/rpcsmartrouter/rpcsmartrouter.go`
- `protocol/rpcconsumer/rpcconsumer.go`

The endpoint clears optimizer score state immediately by calling `ProviderOptimizer.ResetState()` for every chain optimizer, without changing clock offset.

This is an additive capability. Existing `/debug/time-warp` and `/debug/time` behavior remains unchanged.

---

## Validator / Provider impact

- **Validators:** no impact (no consensus/state-machine changes).
- **Providers:** no impact.
- **Consumers / Smart router:** no impact unless debug server is explicitly enabled via `--debug-address`.
- **Config changes:** none required for production.

---

## Author Checklist

- [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
- [x] included the correct type prefix in the PR title: `feat`
- [x] confirmed breaking-change marker `!` is not needed (no breaking changes)
- [x] targeted `main`
- [x] included unit tests for new behavior in both packages
- [x] updated docs/comments where needed
- [ ] CI checks passed (pending)

---

## Changes

### `protocol/rpcconsumer/rpcconsumer.go`
- Extended `buildDebugMux(...)` with:
  - `POST /debug/reset-scores`
- Handler behavior:
  - method guard: POST only
  - iterates `optimizers.Range(...)`
  - calls `opt.ResetState()` on each optimizer
  - returns JSON: `{"reset":true,"chains_reset":<N>}`
- Concurrency model is unchanged from prior debug server change:
  - no mutation of `currentOffsetNano`
  - no mutation of `NowFunc`

### `protocol/rpcsmartrouter/rpcsmartrouter.go`
- Same `POST /debug/reset-scores` handler added in `buildDebugMux(...)`.
- Same response contract and method validation as `rpcconsumer`.

### `protocol/rpcconsumer/debug_server_test.go`
- Added:
  - `TestDebugResetScores_ReturnsJSON`
  - `TestDebugResetScores_MethodNotAllowed`
  - `TestDebugResetScores_DoesNotChangeOffset`

### `protocol/rpcsmartrouter/debug_server_test.go`
- Added:
  - `TestDebugResetScores_SmartRouter_ReturnsJSON`
  - `TestDebugResetScores_SmartRouter_MethodNotAllowed`
  - `TestDebugResetScores_SmartRouter_DoesNotChangeOffset`

---

## Why this is needed

Current test flow to clear optimizer scores often uses a full clock dance:

1. warp clock forward
2. send relay
3. reset clock

That flow works, but is multi-step and also changes effective time.

`POST /debug/reset-scores` provides a direct score reset operation for integration tests when time-shift semantics are not needed.

This endpoint is **not a replacement** for clock injection; it is an additional debug tool.

---

## API

### Existing (unchanged)

**Shift clock:**
```
POST /debug/time-warp
{"offset_seconds": 3600}
```

**Read effective/real time:**
```
GET /debug/time
```

### New

**Reset optimizer score state immediately:**
```
POST /debug/reset-scores
```

Response example:
```json
{"reset":true,"chains_reset":2}
```

Method guard example:
- `GET /debug/reset-scores` -> `405 POST only`

---

## Tests

Executed locally:

```bash
go test ./protocol/rpcconsumer/... ./protocol/rpcsmartrouter/...
```

Result:
- `ok github.com/lavanet/lava/v5/protocol/rpcconsumer`
- `ok github.com/lavanet/lava/v5/protocol/rpcsmartrouter`

---

## Production safety

- Debug endpoints only exist when `--debug-address` is set.
- No changes to default runtime behavior when debug server is disabled.
- No on-chain/state-machine/protocol compatibility impact.

---

## Example usage

```bash
# reset scores without touching clock offset
curl -i -X POST https://debug.<USERNAME>.magmadevs.com/debug/reset-scores

# verify clock offset is unchanged
curl -s https://debug.<USERNAME>.magmadevs.com/debug/time | python3 -m json.tool
```

