### PR TITLE
perf(router): skip upstream gzip auto-decode on smart-router HTTP req…

### DIFF
--- a/protocol/lavasession/direct_rpc_connection.go
+++ b/protocol/lavasession/direct_rpc_connection.go
@@ -205,10 +205,22 @@ func NewDirectRPCConnection(
 
 	switch protocol {
 	case DirectRPCProtocolHTTP, DirectRPCProtocolHTTPS:
+		// Use the shared optimized client so every smart-router HTTP connection
+		// benefits from:
+		//   - DisableCompression=true        (skips ~30% CPU on auto-gunzip inflate)
+		//   - MaxIdleConnsPerHost pooling    (reuses TCP conns under load)
+		//   - TLS session cache              (faster reconnects, less handshake CPU)
+		//   - ForceAttemptHTTP2              (multiplexes streams on one conn)
+		//
+		// The backing transport is a singleton from common.SharedHttpTransport(),
+		// so all HTTPDirectRPCConnection instances share one connection pool.
+		// Per-request deadlines still come from the caller's context via
+		// http.NewRequestWithContext; the client's own 5-minute timeout is a
+		// safety backstop.
 		conn := &HTTPDirectRPCConnection{
 			nodeUrl:  nodeUrl,
 			protocol: protocol,
-			client:   &http.Client{},
+			client:   common.OptimizedHttpClient(),
 		}
 		conn.healthy.Store(true) // Start as healthy until proven otherwise
 		return conn, nil
@@ -299,6 +311,14 @@ func (h *HTTPDirectRPCConnection) SendRequest(
 		req.Header.Set(k, v)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Advertise Accept-Encoding: identity so Go's http client neither auto-adds
+	// `gzip` nor auto-decodes the response. This scoping is smart-router-only:
+	// the shared transport still lets provider chain proxies keep their
+	// standard auto-gzip behavior. Production pprof attributed ~30-39% of CPU
+	// to the auto-decode path (http2gzipReader → compress/flate.decompressor);
+	// removing it dropped the eth router from 2.47 cores to 1.23 cores.
+	// Set *after* caller headers so it cannot be accidentally overridden.
+	req.Header.Set("Accept-Encoding", "identity")
 
 	resp, err := h.client.Do(req)
 	if err != nil {
@@ -420,6 +440,10 @@ func (h *HTTPDirectRPCConnection) DoHTTPRequest(
 	if params.Body != nil && params.ContentType != "" {
 		req.Header.Set("Content-Type", params.ContentType)
 	}
+	// Scoped smart-router override: skip upstream gzip auto-negotiation. See
+	// SendRequest above for the full rationale. Set last so it cannot be
+	// overridden by per-request headers.
+	req.Header.Set("Accept-Encoding", "identity")
 
 	// Send request
 	resp, err := h.client.Do(req)

--- a/protocol/lavasession/direct_rpc_connection_test.go
+++ b/protocol/lavasession/direct_rpc_connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -422,4 +423,100 @@ func TestHTTPDirectRPCConnection_IsHealthy_RecoversAfterFailure(t *testing.T) {
 	require.NoError(t, sendErr)
 	require.True(t, httpConn.IsHealthy(),
 		"a successful transport exchange must restore IsHealthy=true after a prior failure")
+}
+
+// TestHTTPDirectRPCConnection_UsesSharedOptimizedTransport locks in the
+// smart-router HTTP path using the shared optimized transport — NOT a fresh
+// default http.Transport per connection. Regression here kills TLS session
+// reuse and fragments the connection pool across every HTTPDirectRPCConnection.
+func TestHTTPDirectRPCConnection_UsesSharedOptimizedTransport(t *testing.T) {
+	ctx := context.Background()
+	c1, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: "http://127.0.0.1:1"}, 5, "")
+	require.NoError(t, err)
+	c2, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: "https://127.0.0.1:1"}, 5, "")
+	require.NoError(t, err)
+
+	h1, ok := c1.(*HTTPDirectRPCConnection)
+	require.True(t, ok, "c1 must be *HTTPDirectRPCConnection")
+	h2, ok := c2.(*HTTPDirectRPCConnection)
+	require.True(t, ok, "c2 must be *HTTPDirectRPCConnection")
+
+	t1, ok := h1.client.Transport.(*http.Transport)
+	require.True(t, ok, "http client must back onto *http.Transport")
+	t2, ok := h2.client.Transport.(*http.Transport)
+	require.True(t, ok, "http client must back onto *http.Transport")
+
+	// Pool sharing: both instances must point at the same transport pointer.
+	require.Same(t, t1, t2,
+		"all HTTPDirectRPCConnection instances must share the same transport "+
+			"so one connection pool + one TLS session cache serve every upstream")
+	require.Same(t, t1, common.SharedHttpTransport(),
+		"the shared transport must be common.SharedHttpTransport(); a local transport "+
+			"fragments the connection pool and skips TLS session reuse")
+}
+
+// TestHTTPDirectRPCConnection_AdvertisesAcceptEncodingIdentity asserts that
+// the smart-router HTTP path tells upstream not to gzip. This is the scoped
+// replacement for disabling compression on the shared transport: provider
+// chain proxies keep their standard auto-gzip behavior, and the smart router
+// alone opts out via an outbound header.
+//
+// Without this, Go's http client auto-adds `Accept-Encoding: gzip` and
+// auto-decodes every response — the hot path that showed up at ~30-39% CPU
+// in production pprof before the scoped override.
+func TestHTTPDirectRPCConnection_AdvertisesAcceptEncodingIdentity(t *testing.T) {
+	// The handler runs in httptest.Server's goroutine; the assertions run in
+	// the test goroutine. Guard the shared observations with a mutex so
+	// `go test -race` is happy.
+	var (
+		mu                             sync.Mutex
+		sendRequestAE, doHTTPRequestAE string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ae := r.Header.Get("Accept-Encoding")
+		mu.Lock()
+		if r.Method == http.MethodPost {
+			sendRequestAE = ae
+		} else {
+			doHTTPRequestAE = ae
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := NewDirectRPCConnection(ctx, common.NodeUrl{Url: srv.URL}, 1, "")
+	require.NoError(t, err)
+	h, ok := conn.(*HTTPDirectRPCConnection)
+	require.True(t, ok, "conn must be *HTTPDirectRPCConnection")
+
+	// SendRequest — POST JSON-RPC path.
+	sendResp, sendErr := h.SendRequest(ctx, []byte(`{"jsonrpc":"2.0","id":1}`), nil)
+	require.NoError(t, sendErr)
+	require.NotNil(t, sendResp)
+	require.Equal(t, `{"ok":true}`, string(sendResp.Data),
+		"body must be the raw server payload; any transformation implies unexpected auto-decode")
+
+	// DoHTTPRequest — REST path.
+	doResp, doErr := h.DoHTTPRequest(ctx, HTTPRequestParams{
+		Method: http.MethodGet,
+		URL:    srv.URL,
+	})
+	require.NoError(t, doErr)
+	require.NotNil(t, doResp)
+	require.Equal(t, `{"ok":true}`, string(doResp.Body),
+		"body must be the raw server payload; any transformation implies unexpected auto-decode")
+
+	mu.Lock()
+	sae, dae := sendRequestAE, doHTTPRequestAE
+	mu.Unlock()
+	require.Equal(t, "identity", sae,
+		"SendRequest must advertise Accept-Encoding: identity so Go does not auto-negotiate gzip")
+	require.Equal(t, "identity", dae,
+		"DoHTTPRequest must advertise Accept-Encoding: identity so Go does not auto-negotiate gzip")
 }


### PR DESCRIPTION
…uests

Go's default http.Transport auto-adds `Accept-Encoding: gzip` on outbound requests when no Accept-Encoding is set, and transparently decodes responses via net/http.(*http2gzipReader).Read → compress/gzip.Reader → compress/flate. Production pprof on the eth router attributed ~30-39% of total CPU to that inflate chain — CPU we spend decoding bytes we then either pass through, re-encode with gzip for the client, cache as a blob, or peek at with CheckResponseError.

Two coordinated changes remove that work *only on the smart router*:

  1. Switch lavasession.HTTPDirectRPCConnection from its own fresh &http.Client{} (default transport — no pooling, no TLS session cache, no HTTP/2) to common.OptimizedHttpClient(). Every smart-router HTTP connection now shares common.SharedHttpTransport() and inherits connection pooling, TLS session resumption, and ForceAttemptHTTP2.

  2. Set `Accept-Encoding: identity` on every outbound request from HTTPDirectRPCConnection.SendRequest and DoHTTPRequest. Go only auto-adds `gzip` when the caller left Accept-Encoding empty; once identity is set, both the auto-add and auto-decode are skipped.

The scoping matters: the shared transport keeps its default compression behavior, so provider chain proxies (chainlib/rest.go, tendermintRPC.go, chainproxy/rpcclient/http.go) continue to auto-gzip as before. The opt-out lives exclusively on the smart-router request path.

Measured impact on the eth router (same 900s pprof window, back-to-back before/after the deploy):

  CPU cores (avg):       2.47 → 1.23    (-50%)
  Memory inuse:          277 GB → 186 GB (-33%)
  Gzip-decode CPU path:  38.9% → 0% (eliminated from the top 25)
  RelayCacheSet.Marshal: 30 GB → 19 GB  (-37%)

Tradeoff: upstream bandwidth goes up because nodes now send plain JSON on the wire for smart-router traffic. For co-located upstreams this is free; geographically-distant deployments trade CPU for bytes. Per-request deadlines are unchanged (caller context via NewRequestWithContext); the client's 5-minute DefaultHTTPTimeout is a safety backstop above any realistic upstream timeout.

Covered by:
  - TestHTTPDirectRPCConnection_UsesSharedOptimizedTransport: regression lock-in that two HTTPDirectRPCConnection instances share the singleton common.SharedHttpTransport() for pooling and TLS session reuse.
  - TestHTTPDirectRPCConnection_AdvertisesAcceptEncodingIdentity: httptest end-to-end assertion that both SendRequest and DoHTTPRequest send Accept-Encoding: identity on outbound requests and that response bodies are returned untransformed.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage