### PR TITLE
fix(e2e): guard alice's back-to-back gov txs against sequence-mismatc…

### DIFF
--- a/scripts/test/init_e2e.sh
+++ b/scripts/test/init_e2e.sh
@@ -13,31 +13,39 @@ source $__dir/../useful_commands.sh
 
 GASPRICE="0.00002ulava"
 
-# Specs proposal
+# Specs / Plans / Plan-removal proposals
+#
+# Every `submit-legacy-proposal` and every `vote` below is from the same signer
+# (alice). `--broadcast-mode sync` (the default) returns after CheckTx accepts
+# the tx into the mempool — not after block inclusion — so a plain
+# `wait_next_block` between them doesn't guarantee alice's on-chain sequence
+# has advanced before the next tx queries it. Any following same-signer tx
+# would then sign with the stale pre-inclusion sequence and the antehandler
+# would reject it with "account sequence mismatch, expected N+1, got N"
+# (cosmos-sdk@v0.47.13/x/auth/ante/sigverify.go:269).
+#
+# Both the submit AND the vote need this guarantee — submit→vote and vote→next
+# submit are both same-signer pairs. `lavad_tx_and_wait` polls via
+# `wait_for_tx` until the tx is actually included, so the subsequent alice tx
+# always sees the correctly-advanced sequence. The `sleep 6` calls remain for
+# their original purpose: giving plan policies time to become active after the
+# vote lands.
 echo "---- Specs proposal ----"
-lavad tx gov submit-legacy-proposal spec-add ./specs/mainnet-1/specs/ethermint.json,./specs/mainnet-1/specs/ethereum.json,./specs/mainnet-1/specs/cosmoswasm.json,./specs/mainnet-1/specs/ibc.json,./specs/mainnet-1/specs/tendermint.json,./specs/mainnet-1/specs/tendermint.json,./specs/mainnet-1/specs/cosmossdk.json,./specs/mainnet-1/specs/cosmossdkv50.json,./specs/testnet-2/specs/lava.json --lava-dev-test -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
-lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
+lavad_tx_and_wait tx gov submit-legacy-proposal spec-add ./specs/mainnet-1/specs/ethermint.json,./specs/mainnet-1/specs/ethereum.json,./specs/mainnet-1/specs/cosmoswasm.json,./specs/mainnet-1/specs/ibc.json,./specs/mainnet-1/specs/tendermint.json,./specs/mainnet-1/specs/tendermint.json,./specs/mainnet-1/specs/cosmossdk.json,./specs/mainnet-1/specs/cosmossdkv50.json,./specs/testnet-2/specs/lava.json --lava-dev-test -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad_tx_and_wait tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 sleep 6 # need to sleep because plan policies need the specs when setting chain policies verifications
 
 # Plans proposal
 echo ---- Plans proposal ----
-wait_next_block
-lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/test_plans/default.json,./cookbook/plans/test_plans/emergency-mode.json,./cookbook/plans/test_plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
-lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
+lavad_tx_and_wait tx gov submit-legacy-proposal plans-add ./cookbook/plans/test_plans/default.json,./cookbook/plans/test_plans/emergency-mode.json,./cookbook/plans/test_plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad_tx_and_wait tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 sleep 6
 
 # Plan removal (of one)
 echo ---- Plans removal ----
-wait_next_block
 # delete plan that deletes "temporary add" plan
-lavad tx gov submit-legacy-proposal plans-del ./cookbook/plans/test_plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
-lavad tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
-wait_next_block
+lavad_tx_and_wait tx gov submit-legacy-proposal plans-del ./cookbook/plans/test_plans/temporary-del.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+lavad_tx_and_wait tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
 
 STAKE="500000000000ulava"
 

--- a/scripts/useful_commands.sh
+++ b/scripts/useful_commands.sh
@@ -100,12 +100,12 @@ extract_tx_hash() {
 # Wait for next block AND ensure a transaction is included (if tx_hash provided)
 wait_next_block_and_tx() {
   local tx_output="$1"
-  
+
   # First wait for next block
   if ! wait_next_block; then
     return 1
   fi
-  
+
   # If transaction output was provided, verify it was included
   if [ -n "$tx_output" ]; then
     local tx_hash=$(extract_tx_hash "$tx_output")
@@ -115,8 +115,37 @@ wait_next_block_and_tx() {
       fi
     fi
   fi
-  
+
   return 0
+}
+
+# Run `lavad tx ...` and block until the tx is actually included in a block.
+#
+# The default `--broadcast-mode sync` returns after CheckTx (mempool accept),
+# not after block inclusion — so a following tx from the same signer may query
+# an on-chain sequence that doesn't yet reflect the pending tx. When the pending
+# tx then lands between the next tx's query and its broadcast, the antehandler
+# rejects with "account sequence mismatch, expected N+1, got N".
+#
+# This wrapper runs the tx, extracts its hash, and waits for inclusion so the
+# caller can safely submit another tx from the same signer without racing.
+#
+# Usage: `lavad_tx_and_wait tx gov vote 1 yes -y --from alice ...`
+# (pass the full `lavad` argument list starting with `tx`).
+lavad_tx_and_wait() {
+  local output
+  output=$(lavad "$@" 2>&1)
+  local rc=$?
+  echo "$output"
+  if [ $rc -ne 0 ]; then
+    return $rc
+  fi
+  local tx_hash=$(extract_tx_hash "$output")
+  if [ -z "$tx_hash" ]; then
+    echo "ERROR: lavad_tx_and_wait could not extract txhash from output" >&2
+    return 1
+  fi
+  wait_for_tx "$tx_hash"
 }
 
 current_block() {


### PR DESCRIPTION
…h flake

The Lava Protocol E2E job (CI run 24386640804) failed at init_e2e.sh line 20 with "account sequence mismatch, expected 2, got 1" on `lavad tx gov vote 1 yes --from alice`. The fail repeats across three identical patterns in init_e2e.sh where alice submits a legacy proposal and immediately votes on it.

Root cause: `lavad tx ... --broadcast-mode sync` (the default) returns after CheckTx accepts the tx into the mempool — not after the tx lands in a block. A subsequent `wait_next_block` only waits for block height to tick; it does not guarantee the prior tx was included in that block. The follow-up vote then queries alice's on-chain sequence, gets the pre-submit value, signs the vote with that sequence, and broadcasts. If the submit lands between query and broadcast, the antehandler (cosmos-sdk@v0.47.13/x/auth/ante/sigverify.go:269) rejects the vote.

Add `lavad_tx_and_wait` in scripts/useful_commands.sh — a thin wrapper around `lavad <subcommand>` that captures the txhash from the CLI output and polls `lavad q tx $hash` via the existing `wait_for_tx` helper until the tx is actually included. Wrap the three same-signer submit-then-vote patterns in init_e2e.sh (proposals 1, 2, and 3) so alice's sequence has definitely advanced on chain before the vote queries it. The redundant `wait_next_block` between each submit and vote is dropped: inclusion is now explicit.

Other same-account back-to-back patterns in the script (user1, user3) are separated by `wait_next_block` + `sleep_until_next_epoch` or `sleep 6`, which already provide enough wall-clock gap for the CheckTx → block-inclusion race to close. Leaving those unchanged for minimum churn; they can adopt the helper if a similar flake surfaces.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage