### PR TITLE
fix: no retry on non retryable node errors

### DIFF
--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -388,6 +388,15 @@ type RelayResult struct {
 	// zero retries, zero CU, no provider scoring. User errors are NOT cached
 	// because the next request from the same client may carry valid input.
 	IsUserError bool
+	// IsNonRetryable is the umbrella flag the retry state machine consults:
+	// it's true whenever the matched registry LavaError has Retryable=false,
+	// which covers unsupported method, user input error, execution reverted,
+	// out of gas, invalid signature, double spend, etc. Retrying on another
+	// provider would just reproduce the same deterministic failure.
+	// IsUnsupportedMethod and IsUserError are independent subset flags derived
+	// from the SubCategory and used only to gate CU-charging and caching
+	// policy — they do NOT narrow the retry decision below IsNonRetryable.
+	IsNonRetryable bool
 }
 
 func (rr *RelayResult) GetReplyServer() pairingtypes.Relayer_RelaySubscribeClient {

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -410,6 +410,94 @@ func IsUserInputError(chainID string, statusCode int, message string) bool {
 	return classifySubCategoryAcrossTransports(chainID, statusCode, message).IsUserError()
 }
 
+// IsNonRetryableNodeError returns true when the classified LavaError for the
+// given node-error response has Retryable=false (e.g. CHAIN_EXECUTION_REVERTED,
+// CHAIN_OUT_OF_GAS, CHAIN_DOUBLE_SPEND, CHAIN_INVALID_SIGNATURE, and every
+// other terminal error in the 3000-range). Unlike IsUserInputError /
+// IsUnsupportedMethodError this does NOT key off SubCategory — it honors the
+// Retryable flag directly so every non-retryable LavaError short-circuits
+// retries, not only the zero-CU user-facing subset.
+func IsNonRetryableNodeError(chainID string, statusCode int, message string) bool {
+	family := ChainFamilyUnknown
+	if chainID != "" {
+		family = GetChainFamilyOrDefault(chainID)
+	}
+	for _, transport := range []TransportType{TransportJsonRPC, TransportREST, TransportGRPC} {
+		c := ClassifyError(nil, family, transport, statusCode, message)
+		if c == nil || c == LavaErrorUnknown {
+			continue
+		}
+		return !c.Retryable
+	}
+	return false
+}
+
+// IsNonRetryableNodeErrorWithContext is the variant of IsNonRetryableNodeError
+// for call sites that already know the chain family and transport exactly (e.g.
+// the smart router's direct-RPC senders). It avoids the JSON-RPC→REST→gRPC
+// scan of classifySubCategoryAcrossTransports and the chainID-to-family lookup.
+// Pass ChainFamilyUnknown when the family is genuinely unknown.
+func IsNonRetryableNodeErrorWithContext(family ChainFamily, transport TransportType, statusCode int, message string) bool {
+	c := ClassifyError(nil, family, transport, statusCode, message)
+	if c == nil || c == LavaErrorUnknown {
+		return false
+	}
+	return !c.Retryable
+}
+
+// NodeErrorClassification aggregates the three policy flags derived from a
+// single registry lookup on a node-error response:
+//   - IsNonRetryable: registry entry is Retryable=false (hard stop for retries).
+//   - IsUnsupportedMethod / IsUserError: SubCategory-based predicates used by
+//     the consumer to apply the zero-CU carve-out and caching policy. Both are
+//     strict subsets of IsNonRetryable.
+type NodeErrorClassification struct {
+	IsNonRetryable      bool
+	IsUnsupportedMethod bool
+	IsUserError         bool
+}
+
+// ClassifyNodeErrorForRetry runs ClassifyError exactly once and derives the
+// three flags consumed by the consumer's retry decision and CU/caching
+// carve-outs. Prefer this over sequential IsNonRetryableNodeError /
+// IsUnsupportedMethodError / IsUserInputError calls on hot error paths — each
+// of those internally scans all three transports, which is wasteful when the
+// caller already knows family and transport.
+//
+// errorCode semantics depend on transport:
+//   - TransportJsonRPC: pass the JSON-RPC error.code from the response body
+//     (e.g. -32700, -32602). HTTP status is usually 200 for JSON-RPC node
+//     errors and would miss the code-based registry mappings.
+//   - TransportREST / TransportGRPC: the HTTP / gRPC status code.
+//
+// Unknown classifications fail open (all flags false → retryable).
+func ClassifyNodeErrorForRetry(family ChainFamily, transport TransportType, errorCode int, message string) NodeErrorClassification {
+	c := ClassifyError(nil, family, transport, errorCode, message)
+	if c == nil || c == LavaErrorUnknown {
+		return NodeErrorClassification{}
+	}
+	return NodeErrorClassification{
+		IsNonRetryable:      !c.Retryable,
+		IsUnsupportedMethod: c.SubCategory.IsUnsupportedMethod(),
+		IsUserError:         c.SubCategory.IsUserError(),
+	}
+}
+
+// ApiInterfaceToTransport maps a spec API interface string (jsonrpc,
+// tendermintrpc, rest, grpc) to the TransportType used by the error registry.
+// Unknown or empty inputs fall through to TransportJsonRPC, which is the most
+// common transport and matches the broadest set of registry matchers.
+func ApiInterfaceToTransport(apiInterface string) TransportType {
+	switch apiInterface {
+	case "rest":
+		return TransportREST
+	case "grpc":
+		return TransportGRPC
+	default:
+		return TransportJsonRPC
+	}
+}
+
 // ClassifyMessage classifies an error from just a message string and an optional
 // numeric code, trying all transport types in order (JsonRPC → REST → gRPC) and
 // returning the first non-unknown classification.

--- a/protocol/common/error_registry_test.go
+++ b/protocol/common/error_registry_test.go
@@ -554,6 +554,118 @@ func TestIsUserInputError_KnownCases(t *testing.T) {
 	assert.False(t, IsUserInputError("ETH1", 0, "context deadline exceeded"))
 }
 
+// TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup verifies the
+// single-pass helper the consumer hot path uses. Each row asserts all three
+// flags at once because the consumer relies on their mutual consistency —
+// IsUnsupportedMethod and IsUserError must always imply IsNonRetryable, and
+// unknown messages must fail open (all flags false → retryable).
+func TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup(t *testing.T) {
+	cases := []struct {
+		name             string
+		family           ChainFamily
+		transport        TransportType
+		errorCode        int
+		message          string
+		wantNonRetryable bool
+		wantUnsupported  bool
+		wantUserErr      bool
+	}{
+		{
+			name:             "EVM execution reverted → terminal, neither unsupported nor user",
+			family:           ChainFamilyEVM,
+			transport:        TransportJsonRPC,
+			errorCode:        3,
+			message:          "execution reverted",
+			wantNonRetryable: true,
+		},
+		{
+			name:             "EVM method not found → terminal + unsupported",
+			family:           ChainFamilyEVM,
+			transport:        TransportJsonRPC,
+			errorCode:        -32601,
+			message:          "method not found",
+			wantNonRetryable: true,
+			wantUnsupported:  true,
+		},
+		{
+			name:             "JSON-RPC body code -32700 parse error → terminal + user",
+			family:           ChainFamilyEVM,
+			transport:        TransportJsonRPC,
+			errorCode:        -32700,
+			message:          "parse error",
+			wantNonRetryable: true,
+			wantUserErr:      true,
+		},
+		{
+			name:             "generic transient → retryable (all flags false)",
+			family:           ChainFamilyEVM,
+			transport:        TransportJsonRPC,
+			errorCode:        502,
+			message:          "bad gateway",
+			wantNonRetryable: false,
+		},
+		{
+			name:             "unknown classification fails open",
+			family:           ChainFamilyUnknown,
+			transport:        TransportJsonRPC,
+			errorCode:        0,
+			message:          "totally unfamiliar garbage",
+			wantNonRetryable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyNodeErrorForRetry(tc.family, tc.transport, tc.errorCode, tc.message)
+			assert.Equal(t, tc.wantNonRetryable, got.IsNonRetryable, "IsNonRetryable")
+			assert.Equal(t, tc.wantUnsupported, got.IsUnsupportedMethod, "IsUnsupportedMethod")
+			assert.Equal(t, tc.wantUserErr, got.IsUserError, "IsUserError")
+			// Invariant: the two subset flags must never be set without
+			// IsNonRetryable also being set.
+			if got.IsUnsupportedMethod || got.IsUserError {
+				assert.True(t, got.IsNonRetryable, "subset flags imply IsNonRetryable")
+			}
+		})
+	}
+}
+
+// TestApiInterfaceToTransport maps the spec API interface strings to the
+// TransportType consumed by the error registry. tendermintrpc and unknown
+// inputs fall back to JSON-RPC — the consumer and smart router rely on this
+// default to avoid threading a null transport through hot paths.
+func TestApiInterfaceToTransport(t *testing.T) {
+	cases := []struct {
+		apiInterface string
+		want         TransportType
+	}{
+		{apiInterface: "jsonrpc", want: TransportJsonRPC},
+		{apiInterface: "tendermintrpc", want: TransportJsonRPC},
+		{apiInterface: "rest", want: TransportREST},
+		{apiInterface: "grpc", want: TransportGRPC},
+		{apiInterface: "", want: TransportJsonRPC},
+		{apiInterface: "anything-else", want: TransportJsonRPC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.apiInterface, func(t *testing.T) {
+			assert.Equal(t, tc.want, ApiInterfaceToTransport(tc.apiInterface))
+		})
+	}
+}
+
+// TestIsNonRetryableNodeErrorWithContext_JSONRPCBodyCode documents that the
+// JSON-RPC Tier-1 code matchers only fire when callers pass the body error
+// code (e.g. -32700) rather than the HTTP status that wraps it. This is the
+// invariant the consumer and smart-router JSON-RPC paths rely on when they
+// call ExtractJSONRPCErrorCode before classification.
+func TestIsNonRetryableNodeErrorWithContext_JSONRPCBodyCode(t *testing.T) {
+	// Using HTTP 200 (the wrapper status for JSON-RPC node errors) the
+	// registry never reaches the body-code matcher.
+	assert.False(t, IsNonRetryableNodeErrorWithContext(ChainFamilyEVM, TransportJsonRPC, 200, ""))
+	// Passing the body code unlocks the Tier-1 JSON-RPC matcher for USER_*.
+	assert.True(t, IsNonRetryableNodeErrorWithContext(ChainFamilyEVM, TransportJsonRPC, -32700, ""))
+	assert.True(t, IsNonRetryableNodeErrorWithContext(ChainFamilyEVM, TransportJsonRPC, -32602, ""))
+}
+
 // ---------------------------------------------------------------------------
 // ChainFamily tests
 // ---------------------------------------------------------------------------

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -283,15 +283,21 @@ func (rp *RelayProcessor) HasUnsupportedMethodErrors() bool {
 	return false
 }
 
-// HasNonRetryableUserFacingErrors returns true when any current error carries a
-// subcategory whose behavioral contract is "don't retry, don't charge CU" —
-// currently SubCategoryUnsupportedMethod or SubCategoryUserError. This is the
-// single entry point the retry state machine should use so adding a new such
-// subcategory only requires updating ErrorSubCategory.IsNonRetryableUserFacing.
+// HasNonRetryableUserFacingErrors returns true when any current error is
+// terminal for the retry state machine. The retry decision rests on a single
+// authority: the classified LavaError's Retryable flag.
 //
-// This is the superset of HasUnsupportedMethodErrors and should be preferred
-// at retry-decision sites. HasUnsupportedMethodErrors remains for callers
-// that need the narrower check (e.g. caching decisions).
+//   - Node errors: IsNonRetryable is set by the classifier when the registry
+//     marks the matched LavaError as Retryable=false. This covers unsupported
+//     method, user input error, execution reverted, out of gas, invalid
+//     signature, double spend, and every other terminal entry in the registry.
+//   - Protocol errors: ShouldRetryError consults the same registry for the
+//     wrapped error. Epoch mismatches are still explicitly allowed to retry.
+//
+// Adding a new terminal error only requires registering it with Retryable=false.
+// The function name retains "UserFacing" for historical continuity but the
+// scope is simply "non-retryable"; HasUnsupportedMethodErrors remains for
+// callers that need the narrower subcategory check (e.g. caching decisions).
 func (rp *RelayProcessor) HasNonRetryableUserFacingErrors() bool {
 	if rp == nil {
 		return false
@@ -299,24 +305,13 @@ func (rp *RelayProcessor) HasNonRetryableUserFacingErrors() bool {
 
 	_, nodeErrorResults, protocolErrors := rp.GetResultsData()
 
-	// Node error path: either flag is a hard stop for retries.
 	for _, nodeErrorResult := range nodeErrorResults {
-		if nodeErrorResult.IsUnsupportedMethod || nodeErrorResult.IsUserError {
+		if nodeErrorResult.IsNonRetryable {
 			return true
 		}
 	}
 
-	// Protocol error path: inspect the wrapped LavaError subcategory. We keep
-	// the existing "unsupported-method-by-message" and "non-retryable" checks
-	// from HasUnsupportedMethodErrors so behavior for legacy providers is
-	// unchanged.
 	for _, protocolError := range protocolErrors {
-		if chainlib.IsNonRetryableUserFacingErrorType(protocolError.GetError()) {
-			return true
-		}
-		if chainlib.IsUnsupportedMethodError(protocolError.GetError()) {
-			return true
-		}
 		if lavasession.EpochMismatchError.Is(protocolError.GetError()) {
 			continue
 		}

--- a/protocol/relaycore/relay_processor_test.go
+++ b/protocol/relaycore/relay_processor_test.go
@@ -1527,6 +1527,88 @@ func TestHasUnsupportedMethodErrors(t *testing.T) {
 	})
 }
 
+// TestRelayProcessor_RetryDecisionHonorsRetryableFlag covers the retry gate at
+// the relay processor level — the single authority consulted by both the
+// consumer and smart-router state machines via HasRequiredNodeResults →
+// shouldRetryRelay → HasNonRetryableUserFacingErrors. We assert two symmetric
+// cases:
+//   - a non-retryable node error (IsNonRetryable=true) short-circuits retries
+//   - a retryable node error (IsNonRetryable=false) allows retries
+func TestRelayProcessor_RetryDecisionHonorsRetryableFlag(t *testing.T) {
+	cases := []struct {
+		name             string
+		nonRetryable     bool
+		wantNonRetryable bool
+	}{
+		{name: "non-retryable node error stops retries", nonRetryable: true, wantNonRetryable: true},
+		{name: "retryable node error allows retries", nonRetryable: false, wantNonRetryable: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			chainParser, _, _, closeServer, _, err := chainlib.CreateChainLibMocks(ctx, "LAV1", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+			if closeServer != nil {
+				defer closeServer()
+			}
+			require.NoError(t, err)
+			chainMsg, err := chainParser.ParseMsg("/cosmos/base/tendermint/v1beta1/blocks/17", nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+			protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, "", "")
+
+			usedProviders := lavasession.NewUsedProviders(nil)
+			relayProcessor := NewRelayProcessor(ctx, nil, nil, RelayProcessorMetrics, RelayProcessorMetrics, RelayRetriesManagerInstance, newMockRelayStateMachine(protocolMessage, usedProviders))
+
+			lockCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
+			defer cancel()
+			require.Nil(t, usedProviders.TryLockSelection(lockCtx))
+			usedProviders.AddUsed(lavasession.ConsumerSessionsMap{"lava@test": &lavasession.SessionInfo{}}, nil)
+
+			go SendNodeErrorWithRetryable(relayProcessor, "lava@test", time.Millisecond*5, tc.nonRetryable)
+
+			waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+			defer waitCancel()
+			require.NoError(t, relayProcessor.WaitForResults(waitCtx))
+
+			require.Equal(t, tc.wantNonRetryable, relayProcessor.HasNonRetryableUserFacingErrors(),
+				"HasNonRetryableUserFacingErrors mismatch — retry decision must rest on the IsNonRetryable flag")
+		})
+	}
+}
+
+// TestIsNonRetryableNodeError_Classification verifies the classifier helper
+// the consumer/smart-router hot paths use to populate RelayResult.IsNonRetryable
+// correctly separates retryable transient errors from terminal deterministic
+// ones. "execution reverted" is the canonical case that regressed before this
+// fix (non-retryable in the registry, but the old code ignored Retryable=false
+// for node errors that weren't unsupported-method or user-input).
+func TestIsNonRetryableNodeError_Classification(t *testing.T) {
+	cases := []struct {
+		name    string
+		chainID string
+		status  int
+		message string
+		want    bool
+	}{
+		{name: "execution reverted is non-retryable", chainID: "ETH1", status: 200, message: "execution reverted", want: true},
+		{name: "execution reverted with data is non-retryable", chainID: "ETH1", status: 200, message: "execution reverted: NFT not found", want: true},
+		{name: "unsupported method is non-retryable (Retryable=false)", chainID: "ETH1", status: 404, message: "method not found", want: true},
+		{name: "user parse error is non-retryable", chainID: "ETH1", status: -32700, message: "parse error", want: true},
+		{name: "generic transient error is retryable", chainID: "ETH1", status: 502, message: "bad gateway", want: false},
+		{name: "unknown message is retryable (returns false)", chainID: "ETH1", status: 0, message: "totally unfamiliar garbage", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := common.IsNonRetryableNodeError(tc.chainID, tc.status, tc.message)
+			require.Equal(t, tc.want, got, "message %q", tc.message)
+		})
+	}
+}
+
 // TestCrossValidationEmptyArrayResponse tests that empty arrays [] are valid for cross-validation
 func TestCrossValidationEmptyArrayResponse(t *testing.T) {
 	ctx := context.Background()

--- a/protocol/relaycore/testing_helpers_test.go
+++ b/protocol/relaycore/testing_helpers_test.go
@@ -111,6 +111,29 @@ func SendNodeError(relayProcessor *RelayProcessor, provider string, delay time.D
 	relayProcessor.SetResponse(response)
 }
 
+// SendNodeErrorWithRetryable sends a node error and lets the caller set the
+// IsNonRetryable flag that the classifier would normally populate. Used to
+// exercise the retry gate in HasNonRetryableUserFacingErrors.
+func SendNodeErrorWithRetryable(relayProcessor *RelayProcessor, provider string, delay time.Duration, nonRetryable bool) {
+	time.Sleep(delay)
+	relayProcessor.GetUsedProviders().RemoveUsed(provider, lavasession.NewRouterKey(nil), nil)
+	response := &RelayResponse{
+		RelayResult: common.RelayResult{
+			Request: &pairingtypes.RelayRequest{
+				RelaySession: &pairingtypes.RelaySession{},
+				RelayData:    &pairingtypes.RelayPrivateData{},
+			},
+			Reply:          &pairingtypes.RelayReply{Data: []byte(`{"message":"bad","code":123}`)},
+			ProviderInfo:   common.ProviderInfo{ProviderAddress: provider},
+			StatusCode:     500,
+			IsNodeError:    true,
+			IsNonRetryable: nonRetryable,
+		},
+		Err: nil,
+	}
+	relayProcessor.SetResponse(response)
+}
+
 func SendNodeErrorJsonRpc(relayProcessor *RelayProcessor, provider string, delay time.Duration) {
 	time.Sleep(delay)
 	id, _ := json.Marshal(1)

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -1285,21 +1285,45 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 			// Both carry the "don't retry, don't charge" contract via the
 			// IsNonRetryableUserFacing subcategory predicate; caching diverges.
 			if isNodeError {
-				isUnsupported := common.IsUnsupportedMethodError(rpccs.listenEndpoint.ChainID, localRelayResult.StatusCode, errorMessage)
-				isUserErr := common.IsUserInputError(rpccs.listenEndpoint.ChainID, localRelayResult.StatusCode, errorMessage)
-
-				localRelayResult.IsUnsupportedMethod = isUnsupported
-				localRelayResult.IsUserError = isUserErr
+				// Classify once per node error. The three flags (IsNonRetryable,
+				// IsUnsupportedMethod, IsUserError) all come from the same
+				// registry lookup; doing three separate classify passes here
+				// would triple the work on a hot error path.
+				family := common.ChainFamilyUnknown
+				if f, ok := common.GetChainFamily(rpccs.listenEndpoint.ChainID); ok {
+					family = f
+				}
+				transport := common.ApiInterfaceToTransport(rpccs.listenEndpoint.ApiInterface)
+				// JSON-RPC node errors return HTTP 200 with the real error code
+				// embedded in the response body (error.code). The registry's
+				// code-based JSON-RPC matchers (e.g. -32700, -32602) only hit
+				// if we feed them that body code rather than the HTTP status.
+				errorCode := localRelayResult.StatusCode
+				if transport == common.TransportJsonRPC && localRelayResult.Reply != nil {
+					if jsonrpcCode := common.ExtractJSONRPCErrorCode(localRelayResult.Reply.Data); jsonrpcCode != 0 {
+						errorCode = jsonrpcCode
+					}
+				}
+				classification := common.ClassifyNodeErrorForRetry(family, transport, errorCode, errorMessage)
+				localRelayResult.IsNonRetryable = classification.IsNonRetryable
+				localRelayResult.IsUnsupportedMethod = classification.IsUnsupportedMethod
+				localRelayResult.IsUserError = classification.IsUserError
 
 				switch {
-				case isUnsupported:
+				case classification.IsUnsupportedMethod:
 					utils.LavaFormatInfo("unsupported method detected in relay result",
 						utils.LogAttr("GUID", ctx),
 						utils.LogAttr("method", protocolMessage.GetApi().Name),
 						utils.LogAttr("error", errorMessage),
 					)
-				case isUserErr:
+				case classification.IsUserError:
 					utils.LavaFormatInfo("user input error detected in relay result",
+						utils.LogAttr("GUID", ctx),
+						utils.LogAttr("method", protocolMessage.GetApi().Name),
+						utils.LogAttr("error", errorMessage),
+					)
+				case classification.IsNonRetryable:
+					utils.LavaFormatInfo("non-retryable node error detected in relay result",
 						utils.LogAttr("GUID", ctx),
 						utils.LogAttr("method", protocolMessage.GetApi().Name),
 						utils.LogAttr("error", errorMessage),

--- a/protocol/rpcsmartrouter/direct_rpc_relay.go
+++ b/protocol/rpcsmartrouter/direct_rpc_relay.go
@@ -407,6 +407,16 @@ func (d *DirectRPCRelaySender) sendJSONRPCRelay(
 		},
 		IsNodeError: hasError,
 	}
+	if hasError {
+		// JSON-RPC node errors come back as HTTP 200 with the real code inside
+		// error.code. Prefer the body code over the HTTP status so registry
+		// code-based matchers (e.g. -32700, -32602) fire.
+		errorCode := statusCode
+		if jsonrpcCode := common.ExtractJSONRPCErrorCode(responseData); jsonrpcCode != 0 {
+			errorCode = jsonrpcCode
+		}
+		result.IsNonRetryable = common.IsNonRetryableNodeErrorWithContext(d.chainFamily, common.TransportJsonRPC, errorCode, errorMessage)
+	}
 
 	return result, nil
 }
@@ -518,6 +528,9 @@ func (d *DirectRPCRelaySender) sendRESTRelay(
 			ProviderAddress: providerAddress,
 		},
 		IsNodeError: isNodeError, // Correct transport-level classification
+	}
+	if hasError {
+		result.IsNonRetryable = common.IsNonRetryableNodeErrorWithContext(d.chainFamily, common.TransportREST, response.StatusCode, errorMessage)
 	}
 
 	utils.LavaFormatTrace("REST request completed",
@@ -671,6 +684,9 @@ func (d *DirectRPCRelaySender) sendGRPCRelay(
 			ProviderAddress: providerAddress,
 		},
 		IsNodeError: hasError,
+	}
+	if hasError {
+		result.IsNonRetryable = common.IsNonRetryableNodeErrorWithContext(d.chainFamily, common.TransportGRPC, response.StatusCode, errorMessage)
 	}
 
 	return result, nil

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -1913,6 +1913,7 @@ func (rpcss *RPCSmartRouterServer) relayInnerDirect(
 	relayResult.Finalized = result.Finalized
 	relayResult.StatusCode = result.StatusCode
 	relayResult.IsNodeError = result.IsNodeError
+	relayResult.IsNonRetryable = result.IsNonRetryable
 	relayResult.ProviderInfo = result.ProviderInfo
 	if relayResult.Reply != nil {
 		relayResult.Reply.Metadata = append(relayResult.Reply.Metadata, pairingtypes.Metadata{


### PR DESCRIPTION
Node errors classified to a LavaError with Retryable=false (e.g. CHAIN_EXECUTION_REVERTED, CHAIN_OUT_OF_GAS, CHAIN_DOUBLE_SPEND) were retried because the state machine only short-circuited on IsUnsupportedMethod / IsUserError subcategories and ignored the registry's Retryable flag. Populate RelayResult.IsNonRetryable from the classifier on both consumer and smart-router paths and make HasNonRetryableUserFacingErrors rest solely on that flag.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage