### PR TITLE
perf: configurable response compression

### DIFF
--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -376,6 +376,74 @@ func GetRelayTimeout(chainMessage ChainMessageForSend, averageBlockTime time.Dur
 	return extraRelayTimeout + relayTimeAddition
 }
 
+// applyResponseCompression wires the fiber compress middleware according to
+// cmdFlags.ResponseCompression. Modes:
+//
+//	"off"    — no compression middleware registered. Cheapest on CPU; clients get
+//	           raw bytes. Use when the process sits behind a compressing ingress.
+//	"brotli" — current legacy behavior: fasthttp auto-negotiates br/gzip/deflate
+//	           based on Accept-Encoding. Brotli in Go costs ~3x the CPU of gzip
+//	           for similar wire savings, so this is the expensive choice.
+//	"gzip"   — default. Strips `br` from Accept-Encoding before fasthttp's
+//	           encoder picks, so the best encoding advertised falls back to gzip
+//	           (or deflate). ~3x cheaper than brotli on the same workload.
+//
+// Any unknown value is treated as "gzip" but logs a warning — a deploy-time
+// typo in the flag would otherwise silently downgrade compression config.
+func applyResponseCompression(app *fiber.App, mode string) {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	switch normalized {
+	case common.ResponseCompressionOff:
+		return
+	case common.ResponseCompressionBrotli:
+		app.Use(compress.New(compress.Config{Level: compress.LevelBestSpeed}))
+	default: // "gzip", "", or anything else
+		if normalized != common.ResponseCompressionGzip && normalized != "" {
+			utils.LavaFormatWarning("unknown response-compression mode, falling back to gzip",
+				nil, utils.LogAttr("mode", mode))
+		}
+		app.Use(stripBrotliAcceptEncoding)
+		app.Use(compress.New(compress.Config{Level: compress.LevelBestSpeed}))
+	}
+}
+
+// stripBrotliAcceptEncoding removes the `br` coding from Accept-Encoding before
+// downstream middleware inspects it. Preserves q-values on remaining codings and
+// is a no-op when the header is missing. Case-insensitive per RFC 7231 §5.3.4.
+func stripBrotliAcceptEncoding(c *fiber.Ctx) error {
+	ae := c.Get(fiber.HeaderAcceptEncoding)
+	if ae == "" {
+		return c.Next()
+	}
+	parts := strings.Split(ae, ",")
+	kept := parts[:0]
+	stripped := false
+	for _, part := range parts {
+		coding := part
+		if semi := strings.IndexByte(coding, ';'); semi >= 0 {
+			coding = coding[:semi]
+		}
+		if strings.EqualFold(strings.TrimSpace(coding), "br") {
+			stripped = true
+			continue
+		}
+		kept = append(kept, part)
+	}
+	if stripped {
+		if len(kept) == 0 {
+			// Client advertised only `br`. An absent Accept-Encoding is
+			// semantically different from an empty-value one: many stacks
+			// (fasthttp included) treat absent as "no client preference, pick
+			// your default" while empty-value can short-circuit content
+			// negotiation entirely. Delete the header to fall back to default.
+			c.Request().Header.Del(fiber.HeaderAcceptEncoding)
+		} else {
+			c.Request().Header.Set(fiber.HeaderAcceptEncoding, strings.Join(kept, ","))
+		}
+	}
+	return c.Next()
+}
+
 // setup a common preflight and cors configuration allowing wild cards and preflight caching.
 func createAndSetupBaseAppListener(cmdFlags common.ConsumerCmdFlags, healthCheckPath string, healthReporter HealthReporter) *fiber.App {
 	app := fiber.New(fiber.Config{
@@ -383,7 +451,7 @@ func createAndSetupBaseAppListener(cmdFlags common.ConsumerCmdFlags, healthCheck
 		JSONDecoder: json.Unmarshal,
 	})
 	app.Use(favicon.New())
-	app.Use(compress.New(compress.Config{Level: compress.LevelBestSpeed}))
+	applyResponseCompression(app, cmdFlags.ResponseCompression)
 	app.Use(func(c *fiber.Ctx) error {
 		// we set up wild card by default.
 		c.Set("Access-Control-Allow-Origin", cmdFlags.OriginFlag)

--- a/protocol/chainlib/common_test.go
+++ b/protocol/chainlib/common_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	websocket2 "github.com/gorilla/websocket"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/lavanet/lava/v5/protocol/common"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -452,6 +454,95 @@ func TestCheckUTXOResponseAndFixReply(t *testing.T) {
 		errorField := parsed["error"]
 		require.NotNil(t, errorField, "error field must be preserved when not null")
 	})
+}
+
+func TestStripBrotliAcceptEncoding(t *testing.T) {
+	cases := []struct {
+		name, input, want string
+		// wantPresent distinguishes "header absent" (fasthttp.Peek == nil) from
+		// "header present with empty value" — the two cases are semantically
+		// different for downstream content negotiation.
+		wantPresent bool
+	}{
+		{"br_only_deletes_header", "br", "", false},
+		{"br_with_gzip_and_deflate", "br, gzip, deflate", " gzip, deflate", true},
+		{"br_with_qvalues", "br;q=1.0, gzip;q=0.8", " gzip;q=0.8", true},
+		{"gzip_only_no_op", "gzip, deflate", "gzip, deflate", true},
+		{"uppercase_BR_stripped", "BR, gzip", " gzip", true},
+		{"br_not_a_token_preserved", "gzip, xbr, deflate", "gzip, xbr, deflate", true},
+		{"empty_header_no_op", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			var seen string
+			var present bool
+			app.Use(stripBrotliAcceptEncoding)
+			app.Get("/", func(c *fiber.Ctx) error {
+				seen = c.Get(fiber.HeaderAcceptEncoding)
+				present = c.Request().Header.Peek(fiber.HeaderAcceptEncoding) != nil
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+			if tc.input != "" {
+				req.Header.Set(fiber.HeaderAcceptEncoding, tc.input)
+			}
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, tc.want, seen)
+			require.Equal(t, tc.wantPresent, present, "header presence mismatch (absent vs empty-value)")
+		})
+	}
+}
+
+func TestApplyResponseCompression(t *testing.T) {
+	// Payload large enough to exceed fasthttp's built-in minimum compression threshold.
+	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":"%s"}`, strings.Repeat("a", 4096)))
+
+	cases := []struct {
+		name             string
+		mode             string
+		acceptEncoding   string
+		wantEncoding     string // "" means no Content-Encoding header
+		wantBodyPassThru bool   // true means response body should equal payload byte-for-byte
+	}{
+		{"off_mode_no_compression", common.ResponseCompressionOff, "br, gzip, deflate", "", true},
+		{"brotli_mode_encodes_br_when_advertised", common.ResponseCompressionBrotli, "br, gzip", "br", false},
+		{"brotli_mode_falls_back_to_gzip_when_br_absent", common.ResponseCompressionBrotli, "gzip, deflate", "gzip", false},
+		{"gzip_mode_strips_br_and_falls_back_to_gzip", common.ResponseCompressionGzip, "br, gzip, deflate", "gzip", false},
+		{"gzip_mode_with_no_client_br_still_uses_gzip", common.ResponseCompressionGzip, "gzip", "gzip", false},
+		{"unknown_mode_defaults_to_gzip", "something-unknown", "br, gzip", "gzip", false},
+		{"empty_mode_defaults_to_gzip", "", "br, gzip", "gzip", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			applyResponseCompression(app, tc.mode)
+			app.Get("/", func(c *fiber.Ctx) error {
+				c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+				return c.Send(payload)
+			})
+
+			req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+			req.Header.Set(fiber.HeaderAcceptEncoding, tc.acceptEncoding)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, tc.wantEncoding, resp.Header.Get(fiber.HeaderContentEncoding),
+				"unexpected Content-Encoding")
+
+			if tc.wantBodyPassThru {
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.Equal(t, payload, body, "off mode must return raw bytes")
+			}
+		})
+	}
 }
 
 func TestCompareRequestedBlockInBatch(t *testing.T) {

--- a/protocol/chainlib/compression_bench_test.go
+++ b/protocol/chainlib/compression_bench_test.go
@@ -1,0 +1,173 @@
+package chainlib
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// LAVA_BENCH_HUGE=1 opts into the huge_* payload buckets (128 MB / 1 GB).
+// They are skipped by default because a single 1 GB brotli iteration takes
+// ~15–20 s on a single core, and allocating 1 GB on CI is unfriendly.
+const hugeBenchEnvVar = "LAVA_BENCH_HUGE"
+
+// compressionBenchSizes defines the payload buckets used by both the benchmark
+// and the companion ratio test. JSON-RPC traffic on ETH routers clusters around
+// these shapes in practice:
+//
+//	small  — eth_blockNumber / eth_chainId
+//	medium — single eth_getTransactionReceipt, moderate eth_call
+//	large  — eth_getLogs over a multi-block range, debug_trace*
+var compressionBenchSizes = []struct {
+	name  string
+	bytes int
+	huge  bool // gated behind LAVA_BENCH_HUGE=1
+}{
+	{"small_~256B", 256, false},
+	{"medium_~16KB", 16 * 1024, false},
+	{"large_~1MB", 1024 * 1024, false},
+	{"huge_~128MB", 128 * 1024 * 1024, true},
+	{"huge_~1GB", 1024 * 1024 * 1024, true},
+}
+
+var compressionBenchModes = []string{
+	common.ResponseCompressionOff,
+	common.ResponseCompressionGzip,
+	common.ResponseCompressionBrotli,
+}
+
+// BenchmarkResponseCompression measures per-request CPU cost of the three
+// response-compression modes across small / medium / large JSON-RPC-shaped
+// payloads. It exercises the full fiber middleware chain so numbers reflect
+// what production actually pays, not just the raw encoder.
+//
+//	go test ./protocol/chainlib/ -bench ResponseCompression -benchmem -run=^$ -count=3
+//
+// MB/s (via SetBytes) is the metric to compare: higher = less CPU per byte of
+// response. Wire-size savings are covered by TestCompressionRatios below.
+func BenchmarkResponseCompression(b *testing.B) {
+	hugeEnabled := os.Getenv(hugeBenchEnvVar) != ""
+	for _, size := range compressionBenchSizes {
+		if size.huge && !hugeEnabled {
+			continue
+		}
+		payload := generateJSONRPCPayload(size.bytes)
+		for _, mode := range compressionBenchModes {
+			b.Run(fmt.Sprintf("%s/%s", size.name, mode), func(b *testing.B) {
+				app := fiber.New(fiber.Config{
+					DisableStartupMessage: true,
+					// Allow 1 GB bodies through fasthttp (default is 4 MB).
+					BodyLimit: 2 * 1024 * 1024 * 1024,
+				})
+				applyResponseCompression(app, mode)
+				app.Get("/", func(c *fiber.Ctx) error {
+					c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+					return c.Send(payload)
+				})
+
+				b.SetBytes(int64(len(payload)))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+					req.Header.Set(fiber.HeaderAcceptEncoding, "br, gzip, deflate")
+					resp, err := app.Test(req, -1)
+					if err != nil {
+						b.Fatalf("request %d: %v", i, err)
+					}
+					// Drain + close so fasthttp recycles the response buffer.
+					_, _ = io.Copy(io.Discard, resp.Body)
+					resp.Body.Close()
+				}
+			})
+		}
+	}
+}
+
+// TestCompressionRatios prints the wire-size savings of each mode vs uncompressed
+// for each payload bucket. Running it alongside the benchmark gives a full
+// picture: benchmark = CPU cost per byte, this test = bandwidth saved per byte.
+//
+// Not an assertion test — it always passes. Run with -v to see the table:
+//
+//	go test ./protocol/chainlib/ -run TestCompressionRatios -v
+//
+// Ratios in this table are upper bounds. The generated payload has repeating
+// structure (zero-padded hex fields) that compresses better than real-world
+// JSON-RPC responses would. Expect production ratios closer to 3–5× for
+// typical eth_getLogs responses, not the 25–30× shown here. CPU throughput
+// numbers (from the benchmark) are load-bearing regardless, because encoder
+// CPU is dominated by traversal length, not entropy.
+func TestCompressionRatios(t *testing.T) {
+	hugeEnabled := os.Getenv(hugeBenchEnvVar) != ""
+
+	t.Logf("%-14s %-8s %14s %14s %8s %8s",
+		"size", "mode", "original_B", "encoded_B", "ratio", "saved_%")
+
+	for _, size := range compressionBenchSizes {
+		if size.huge && !hugeEnabled {
+			continue
+		}
+		payload := generateJSONRPCPayload(size.bytes)
+		for _, mode := range compressionBenchModes {
+			app := fiber.New(fiber.Config{
+				DisableStartupMessage: true,
+				BodyLimit:             2 * 1024 * 1024 * 1024,
+			})
+			applyResponseCompression(app, mode)
+			app.Get("/", func(c *fiber.Ctx) error {
+				c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+				return c.Send(payload)
+			})
+
+			req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+			req.Header.Set(fiber.HeaderAcceptEncoding, "br, gzip, deflate")
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+			encoded, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			require.NoError(t, err)
+
+			ratio := float64(len(payload)) / float64(len(encoded))
+			savedPct := 100.0 * (1.0 - float64(len(encoded))/float64(len(payload)))
+			t.Logf("%-14s %-8s %14d %14d %7.2fx %7.1f%%",
+				size.name, mode, len(payload), len(encoded), ratio, savedPct)
+		}
+	}
+}
+
+// generateJSONRPCPayload returns a deterministic JSON-RPC-shaped payload of
+// approximately targetBytes. The shape mimics eth_getLogs: an array of log
+// entries with hex addresses, topics, and data fields. Realistic JSON matters
+// because compression ratios collapse on entropic input, which would make the
+// benchmark misleading.
+func generateJSONRPCPayload(targetBytes int) []byte {
+	// Small bucket: a single eth_chainId / eth_blockNumber–shaped payload.
+	if targetBytes <= 512 {
+		pad := targetBytes - 36
+		if pad < 0 {
+			pad = 0
+		}
+		return []byte(`{"jsonrpc":"2.0","id":1,"result":"0x` + strings.Repeat("a", pad) + `"}`)
+	}
+
+	const entryTemplate = `{"address":"0x%040d","topics":["0x%064d","0x%064d"],"data":"0x%0512d","blockNumber":"0x%x","transactionHash":"0x%064d","logIndex":"0x%x","removed":false}`
+
+	var buf strings.Builder
+	buf.Grow(targetBytes + 512)
+	buf.WriteString(`{"jsonrpc":"2.0","id":1,"result":[`)
+	for i := 0; buf.Len() < targetBytes; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, entryTemplate, i, i+1, i+2, i+3, i+1_000_000, i+4, i)
+	}
+	buf.WriteString(`]}`)
+	return []byte(buf.String())
+}

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -115,6 +115,16 @@ const (
 	MaxSessionsPerProviderFlagName   = "max-sessions-per-provider"  // Max number of sessions allowed per provider
 	DefaultProcessingTimeoutFlagName = "default-processing-timeout" // default timeout for relay processing
 	MinRelayTimeoutFlagName          = "min-relay-timeout"          // minimum relay timeout floor (default 1s)
+
+	// ResponseCompressionFlag controls the encoding used by the fiber compress
+	// middleware on client-facing responses. Accepted values: "gzip", "brotli", "off".
+	// Default is "gzip" because brotli in Go (andybalholm/brotli) costs ~3x more CPU
+	// than gzip for similar wire savings on typical JSON-RPC payloads.
+	ResponseCompressionFlag    = "response-compression"
+	ResponseCompressionGzip    = "gzip"
+	ResponseCompressionBrotli  = "brotli"
+	ResponseCompressionOff     = "off"
+	DefaultResponseCompression = ResponseCompressionGzip
 )
 
 const (
@@ -142,6 +152,7 @@ type ConsumerCmdFlags struct {
 	EpochDuration            time.Duration // duration of each epoch for time-based epoch system (standalone mode)
 	EnableSelectionStats     bool          // enables selection stats header for debugging provider selection
 	DebugAddress             string        // address for the debug HTTP server, e.g. ":9999". Empty = disabled.
+	ResponseCompression      string        // "gzip" (default), "brotli", or "off" — controls client-facing response compression
 }
 
 // default rolling logs behavior (if enabled) will store 3 files each 100MB for up to 1 day every time.

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -802,6 +802,7 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 				GitLabToken:              viper.GetString(common.GitLabTokenFlag),
 				EnableSelectionStats:     viper.GetBool(common.EnableSelectionStatsHeaderFlag),
 				DebugAddress:             viper.GetString("debug-address"),
+				ResponseCompression:      viper.GetString(common.ResponseCompressionFlag),
 			}
 
 			rpcConsumerSharedState := viper.GetBool(common.SharedStateFlag)
@@ -831,6 +832,7 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 	cmdRPCConsumer.MarkFlagRequired(common.GeolocationFlag)
 	cmdRPCConsumer.Flags().Bool(lavasession.AllowInsecureConnectionToProvidersFlag, false, "allow insecure provider-dialing. used for development and testing")
 	cmdRPCConsumer.Flags().Bool(lavasession.AllowGRPCCompressionFlag, false, "allow messages to be compressed when communicating between the consumer and provider")
+	cmdRPCConsumer.Flags().String(common.ResponseCompressionFlag, common.DefaultResponseCompression, "client-facing response compression: gzip (default), brotli, or off")
 	cmdRPCConsumer.Flags().Uint64Var(&lavasession.MaximumStreamsOverASingleConnection, lavasession.MaximumStreamsOverASingleConnectionFlag, lavasession.DefaultMaximumStreamsOverASingleConnection, "maximum number of parallel streams over a single provider connection")
 	cmdRPCConsumer.Flags().Bool(common.TestModeFlagName, false, "test mode causes rpcconsumer to send dummy data and print all of the metadata in it's listeners")
 	cmdRPCConsumer.Flags().String(performance.PprofAddressFlagName, "", "pprof server address, used for code profiling")

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1484,6 +1484,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 				EpochDuration:            epochDuration,
 				EnableSelectionStats:     viper.GetBool(common.EnableSelectionStatsHeaderFlag),
 				DebugAddress:             viper.GetString("debug-address"),
+				ResponseCompression:      viper.GetString(common.ResponseCompressionFlag),
 			}
 
 			rpcSmartRouterSharedState := viper.GetBool(common.SharedStateFlag)
@@ -1511,6 +1512,7 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 	cmdRPCSmartRouter.Flags().Uint(common.MaximumConcurrentProvidersFlagName, 3, "max number of concurrent providers to communicate with")
 	cmdRPCSmartRouter.MarkFlagRequired(common.GeolocationFlag)
 	cmdRPCSmartRouter.Flags().Bool(lavasession.AllowInsecureConnectionToProvidersFlag, false, "allow insecure provider-dialing. used for development and testing")
+	cmdRPCSmartRouter.Flags().String(common.ResponseCompressionFlag, common.DefaultResponseCompression, "client-facing response compression: gzip (default), brotli, or off")
 	cmdRPCSmartRouter.Flags().Bool("skip-policy-verification", false, "skip policy verification (no-op for smart router)")
 	cmdRPCSmartRouter.Flags().Bool("skip-relay-signing", false, "skip relay signing (no-op for smart router)")
 	cmdRPCSmartRouter.Flags().Uint64Var(&lavasession.MaximumStreamsOverASingleConnection, lavasession.MaximumStreamsOverASingleConnectionFlag, lavasession.DefaultMaximumStreamsOverASingleConnection, "maximum number of parallel streams over a single provider connection")


### PR DESCRIPTION
# Description

```
Compression mode comparison

  CPU cost (benchmark, Apple M4)

  ┌─────────┬─────────────┬──────────────┬────────────────┬─────────────┬────────────────┐
  │ Payload │ off (ns/op) │ gzip (ns/op) │ brotli (ns/op) │ gzip vs off │ brotli vs gzip │
  ├─────────┼─────────────┼──────────────┼────────────────┼─────────────┼────────────────┤
  │ ~256 B  │       4,175 │        8,320 │         11,491 │ 2.0× slower │    1.4× slower │
  ├─────────┼─────────────┼──────────────┼────────────────┼─────────────┼────────────────┤
  │ ~16 KB  │       6,787 │       18,842 │         59,676 │ 2.8× slower │    3.2× slower │
  ├─────────┼─────────────┼──────────────┼────────────────┼─────────────┼────────────────┤
  │ ~1 MB   │     104,720 │      465,923 │        724,516 │ 4.5× slower │    1.6× slower │
  └─────────┴─────────────┴──────────────┴────────────────┴─────────────┴────────────────┘

  Throughput (MB/s) tells the same story: off ≫ gzip ≫ brotli.

  Wire savings (synthetic; ratios inflated)

  ┌─────────┬────────────┬──────────────┐
  │ Payload │ gzip saved │ brotli saved │
  ├─────────┼────────────┼──────────────┤
  │ ~256 B  │      76.0% │        54.3% │
  ├─────────┼────────────┼──────────────┤
  │ ~16 KB  │      95.8% │        95.4% │
  ├─────────┼────────────┼──────────────┤
  │ ~1 MB   │      96.6% │        96.3% │
  └─────────┴────────────┴──────────────┘

  Gzip ties or beats brotli on savings at every size here (because brotli quality=0 is weaker at long-repeat detection than gzip BestSpeed). Real-world JSON-RPC will compress closer to 3–5× for both, but the
  relative ranking holds.

  Bottom line

  - Brotli costs dramatically more CPU for ~zero extra bandwidth savings on JSON-RPC payloads. The penalty peaks at the 16 KB bucket — exactly where typical responses land — where brotli is 3.2× slower than gzip.
  - Gzip is the right default. Matches or beats brotli on savings, 2–3× cheaper to compute, and universally supported.
  - Off is only worth it when an upstream ingress/CDN is already compressing (or for debugging). CPU savings vs gzip: another 2–4×, but you pay for it with ~95% more bytes on the wire.

```
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage