### PR TITLE
perf(chainlib): zero-copy passthrough in checkUTXOResponseAndFixReply…

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -161,20 +161,22 @@ func isUTXOFamily(chainID string) bool {
 	return chainID == "BTC" || chainID == "BTCT" || chainID == "LTC" || chainID == "LTCT" || chainID == "DOGE" || chainID == "DOGET" || chainID == "BCH" || chainID == "BCHT"
 }
 
-func checkUTXOResponseAndFixReply(chainID string, replyData []byte) string {
-	response := string(replyData)
+// checkUTXOResponseAndFixReply returns the reply body for UTXO-family chains after
+// reformatting it for JSON-RPC 1.0 semantics, and returns replyData unchanged for all
+// other chains. The non-UTXO path is zero-copy: hot chains (ETH, Cosmos, etc.) no
+// longer pay a full string(replyData) allocation per response.
+func checkUTXOResponseAndFixReply(chainID string, replyData []byte) []byte {
 	if !isUTXOFamily(chainID) {
-		return response
+		return replyData
 	}
 
 	// Try single response first
 	var jsonMsg *rpcclient.JsonrpcMessage
 	if err := json.Unmarshal(replyData, &jsonMsg); err == nil {
-		btcResponse := convertToUTXOResponse(jsonMsg)
-		if marshaledRes, err := json.Marshal(btcResponse); err == nil {
-			response = string(marshaledRes)
+		if marshaledRes, err := json.Marshal(convertToUTXOResponse(jsonMsg)); err == nil {
+			return marshaledRes
 		}
-		return response
+		return replyData
 	}
 
 	// Try batch response (JSON array)
@@ -185,11 +187,13 @@ func checkUTXOResponseAndFixReply(chainID string, replyData []byte) string {
 			btcBatch[i] = convertToUTXOResponse(&jsonMsgs[i])
 		}
 		if marshaledRes, err := json.Marshal(btcBatch); err == nil {
-			response = string(marshaledRes)
+			return marshaledRes
 		}
 	}
 
-	return response
+	// Reached only if batch unmarshal failed OR batch marshal failed: return the
+	// original bytes unchanged so the caller still gets a well-formed reply.
+	return replyData
 }
 
 // convertToUTXOResponse converts a JsonrpcMessage to BTCResponse format.
@@ -214,6 +218,18 @@ func addHeadersAndSendString(c *fiber.Ctx, metaData []pairingtypes.Metadata, dat
 	}
 
 	return c.SendString(data)
+}
+
+// addHeadersAndSendBytes is the []byte counterpart of addHeadersAndSendString.
+// Used on the ETH/Cosmos hot path so the upstream reply body flows straight to
+// fiber.Ctx.Send without a string(response) detour — which would otherwise
+// cancel out the zero-copy passthrough in checkUTXOResponseAndFixReply.
+func addHeadersAndSendBytes(c *fiber.Ctx, metaData []pairingtypes.Metadata, data []byte) error {
+	for _, value := range metaData {
+		c.Set(value.Name, value.Value)
+	}
+
+	return c.Send(data)
 }
 
 func convertToJsonError(errorMsg string) string {

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -402,7 +402,7 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 		result := checkUTXOResponseAndFixReply("DOGE", []byte(input))
 		// Should preserve error:null and strip jsonrpc (BTC uses JSON-RPC 1.0)
 		var parsed map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		require.NoError(t, json.Unmarshal(result, &parsed))
 		_, hasError := parsed["error"]
 		require.True(t, hasError, "error field must be present (even when null)")
 		_, hasJsonrpc := parsed["jsonrpc"]
@@ -414,7 +414,7 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 		input := `[{"jsonrpc":"2.0","id":"1","result":"hash1"},{"jsonrpc":"2.0","id":"2","result":"hash2"}]`
 		result := checkUTXOResponseAndFixReply("DOGE", []byte(input))
 		var parsed []map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		require.NoError(t, json.Unmarshal(result, &parsed))
 		require.Len(t, parsed, 2)
 		for i, elem := range parsed {
 			_, hasError := elem["error"]
@@ -429,7 +429,7 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 		input := `[{"jsonrpc":"2.0","id":"1773768178254-0","result":"23699c7e"}]`
 		result := checkUTXOResponseAndFixReply("DOGE", []byte(input))
 		var parsed []map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(result), &parsed), "single-element batch must remain an array")
+		require.NoError(t, json.Unmarshal(result, &parsed), "single-element batch must remain an array")
 		require.Len(t, parsed, 1)
 		require.Equal(t, "1773768178254-0", parsed[0]["id"])
 		_, hasError := parsed[0]["error"]
@@ -440,15 +440,20 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 
 	t.Run("non_btc_chain_passthrough", func(t *testing.T) {
 		input := `{"jsonrpc":"2.0","id":1,"result":"abc"}`
-		result := checkUTXOResponseAndFixReply("ETH1", []byte(input))
-		require.Equal(t, input, result, "non-BTC chains should pass through unchanged")
+		replyData := []byte(input)
+		result := checkUTXOResponseAndFixReply("ETH1", replyData)
+		require.Equal(t, input, string(result), "non-BTC chains should pass through unchanged")
+		// Zero-copy passthrough: non-UTXO chains must return the exact same backing slice
+		// (same ptr + len), not a copy. This is the core guarantee of this function for the
+		// hot path — regressing it would reintroduce the 4.5GB/12m alloc that motivated the fix.
+		require.Same(t, &replyData[0], &result[0], "non-UTXO chains must return the input slice without copying")
 	})
 
 	t.Run("btc_with_actual_error", func(t *testing.T) {
 		input := `{"id":"1","error":{"code":-8,"message":"Block height out of range"},"result":null}`
 		result := checkUTXOResponseAndFixReply("BTC", []byte(input))
 		var parsed map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		require.NoError(t, json.Unmarshal(result, &parsed))
 		errorField := parsed["error"]
 		require.NotNil(t, errorField, "error field must be preserved when not null")
 	})

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -502,13 +502,21 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 		}
 
 		response := checkUTXOResponseAndFixReply(chainID, reply.Data)
-		// Log request and response
+		// Log request and response — gate the string conversion behind the
+		// debug-level check because LogRequestAndResponse routes the happy path
+		// through LavaFormatDebug. At info/warn+ the value is never emitted,
+		// but Go evaluates arguments eagerly, so a blind string(response) would
+		// still allocate a full copy of every reply body on the hot path.
+		var loggedResponse string
+		if utils.IsDebugEnabled() {
+			loggedResponse = string(response)
+		}
 		apil.logger.LogRequestAndResponse("jsonrpc http",
 			false,
 			"POST",
 			fiberCtx.Request().URI().String(),
 			msg,
-			response,
+			loggedResponse,
 			msgSeed,
 			time.Since(startTime),
 			nil,
@@ -516,8 +524,9 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 		if relayResult.GetStatusCode() != 0 {
 			fiberCtx.Status(relayResult.StatusCode)
 		}
-		// Return json response
-		err = addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+		// Return json response — send bytes directly so we don't allocate
+		// another string(response) on top of the already-pass-through body.
+		err = addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		return err
 	}
 	app.Post("/*", handlerPost)


### PR DESCRIPTION
… for non-UTXO chains

The function unconditionally did `string(replyData)` on entry, which allocated a full copy of every upstream reply body — even for non-UTXO chains that then returned immediately without using it. A live pprof capture on the eth router attributed ~4.5 GB of inuse memory over a 12-minute window to this single allocation.

Return []byte and only reformat on the UTXO path; non-UTXO chains (ETH, Cosmos, tendermint, etc.) now pass through the original slice with no copy. Test coverage adds a pointer-identity assertion so any future regression that reintroduces an eager copy fails loudly.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage