### PR TITLE
perf(chainlib): send response bodies as bytes via fiber.Ctx.Send

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -212,18 +212,10 @@ func convertToUTXOResponse(msg *rpcclient.JsonrpcMessage) *rpcclient.BTCResponse
 	}
 }
 
-func addHeadersAndSendString(c *fiber.Ctx, metaData []pairingtypes.Metadata, data string) error {
-	for _, value := range metaData {
-		c.Set(value.Name, value.Value)
-	}
-
-	return c.SendString(data)
-}
-
-// addHeadersAndSendBytes is the []byte counterpart of addHeadersAndSendString.
-// Used on the ETH/Cosmos hot path so the upstream reply body flows straight to
-// fiber.Ctx.Send without a string(response) detour — which would otherwise
-// cancel out the zero-copy passthrough in checkUTXOResponseAndFixReply.
+// addHeadersAndSendBytes writes response metadata headers and sends the raw body via
+// fiber.Ctx.Send to avoid the []byte → string → []byte round-trip that fiber.Ctx.SendString
+// imposes at every call site. Hot-path response bodies (already []byte from the relay
+// pipeline) no longer pay an extra string-conversion allocation per request.
 func addHeadersAndSendBytes(c *fiber.Ctx, metaData []pairingtypes.Metadata, data []byte) error {
 	for _, value := range metaData {
 		c.Set(value.Name, value.Value)
@@ -232,15 +224,18 @@ func addHeadersAndSendBytes(c *fiber.Ctx, metaData []pairingtypes.Metadata, data
 	return c.Send(data)
 }
 
-func convertToJsonError(errorMsg string) string {
+// convertToJsonError returns a JSON-encoded `{"error": errorMsg}` body as raw bytes.
+// Returning []byte (rather than string) lets every error-path caller hand the
+// result straight to addHeadersAndSendBytes / fiber.Ctx.Send with no conversion.
+func convertToJsonError(errorMsg string) []byte {
 	jsonResponse, err := json.Marshal(fiber.Map{
 		"error": errorMsg,
 	})
 	if err != nil {
-		return `{"error": "Failed to marshal error response to json"}`
+		return []byte(`{"error": "Failed to marshal error response to json"}`)
 	}
 
-	return string(jsonResponse)
+	return jsonResponse
 }
 
 func addAttributeToError(key, value, errorMessage string) string {

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/lavanet/lava/v5/protocol/common"
+	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,7 +130,7 @@ func TestConvertToJsonError(t *testing.T) {
 			t.Parallel()
 
 			result := convertToJsonError(testCase.errorMsg)
-			if result != testCase.expected {
+			if string(result) != testCase.expected {
 				t.Errorf("Expected result to be %s, but got %s", testCase.expected, result)
 			}
 		})
@@ -548,6 +549,74 @@ func TestApplyResponseCompression(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddHeadersAndSendBytes(t *testing.T) {
+	t.Run("writes_body_bytes_and_metadata_headers", func(t *testing.T) {
+		payload := []byte(`{"jsonrpc":"2.0","id":1,"result":"0xdeadbeef"}`)
+		meta := []pairingtypes.Metadata{
+			{Name: "X-Test-Trace-Id", Value: "abc-123"},
+			{Name: "Content-Type", Value: "application/json"},
+		}
+
+		app := fiber.New()
+		app.Get("/", func(c *fiber.Ctx) error {
+			return addHeadersAndSendBytes(c, meta, payload)
+		})
+
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Equal(t, payload, body, "response body must match the []byte payload exactly")
+		require.Equal(t, "abc-123", resp.Header.Get("X-Test-Trace-Id"))
+		require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	})
+
+	t.Run("empty_body_is_allowed", func(t *testing.T) {
+		app := fiber.New()
+		app.Get("/", func(c *fiber.Ctx) error {
+			return addHeadersAndSendBytes(c, nil, nil)
+		})
+
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		require.Empty(t, body)
+	})
+
+	t.Run("preserves_binary_payload_bytes", func(t *testing.T) {
+		// The whole point of the []byte signature is that non-UTF8 / binary content
+		// isn't mangled by a []byte → string → []byte round-trip. Verify with a
+		// payload that includes every byte value, including embedded NULs.
+		payload := make([]byte, 256)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		app := fiber.New()
+		app.Get("/", func(c *fiber.Ctx) error {
+			return addHeadersAndSendBytes(c, nil, payload)
+		})
+
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, payload, body, "binary payload must round-trip byte-for-byte")
+	})
 }
 
 func TestCompareRequestedBlockInBatch(t *testing.T) {

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -473,13 +473,13 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			if common.APINotSupportedError.Is(err) {
 				// Convert error to JSON string and add headers
 				errorResponse, _ := json.Marshal(common.JsonRpcMethodNotFoundError)
-				return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), string(errorResponse))
+				return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), errorResponse)
 			}
 
 			if _, ok := err.(*json.SyntaxError); ok {
 				// Convert error to JSON string and add headers
 				errorResponse, _ := json.Marshal(common.JsonRpcParseError)
-				return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), string(errorResponse))
+				return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), errorResponse)
 			}
 
 			// Get unique GUID response
@@ -498,7 +498,7 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 			// Construct json response
 			response := convertToJsonError(errMasking)
 			// Return error json response
-			return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		}
 
 		response := checkUTXOResponseAndFixReply(chainID, reply.Data)

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -322,7 +322,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			response := convertToJsonError(errMasking)
 
 			// Return error json response
-			return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		}
 		// Log request and response
 		apil.logger.LogRequestAndResponse("http in/out", false, http.MethodPost, path, requestBody, string(reply.Data), msgSeed, time.Since(startTime), nil)
@@ -330,7 +330,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			fiberCtx.Status(relayResult.StatusCode)
 		}
 		// Return json response and add metric for after provider processing
-		err = addHeadersAndSendString(fiberCtx, reply.GetMetadata(), string(reply.Data))
+		err = addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), reply.Data)
 		return err
 	}
 
@@ -397,7 +397,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 			response := convertToJsonError(errMasking)
 
 			// Return error json response
-			return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		}
 		if relayResult.GetStatusCode() != 0 {
 			fiberCtx.Status(relayResult.StatusCode)
@@ -406,7 +406,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		apil.logger.LogRequestAndResponse("http in/out", false, http.MethodGet, path, "", string(reply.Data), msgSeed, time.Since(startTime), nil)
 
 		// Return json response
-		err = addHeadersAndSendString(fiberCtx, reply.GetMetadata(), string(reply.Data))
+		err = addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), reply.Data)
 		return err
 	}
 

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -484,7 +484,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			if common.APINotSupportedError.Is(err) {
 				// Convert error to JSON string and add headers
 				errorResponse, _ := json.Marshal(common.JsonRpcMethodNotFoundError)
-				return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), string(errorResponse))
+				return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), errorResponse)
 			}
 
 			// Get unique GUID response
@@ -503,16 +503,15 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			// Construct json response
 			response := rpcInterfaceMessages.ConvertToTendermintError(errMasking, fiberCtx.Body())
 			// Return error json response
-			return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), []byte(response))
 		}
 		// Log request and response
 		apil.logger.LogRequestAndResponse("tendermint http in/out", false, "POST", fiberCtx.Request().URI().String(), msg, string(reply.Data), msgSeed, time.Since(startTime), nil)
 		if relayResult.GetStatusCode() != 0 {
 			fiberCtx.Status(relayResult.StatusCode)
 		}
-		response := string(reply.Data)
 		// Return json response
-		err = addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+		err = addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), reply.Data)
 		return err
 	}
 
@@ -568,16 +567,15 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 			response := convertToJsonError(errMasking)
 
 			// Return error json response
-			return addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+			return addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), response)
 		}
-		response := string(reply.Data)
 		// Log request and response
-		apil.logger.LogRequestAndResponse("tendermint http in/out", false, "GET", fiberCtx.Request().URI().String(), "", response, msgSeed, time.Since(startTime), nil)
+		apil.logger.LogRequestAndResponse("tendermint http in/out", false, "GET", fiberCtx.Request().URI().String(), "", string(reply.Data), msgSeed, time.Since(startTime), nil)
 		if relayResult.GetStatusCode() != 0 {
 			fiberCtx.Status(relayResult.StatusCode)
 		}
 		// Return json response
-		err = addHeadersAndSendString(fiberCtx, reply.GetMetadata(), response)
+		err = addHeadersAndSendBytes(fiberCtx, reply.GetMetadata(), reply.Data)
 		return err
 	}
 


### PR DESCRIPTION
addHeadersAndSendString called fiber.Ctx.SendString, which copies the string into fasthttp's response bytebufferpool. All callers in the relay path already hold the body as []byte (reply.Data) or as JSON marshal output (also []byte) and were round-tripping through string() at the call site. That string() conversion is a full per-request copy on top of the unavoidable copy into fasthttp's buffer — visible in pprof as 96 GB inuse under bytebufferpool.(*ByteBuffer).WriteString on the eth router.

Rename to addHeadersAndSendBytes, take []byte, and use fiber.Ctx.Send. Update every caller (jsonRPC, tendermintRPC, rest) to drop the string() round-trip on success paths where reply.Data is already []byte; error paths keep []byte(s) on the small error strings since those aren't on the hot path. Add focused tests covering body + metadata headers, the empty-body case, and a binary payload round-trip to guard against a regression that reintroduces the string() conversion.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage