### PR TITLE
refactor(errors): remove SubCategoryUserError — charge normal CU for …

### DIFF
--- a/error-registry-design.md
+++ b/error-registry-design.md
@@ -33,7 +33,7 @@ Errors raised from within the Lava protocol itself — not from nodes or chains.
 | 1014 | `PROTOCOL_PROVIDER_DATA_LOSS` | Provider data loss (gRPC DATA_LOSS) | Yes |
 | 1020 | `PROTOCOL_RATE_LIMITED` | Lava-side rate limit exceeded (SubCategoryRateLimit) | No |
 | 1021 | `PROTOCOL_MAX_CU_EXCEEDED` | Maximum compute units exceeded for session | No |
-| 1022 | `PROTOCOL_BATCH_SIZE_EXCEEDED` | Batch request size exceeded limit (SubCategoryUserError) | No |
+| 1022 | `PROTOCOL_BATCH_SIZE_EXCEEDED` | Batch request size exceeded limit | No |
 | 1030 | `PROTOCOL_SESSION_NOT_FOUND` | Session does not exist | No |
 | 1031 | `PROTOCOL_EPOCH_MISMATCH` | Epoch mismatch or too old | No |
 | 1032 | `PROTOCOL_CONSUMER_BLOCKED` | Consumer is blocklisted | No |
@@ -162,9 +162,7 @@ Uses a **tiered classification system** (see Section 3 for details):
 ### Layer D: User Errors (`USER_*` — range 4000-4999) — Category: External
 Errors caused by malformed or invalid client requests — classified by nature of error, regardless of where caught (pre-forwarding by Lava or returned by node).
 
-| Code | Name | Description | Retryable | Standard Code |
-|------|------|-------------|-----------|---------------|
-All Layer D codes carry `SubCategoryUserError` — the consumer hot path short-circuits retries and charges zero CU for invalid client input.
+Layer D codes are non-retryable but charge **normal CU** — the provider does real work on every call because the response is not cached (the next request from the same client may carry valid input). Only `SubCategoryUnsupportedMethod` errors get the zero-CU carve-out, because those responses *are* cached and the provider won't be hit again.
 
 | Code | Name | Description | Retryable | Standard Code |
 |------|------|-------------|-----------|---------------|
@@ -412,21 +410,12 @@ type ErrorSubCategory int
 const (
     SubCategoryNone              ErrorSubCategory = iota
     SubCategoryUnsupportedMethod                         // zero retries, zero CU, cached response, no provider scoring
-    SubCategoryUserError                                 // invalid client input: zero retries, zero CU, no provider scoring (not cached)
     SubCategoryRateLimit                                 // endpoint is healthy but busy; apply backoff, do not mark unhealthy
 )
 
 func (sc ErrorSubCategory) IsUnsupportedMethod() bool { return sc == SubCategoryUnsupportedMethod }
-func (sc ErrorSubCategory) IsUserError() bool         { return sc == SubCategoryUserError }
 func (sc ErrorSubCategory) IsRateLimit() bool         { return sc == SubCategoryRateLimit }
 
-// IsNonRetryableUserFacing combines the subcategories whose contract is
-// "don't retry, don't charge CU". Consumer/retry sites call this instead of
-// checking individual subcategories so adding a new non-retryable-user-facing
-// subcategory only needs to update this one predicate.
-func (sc ErrorSubCategory) IsNonRetryableUserFacing() bool {
-    return sc.IsUnsupportedMethod() || sc.IsUserError()
-}
 
 // LavaError is the central error definition
 type LavaError struct {
@@ -456,23 +445,21 @@ func GetChainFamilyOrDefault(chainID string) ChainFamily // returns ChainFamilyU
 func ClassifyError(connErr *LavaError, family ChainFamily, transport TransportType, code int, msg string) *LavaError
 func ClassifyMessage(code int, msg string) *LavaError // transport + chain unknown
 
-// Retry-policy predicates. IsUnsupportedMethodError and IsUserInputError key off
-// SubCategory (zero-CU carve-out + caching). IsNonRetryableNodeError keys off
+// Retry-policy predicates. IsUnsupportedMethodError keys off SubCategory
+// (zero-CU carve-out + caching). IsNonRetryableNodeError keys off
 // LavaError.Retryable directly so every terminal classification short-circuits
-// retries, not only the user-facing subcategories.
+// retries, not only unsupported methods.
 func IsUnsupportedMethodError(chainID string, statusCode int, message string) bool
-func IsUserInputError(chainID string, statusCode int, message string) bool
 func IsNonRetryableNodeError(chainID string, statusCode int, message string) bool
 func IsNonRetryableNodeErrorWithContext(family ChainFamily, transport TransportType, statusCode int, message string) bool
 
-// NodeErrorClassification aggregates the three retry-related flags derived from a
+// NodeErrorClassification aggregates the retry-related flags derived from a
 // single ClassifyError lookup. IsNonRetryable is the authoritative retry signal;
-// IsUnsupportedMethod / IsUserError are strict subsets that also drive the
-// zero-CU carve-out and caching policy.
+// IsUnsupportedMethod is a strict subset that also drives the zero-CU carve-out
+// and caching policy.
 type NodeErrorClassification struct {
     IsNonRetryable      bool
     IsUnsupportedMethod bool
-    IsUserError         bool
 }
 
 // ClassifyNodeErrorForRetry is the preferred entry point on hot error paths —
@@ -562,7 +549,7 @@ Log output automatically includes:
 - [x] Populate `RelayError.LavaError` in the smart-router path (`direct_rpc_relay.go` → pass classification from `ClassifyDirectRPCError` into the relay response flow)
 - [x] Update `GetBestErrorMessageForUser` to prefer external errors (`CHAIN_*`, `NODE_*`) over internal (`PROTOCOL_*`) when selecting the best error for the user
 - [x] Update `protocol/relaycore/relay_processor.go` to propagate codes
-- [x] Populate `RelayResult.IsNonRetryable` from `ClassifyError` on both consumer and smart-router paths so `relay_processor.HasNonRetryableUserFacingErrors` honors `LavaError.Retryable=false` for every terminal classification — not only `SubCategoryUnsupportedMethod` / `SubCategoryUserError`. Prior to this, node errors like `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, and `CHAIN_DOUBLE_SPEND` were retried across providers despite `Retryable=false` in the registry.
+- [x] Populate `RelayResult.IsNonRetryable` from `ClassifyError` on both consumer and smart-router paths so `relay_processor.HasNonRetryableUserFacingErrors` honors `LavaError.Retryable=false` for every terminal classification — not only `SubCategoryUnsupportedMethod`. Prior to this, node errors like `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, and `CHAIN_DOUBLE_SPEND` were retried across providers despite `Retryable=false` in the registry.
 - [x] Update consumer server (`rpcconsumer/rpcconsumer_server.go`) to log with codes
 - [x] Update provider server (`rpcprovider/rpcprovider_server.go`) to log with codes
 
@@ -607,7 +594,7 @@ _Blocked on protocol upgrade: sdkerrors carry ABCI codes used in the gRPC wire f
 
 9. **Transparent hop: original errors pass through unchanged.** The router/consumer is a transparent hop — the user always receives the original error from the node, unmodified. `LavaError` classification is metadata for internal use only (logging, metrics, endpoint health). Unknown/unmatched errors default to `CategoryExternal` because they are node pass-throughs. _(Clarification added in Phase 7: `handleAndClassify` wraps classified errors in `LavaWrappedError` on the **Go error return path** — this is internal plumbing for retry/health decisions and never reaches the user. The actual node response body travels separately and is always returned unmodified to the user. The "transparent hop" principle applies to the response body, not the internal Go error return.)_
 
-10. **Retryable is the primary retry signal, not SubCategory.** The consumer and smart-router retry state machines short-circuit on `LavaError.Retryable=false` via `RelayResult.IsNonRetryable`, populated at classification time on both paths (consumer: `rpcconsumer_server.go`; smart-router: `direct_rpc_relay.go` / `rpcsmartrouter_server.go`). This covers every terminal classification — `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, `CHAIN_DOUBLE_SPEND`, `CHAIN_INVALID_SIGNATURE`, all of 3000-range — not only user-facing subcategories. SubCategory continues to govern adjacent policy: `SubCategoryUnsupportedMethod` and `SubCategoryUserError` trigger the zero-CU carve-out and caching, and `SubCategoryRateLimit` drives backoff without marking the endpoint unhealthy. `relay_processor.HasNonRetryableUserFacingErrors` keys off the `IsNonRetryable` flag rather than re-classifying, so adding a new non-retryable error type requires no state-machine changes. _(Added after Phase 7: the earlier implementation gated retries on `SubCategory.IsNonRetryableUserFacing()` alone and silently retried every `Retryable=false` node error whose SubCategory was neither `UnsupportedMethod` nor `UserError`.)_
+10. **Retryable is the primary retry signal, not SubCategory.** The consumer and smart-router retry state machines short-circuit on `LavaError.Retryable=false` via `RelayResult.IsNonRetryable`, populated at classification time on both paths (consumer: `rpcconsumer_server.go`; smart-router: `direct_rpc_relay.go` / `rpcsmartrouter_server.go`). This covers every terminal classification — `CHAIN_EXECUTION_REVERTED`, `CHAIN_OUT_OF_GAS`, `CHAIN_DOUBLE_SPEND`, `CHAIN_INVALID_SIGNATURE`, all of 3000-range — not only unsupported methods. SubCategory continues to govern adjacent policy: `SubCategoryUnsupportedMethod` triggers the zero-CU carve-out and caching, and `SubCategoryRateLimit` drives backoff without marking the endpoint unhealthy. Layer D user-input errors are non-retryable but charge normal CU — the provider does real work because responses are not cached. `relay_processor.HasNonRetryableUserFacingErrors` keys off the `IsNonRetryable` flag rather than re-classifying, so adding a new non-retryable error type requires no state-machine changes.
 
 ## 8. Chains Analyzed
 

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -148,17 +148,6 @@ func IsUnsupportedMethodErrorType(err error) bool {
 	return false
 }
 
-// IsNonRetryableUserFacingErrorType checks if an error wraps a LavaError whose
-// subcategory is any "don't retry, don't charge CU" kind — currently
-// SubCategoryUnsupportedMethod or SubCategoryUserError. The retry state
-// machine uses this to short-circuit both classes uniformly.
-func IsNonRetryableUserFacingErrorType(err error) bool {
-	if le := unwrapLavaError(err); le != nil {
-		return le.SubCategory.IsNonRetryableUserFacing()
-	}
-	return false
-}
-
 // IsSolanaNonRetryableError checks if an error indicates a Solana error that should not be retried.
 // Covers -32009 (missing in long-term storage) and -32602 (invalid params).
 // Note: -32007 (ledger jump) IS retryable as another provider may have the data.

--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -382,20 +382,14 @@ type RelayResult struct {
 	ProviderTrailer     metadata.MD // the provider trailer attached to the request. used to transfer useful information (which is not signed so shouldn't be trusted completely).
 	IsNodeError         bool
 	ResponseHash        [32]byte // cached SHA256 hash of Reply.Data for cross-validation comparison, zero-value if not computed
-	IsUnsupportedMethod bool     // Indicates this node error is an unsupported method
-	// IsUserError indicates this node error is caused by invalid client input
-	// (Layer D USER_* codes). Behavioral contract mirrors IsUnsupportedMethod:
-	// zero retries, zero CU, no provider scoring. User errors are NOT cached
-	// because the next request from the same client may carry valid input.
-	IsUserError bool
+	IsUnsupportedMethod bool     // Indicates this node error is an unsupported method (zero CU, cached)
 	// IsNonRetryable is the umbrella flag the retry state machine consults:
 	// it's true whenever the matched registry LavaError has Retryable=false,
-	// which covers unsupported method, user input error, execution reverted,
-	// out of gas, invalid signature, double spend, etc. Retrying on another
-	// provider would just reproduce the same deterministic failure.
-	// IsUnsupportedMethod and IsUserError are independent subset flags derived
-	// from the SubCategory and used only to gate CU-charging and caching
-	// policy — they do NOT narrow the retry decision below IsNonRetryable.
+	// which covers unsupported method, execution reverted, out of gas,
+	// invalid signature, double spend, etc. Retrying on another provider
+	// would just reproduce the same deterministic failure.
+	// IsUnsupportedMethod is an independent subset flag derived from the
+	// SubCategory and used to gate the zero-CU carve-out and caching policy.
 	IsNonRetryable bool
 }
 

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -155,9 +155,9 @@ var genericErrorMappings = map[TransportType][]errorMapping{
 		// --- User input validation (Layer D) ---
 		// These must be ordered BEFORE the broader chain-transaction matchers so
 		// "invalid address" / "invalid block number" don't leak into -32000 catch-all.
-		// Matchers are deliberately tight: NodeMethodNotFound carries
-		// SubCategoryUserError (zero retries, zero CU), so false positives would
-		// silently swallow real chain errors.
+		// Matchers are deliberately tight: false positives would silently
+		// classify real chain errors as user input errors (Retryable=false),
+		// stopping retries that could have succeeded on another provider.
 		//
 		// Block format: "hex string without 0x prefix" is Geth's exact phrase;
 		// "invalid block number" and "invalid block hash" are generic.
@@ -398,25 +398,8 @@ func IsUnsupportedMethodError(chainID string, statusCode int, message string) bo
 	return classifySubCategoryAcrossTransports(chainID, statusCode, message).IsUnsupportedMethod()
 }
 
-// IsUserInputError returns true when the error identified by statusCode and
-// message is classified as invalid client input (Layer D USER_* codes or
-// batch-size-exceeded). The contract mirrors IsUnsupportedMethodError: the
-// chainID enables chain-specific Tier-2 lookups so chain-native messages
-// aren't misclassified as user input. Pass "" when the chain is unknown.
-//
-// The consumer hot path uses this symmetric to IsUnsupportedMethodError to
-// short-circuit retries and charge zero CU for invalid client input.
-func IsUserInputError(chainID string, statusCode int, message string) bool {
-	return classifySubCategoryAcrossTransports(chainID, statusCode, message).IsUserError()
-}
-
 // IsNonRetryableNodeError returns true when the classified LavaError for the
-// given node-error response has Retryable=false (e.g. CHAIN_EXECUTION_REVERTED,
-// CHAIN_OUT_OF_GAS, CHAIN_DOUBLE_SPEND, CHAIN_INVALID_SIGNATURE, and every
-// other terminal error in the 3000-range). Unlike IsUserInputError /
-// IsUnsupportedMethodError this does NOT key off SubCategory — it honors the
-// Retryable flag directly so every non-retryable LavaError short-circuits
-// retries, not only the zero-CU user-facing subset.
+// given node-error response has Retryable=false.
 func IsNonRetryableNodeError(chainID string, statusCode int, message string) bool {
 	family := ChainFamilyUnknown
 	if chainID != "" {
@@ -433,10 +416,7 @@ func IsNonRetryableNodeError(chainID string, statusCode int, message string) boo
 }
 
 // IsNonRetryableNodeErrorWithContext is the variant of IsNonRetryableNodeError
-// for call sites that already know the chain family and transport exactly (e.g.
-// the smart router's direct-RPC senders). It avoids the JSON-RPC→REST→gRPC
-// scan of classifySubCategoryAcrossTransports and the chainID-to-family lookup.
-// Pass ChainFamilyUnknown when the family is genuinely unknown.
+// for call sites that already know the chain family and transport exactly.
 func IsNonRetryableNodeErrorWithContext(family ChainFamily, transport TransportType, statusCode int, message string) bool {
 	c := ClassifyError(nil, family, transport, statusCode, message)
 	if c == nil || c == LavaErrorUnknown {
@@ -445,32 +425,19 @@ func IsNonRetryableNodeErrorWithContext(family ChainFamily, transport TransportT
 	return !c.Retryable
 }
 
-// NodeErrorClassification aggregates the three policy flags derived from a
+// NodeErrorClassification aggregates the policy flags derived from a
 // single registry lookup on a node-error response:
 //   - IsNonRetryable: registry entry is Retryable=false (hard stop for retries).
-//   - IsUnsupportedMethod / IsUserError: SubCategory-based predicates used by
-//     the consumer to apply the zero-CU carve-out and caching policy. Both are
-//     strict subsets of IsNonRetryable.
+//   - IsUnsupportedMethod: SubCategory-based predicate used by the consumer
+//     to apply the zero-CU carve-out and response caching.
 type NodeErrorClassification struct {
 	IsNonRetryable      bool
 	IsUnsupportedMethod bool
-	IsUserError         bool
 }
 
 // ClassifyNodeErrorForRetry runs ClassifyError exactly once and derives the
-// three flags consumed by the consumer's retry decision and CU/caching
-// carve-outs. Prefer this over sequential IsNonRetryableNodeError /
-// IsUnsupportedMethodError / IsUserInputError calls on hot error paths — each
-// of those internally scans all three transports, which is wasteful when the
-// caller already knows family and transport.
-//
-// errorCode semantics depend on transport:
-//   - TransportJsonRPC: pass the JSON-RPC error.code from the response body
-//     (e.g. -32700, -32602). HTTP status is usually 200 for JSON-RPC node
-//     errors and would miss the code-based registry mappings.
-//   - TransportREST / TransportGRPC: the HTTP / gRPC status code.
-//
-// Unknown classifications fail open (all flags false → retryable).
+// policy flags consumed by the consumer's retry decision and CU/caching
+// carve-outs.
 func ClassifyNodeErrorForRetry(family ChainFamily, transport TransportType, errorCode int, message string) NodeErrorClassification {
 	c := ClassifyError(nil, family, transport, errorCode, message)
 	if c == nil || c == LavaErrorUnknown {
@@ -479,14 +446,11 @@ func ClassifyNodeErrorForRetry(family ChainFamily, transport TransportType, erro
 	return NodeErrorClassification{
 		IsNonRetryable:      !c.Retryable,
 		IsUnsupportedMethod: c.SubCategory.IsUnsupportedMethod(),
-		IsUserError:         c.SubCategory.IsUserError(),
 	}
 }
 
 // ApiInterfaceToTransport maps a spec API interface string (jsonrpc,
 // tendermintrpc, rest, grpc) to the TransportType used by the error registry.
-// Unknown or empty inputs fall through to TransportJsonRPC, which is the most
-// common transport and matches the broadest set of registry matchers.
 func ApiInterfaceToTransport(apiInterface string) TransportType {
 	switch apiInterface {
 	case "rest":

--- a/protocol/common/error_codes.go
+++ b/protocol/common/error_codes.go
@@ -82,7 +82,6 @@ var (
 	})
 	LavaErrorBatchSizeExceeded = registerError(&LavaError{
 		Code: 1022, Name: "PROTOCOL_BATCH_SIZE_EXCEEDED", Category: CategoryInternal,
-		SubCategory: SubCategoryUserError, // caller sent too many requests — not retryable, no CU
 		Description: "Batch request size exceeded limit", Retryable: false,
 	})
 	LavaErrorCUMismatch = registerError(&LavaError{
@@ -564,43 +563,37 @@ var (
 // Errors caused by malformed or invalid client requests.
 // ---------------------------------------------------------------------------
 
-// All Layer D codes carry SubCategoryUserError so the consumer hot path can
-// short-circuit retries and charge zero CU uniformly for invalid client input.
-// The subcategory tagging is enforced by a test in error_registry_test.go.
+// Layer D errors are classified for metrics/observability but do NOT receive
+// special CU treatment — providers still charge normal CU for processing
+// invalid client requests (since responses are not cached and the provider
+// does real work on every call).
 var (
 	LavaErrorUserParseError = registerError(&LavaError{
 		Code: 4001, Name: "USER_PARSE_ERROR", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Invalid JSON in request", Retryable: false,
 	})
 	LavaErrorUserInvalidRequest = registerError(&LavaError{
 		Code: 4002, Name: "USER_INVALID_REQUEST", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Request is not a valid JSON-RPC/REST/gRPC object", Retryable: false,
 	})
 	LavaErrorUserInvalidParams = registerError(&LavaError{
 		Code: 4003, Name: "USER_INVALID_PARAMS", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Invalid method parameters", Retryable: false,
 	})
 	LavaErrorUserInvalidBlockFormat = registerError(&LavaError{
 		Code: 4004, Name: "USER_INVALID_BLOCK_FORMAT", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Invalid block number format (e.g., non-hex)", Retryable: false,
 	})
 	LavaErrorUserInvalidAddress = registerError(&LavaError{
 		Code: 4005, Name: "USER_INVALID_ADDRESS", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Invalid address format", Retryable: false,
 	})
 	LavaErrorUserRequestTooLarge = registerError(&LavaError{
 		Code: 4006, Name: "USER_REQUEST_TOO_LARGE", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Request body exceeds size limit", Retryable: false,
 	})
 	LavaErrorUserInvalidHex = registerError(&LavaError{
 		Code: 4007, Name: "USER_INVALID_HEX", Category: CategoryExternal,
-		SubCategory: SubCategoryUserError,
 		Description: "Invalid hex encoding", Retryable: false,
 	})
 )

--- a/protocol/common/error_registry.go
+++ b/protocol/common/error_registry.go
@@ -37,7 +37,6 @@ type ErrorSubCategory int
 const (
 	SubCategoryNone              ErrorSubCategory = iota
 	SubCategoryUnsupportedMethod                  // zero retries, zero CU, cached response, no provider scoring
-	SubCategoryUserError                          // invalid client input: zero retries, zero CU, no provider scoring (not cached — next request may have valid input)
 	SubCategoryRateLimit                          // rate-limit signal: endpoint is healthy but busy, apply backoff, do not mark unhealthy
 )
 
@@ -45,8 +44,6 @@ func (sc ErrorSubCategory) String() string {
 	switch sc {
 	case SubCategoryUnsupportedMethod:
 		return "unsupported_method"
-	case SubCategoryUserError:
-		return "user_error"
 	case SubCategoryRateLimit:
 		return "rate_limit"
 	default:
@@ -58,26 +55,11 @@ func (sc ErrorSubCategory) IsUnsupportedMethod() bool {
 	return sc == SubCategoryUnsupportedMethod
 }
 
-// IsUserError reports whether this subcategory represents invalid client
-// input. Consumers should short-circuit retries and charge zero CU for
-// these errors, symmetric to IsUnsupportedMethod.
-func (sc ErrorSubCategory) IsUserError() bool {
-	return sc == SubCategoryUserError
-}
-
 // IsRateLimit reports whether this subcategory represents a "slow down"
 // signal from the endpoint. Health-tracking callers should apply backoff
 // but NOT mark the endpoint unhealthy — it's working, just busy.
 func (sc ErrorSubCategory) IsRateLimit() bool {
 	return sc == SubCategoryRateLimit
-}
-
-// IsNonRetryableUserFacing returns true for any subcategory whose behavioral
-// contract is "don't retry, don't charge CU". This is the combined check the
-// consumer hot path uses so a new subcategory with the same contract only
-// needs to be added here, not at every call site.
-func (sc ErrorSubCategory) IsNonRetryableUserFacing() bool {
-	return sc.IsUnsupportedMethod() || sc.IsUserError()
 }
 
 // LavaError is the central error definition — a classification struct, not a Go error.

--- a/protocol/common/error_registry_test.go
+++ b/protocol/common/error_registry_test.go
@@ -233,7 +233,6 @@ func TestErrorCategory_String(t *testing.T) {
 func TestErrorSubCategory_String(t *testing.T) {
 	assert.Equal(t, "none", SubCategoryNone.String())
 	assert.Equal(t, "unsupported_method", SubCategoryUnsupportedMethod.String())
-	assert.Equal(t, "user_error", SubCategoryUserError.String())
 }
 
 func TestErrorSubCategory_UnsupportedMethodTagging(t *testing.T) {
@@ -255,56 +254,22 @@ func TestErrorSubCategory_UnsupportedMethodTagging(t *testing.T) {
 	}
 }
 
-// TestErrorSubCategory_UserErrorTagging enforces the invariant that every Layer D code
-// (4000-4999) plus the protocol-layer batch-size-exceeded error carries
-// SubCategoryUserError. Adding a new Layer D code without tagging it would
-// regress the consumer's "don't retry, don't charge CU" behavior for that
-// class of error — this test fails fast if that happens.
-func TestErrorSubCategory_UserErrorTagging(t *testing.T) {
-	// Inclusion: every registered Layer D code must be tagged. Iterate the
-	// registry so new Layer D entries are discovered automatically.
+// TestLayerDErrors_NoSpecialSubCategory ensures Layer D codes (4000-4999) do NOT
+// carry SubCategoryUnsupportedMethod — they are user-input errors that charge
+// normal CU (the provider does real work on every call because the response is
+// not cached).
+func TestLayerDErrors_NoSpecialSubCategory(t *testing.T) {
 	layerDFound := 0
 	for code, le := range errorRegistry {
 		if code >= 4000 && code < 5000 {
 			layerDFound++
-			assert.True(t, le.SubCategory.IsUserError(),
-				"Layer D code %d (%s) must be SubCategoryUserError; tag it in error_codes.go", code, le.Name)
+			assert.Equal(t, SubCategoryNone, le.SubCategory,
+				"Layer D code %d (%s) must NOT carry a special SubCategory — user errors charge normal CU", code, le.Name)
+			assert.False(t, le.Retryable,
+				"Layer D code %d (%s) must be non-retryable", code, le.Name)
 		}
 	}
 	require.Positive(t, layerDFound, "Layer D range should contain at least one registered error")
-
-	// Inclusion: the protocol-layer batch error is a client-side "too many
-	// requests in one batch" failure — the reviewer flagged it specifically.
-	assert.True(t, LavaErrorBatchSizeExceeded.SubCategory.IsUserError(),
-		"PROTOCOL_BATCH_SIZE_EXCEEDED must be tagged as user error")
-
-	// Exclusion: LavaErrorInvalidRelayRequest is a protocol-envelope signature/
-	// hash mismatch — it's consumer-caused but NOT user input in the Layer D
-	// sense. Keep it un-tagged per the reviewer's explicit recommendation.
-	assert.False(t, LavaErrorInvalidRelayRequest.SubCategory.IsUserError(),
-		"PROTOCOL_INVALID_RELAY_REQUEST is an envelope integrity failure, not user input")
-
-	// Exclusion spot-checks on unrelated categories.
-	exclusions := []*LavaError{
-		LavaErrorConnectionTimeout,  // internal, transport
-		LavaErrorNodeInternalError,  // node error
-		LavaErrorChainNonceTooLow,   // chain error
-		LavaErrorNodeMethodNotFound, // unsupported method — mutually exclusive subcategory
-		LavaErrorNodeMethodNotSupported,
-	}
-	for _, le := range exclusions {
-		assert.False(t, le.SubCategory.IsUserError(),
-			"%s must NOT be tagged SubCategoryUserError", le.Name)
-	}
-}
-
-// TestErrorSubCategory_IsNonRetryableUserFacing verifies the combined predicate covers both
-// subcategories and nothing else.
-func TestErrorSubCategory_IsNonRetryableUserFacing(t *testing.T) {
-	assert.True(t, SubCategoryUnsupportedMethod.IsNonRetryableUserFacing())
-	assert.True(t, SubCategoryUserError.IsNonRetryableUserFacing())
-	assert.False(t, SubCategoryNone.IsNonRetryableUserFacing())
-	assert.False(t, SubCategoryRateLimit.IsNonRetryableUserFacing(), "rate-limit is retryable with backoff, not zero-CU terminal")
 }
 
 // TestErrorSubCategory_RateLimitTagging enforces that every rate-limit code carries the
@@ -539,26 +504,28 @@ func TestClassifyError_LayerDCodesHaveMatchers(t *testing.T) {
 	}
 }
 
-// TestIsUserInputError exercises the classify-then-check helper end-to-end
-// so the consumer hot path sees the same answer the registry intends.
-func TestIsUserInputError_KnownCases(t *testing.T) {
-	// JSON-RPC parse error code → USER_PARSE_ERROR → tagged as user error
-	assert.True(t, IsUserInputError("ETH1", -32700, "parse error"))
-	// JSON-RPC invalid params → USER_INVALID_PARAMS → tagged
-	assert.True(t, IsUserInputError("ETH1", -32602, "invalid params"))
-	// Unsupported method → tagged as unsupported, NOT user error
-	assert.False(t, IsUserInputError("ETH1", -32601, "method not found"))
-	// Rate limit → retryable external, not user error
-	assert.False(t, IsUserInputError("ETH1", 0, "rate limit exceeded"))
-	// Connection timeout → internal, not user error
-	assert.False(t, IsUserInputError("ETH1", 0, "context deadline exceeded"))
+// TestLayerDErrors_AreNonRetryable verifies that Layer D user-input errors
+// are classified as non-retryable but do NOT carry SubCategoryUnsupportedMethod
+// (which would zero out CU — providers should be paid for processing invalid input).
+func TestLayerDErrors_AreNonRetryable(t *testing.T) {
+	// JSON-RPC parse error code → USER_PARSE_ERROR → non-retryable
+	le := ClassifyError(nil, ChainFamilyEVM, TransportJsonRPC, -32700, "parse error")
+	assert.Equal(t, LavaErrorUserParseError, le)
+	assert.False(t, le.Retryable)
+	assert.False(t, le.SubCategory.IsUnsupportedMethod())
+
+	// JSON-RPC invalid params → USER_INVALID_PARAMS → non-retryable
+	le = ClassifyError(nil, ChainFamilyEVM, TransportJsonRPC, -32602, "invalid params")
+	assert.Equal(t, LavaErrorUserInvalidParams, le)
+	assert.False(t, le.Retryable)
+	assert.False(t, le.SubCategory.IsUnsupportedMethod())
 }
 
 // TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup verifies the
 // single-pass helper the consumer hot path uses. Each row asserts all three
 // flags at once because the consumer relies on their mutual consistency —
-// IsUnsupportedMethod and IsUserError must always imply IsNonRetryable, and
-// unknown messages must fail open (all flags false → retryable).
+// IsUnsupportedMethod must always imply IsNonRetryable, and unknown messages
+// must fail open (all flags false → retryable).
 func TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup(t *testing.T) {
 	cases := []struct {
 		name             string
@@ -568,10 +535,9 @@ func TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup(t *testing.T)
 		message          string
 		wantNonRetryable bool
 		wantUnsupported  bool
-		wantUserErr      bool
 	}{
 		{
-			name:             "EVM execution reverted → terminal, neither unsupported nor user",
+			name:             "EVM execution reverted → terminal, not unsupported",
 			family:           ChainFamilyEVM,
 			transport:        TransportJsonRPC,
 			errorCode:        3,
@@ -588,13 +554,12 @@ func TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup(t *testing.T)
 			wantUnsupported:  true,
 		},
 		{
-			name:             "JSON-RPC body code -32700 parse error → terminal + user",
+			name:             "JSON-RPC body code -32700 parse error → terminal, not unsupported",
 			family:           ChainFamilyEVM,
 			transport:        TransportJsonRPC,
 			errorCode:        -32700,
 			message:          "parse error",
 			wantNonRetryable: true,
-			wantUserErr:      true,
 		},
 		{
 			name:             "generic transient → retryable (all flags false)",
@@ -619,11 +584,8 @@ func TestClassifyNodeErrorForRetry_DerivesAllFlagsFromSingleLookup(t *testing.T)
 			got := ClassifyNodeErrorForRetry(tc.family, tc.transport, tc.errorCode, tc.message)
 			assert.Equal(t, tc.wantNonRetryable, got.IsNonRetryable, "IsNonRetryable")
 			assert.Equal(t, tc.wantUnsupported, got.IsUnsupportedMethod, "IsUnsupportedMethod")
-			assert.Equal(t, tc.wantUserErr, got.IsUserError, "IsUserError")
-			// Invariant: the two subset flags must never be set without
-			// IsNonRetryable also being set.
-			if got.IsUnsupportedMethod || got.IsUserError {
-				assert.True(t, got.IsNonRetryable, "subset flags imply IsNonRetryable")
+			if got.IsUnsupportedMethod {
+				assert.True(t, got.IsNonRetryable, "IsUnsupportedMethod implies IsNonRetryable")
 			}
 		})
 	}

--- a/protocol/relaycore/relay_processor.go
+++ b/protocol/relaycore/relay_processor.go
@@ -289,8 +289,8 @@ func (rp *RelayProcessor) HasUnsupportedMethodErrors() bool {
 //
 //   - Node errors: IsNonRetryable is set by the classifier when the registry
 //     marks the matched LavaError as Retryable=false. This covers unsupported
-//     method, user input error, execution reverted, out of gas, invalid
-//     signature, double spend, and every other terminal entry in the registry.
+//     method, execution reverted, out of gas, invalid signature, double spend,
+//     and every other terminal entry in the registry.
 //   - Protocol errors: ShouldRetryError consults the same registry for the
 //     wrapped error. Epoch mismatches are still explicitly allowed to retry.
 //
@@ -312,6 +312,9 @@ func (rp *RelayProcessor) HasNonRetryableUserFacingErrors() bool {
 	}
 
 	for _, protocolError := range protocolErrors {
+		if chainlib.IsUnsupportedMethodError(protocolError.GetError()) {
+			return true
+		}
 		if lavasession.EpochMismatchError.Is(protocolError.GetError()) {
 			continue
 		}

--- a/protocol/rpcconsumer/consumer_relay_state_machine.go
+++ b/protocol/rpcconsumer/consumer_relay_state_machine.go
@@ -179,10 +179,8 @@ func (crsm *ConsumerRelayStateMachine) shouldRetry(numberOfNodeErrors uint64) bo
 	return shouldRetry
 }
 
-// hasUnsupportedMethodErrorsInStateMachine checks if we have any non-retryable
-// user-facing errors (unsupported method or user input error) at state machine
-// level. The name retains "UnsupportedMethod" for historical continuity but
-// the check covers both SubCategoryUnsupportedMethod and SubCategoryUserError.
+// hasUnsupportedMethodErrorsInStateMachine checks if we have any unsupported
+// method errors at state machine level — these are the only zero-CU errors.
 func (crsm *ConsumerRelayStateMachine) hasUnsupportedMethodErrorsInStateMachine() bool {
 	if crsm.resultsChecker == nil {
 		return false

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -1279,25 +1279,21 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 			isNodeError, errorMessage := protocolMessage.CheckResponseError(localRelayResult.Reply.Data, localRelayResult.StatusCode)
 			localRelayResult.IsNodeError = isNodeError
 
-			// Classify node errors into two behavioral buckets:
-			//   - Unsupported method → zero CU, no retry, CACHE the response
-			//   - User input error   → zero CU, no retry, do NOT cache
-			// Both carry the "don't retry, don't charge" contract via the
-			// IsNonRetryableUserFacing subcategory predicate; caching diverges.
+			// Classify node errors for retry and CU decisions. One registry
+			// lookup produces both flags: IsNonRetryable terminates the retry
+			// loop for every Retryable=false entry (execution reverted, out of
+			// gas, invalid signature, double spend, unsupported method, ...),
+			// IsUnsupportedMethod gates the zero-CU + caching carve-out.
 			if isNodeError {
-				// Classify once per node error. The three flags (IsNonRetryable,
-				// IsUnsupportedMethod, IsUserError) all come from the same
-				// registry lookup; doing three separate classify passes here
-				// would triple the work on a hot error path.
 				family := common.ChainFamilyUnknown
 				if f, ok := common.GetChainFamily(rpccs.listenEndpoint.ChainID); ok {
 					family = f
 				}
 				transport := common.ApiInterfaceToTransport(rpccs.listenEndpoint.ApiInterface)
-				// JSON-RPC node errors return HTTP 200 with the real error code
-				// embedded in the response body (error.code). The registry's
-				// code-based JSON-RPC matchers (e.g. -32700, -32602) only hit
-				// if we feed them that body code rather than the HTTP status.
+				// JSON-RPC node errors typically come back as HTTP 200 with the
+				// real code in error.code (e.g. -32601, -32004). The registry's
+				// code-based JSON-RPC matchers only fire if we feed them that
+				// body code rather than the HTTP status.
 				errorCode := localRelayResult.StatusCode
 				if transport == common.TransportJsonRPC && localRelayResult.Reply != nil {
 					if jsonrpcCode := common.ExtractJSONRPCErrorCode(localRelayResult.Reply.Data); jsonrpcCode != 0 {
@@ -1307,17 +1303,10 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 				classification := common.ClassifyNodeErrorForRetry(family, transport, errorCode, errorMessage)
 				localRelayResult.IsNonRetryable = classification.IsNonRetryable
 				localRelayResult.IsUnsupportedMethod = classification.IsUnsupportedMethod
-				localRelayResult.IsUserError = classification.IsUserError
 
 				switch {
 				case classification.IsUnsupportedMethod:
 					utils.LavaFormatInfo("unsupported method detected in relay result",
-						utils.LogAttr("GUID", ctx),
-						utils.LogAttr("method", protocolMessage.GetApi().Name),
-						utils.LogAttr("error", errorMessage),
-					)
-				case classification.IsUserError:
-					utils.LavaFormatInfo("user input error detected in relay result",
 						utils.LogAttr("GUID", ctx),
 						utils.LogAttr("method", protocolMessage.GetApi().Name),
 						utils.LogAttr("error", errorMessage),
@@ -1331,19 +1320,17 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 				}
 			}
 
-			// Zero-CU carve-out: both unsupported methods and user input errors
-			// are "not the endpoint's fault" and don't consume the provider's
-			// work budget. Keeping a single branch on the OR means adding a
-			// new non-retryable-user-facing subcategory only needs the code
-			// registry update, not another touch here.
+			// Zero-CU carve-out: unsupported methods are deterministic and
+			// cached — the provider won't be hit again, so zero CU is fair.
+			// User input errors (invalid params, bad hex, etc.) are NOT
+			// zero-CU: the response isn't cached, so the provider does real
+			// work on every call and should be compensated.
 			computeUnits := chainlib.GetComputeUnits(protocolMessage)
-			if localRelayResult.IsUnsupportedMethod || localRelayResult.IsUserError {
+			if localRelayResult.IsUnsupportedMethod {
 				computeUnits = 0
-				utils.LavaFormatDebug("Not charging CU for non-retryable user-facing error",
+				utils.LavaFormatDebug("Not charging CU for unsupported method",
 					utils.LogAttr("GUID", ctx),
 					utils.LogAttr("method", protocolMessage.GetApi().Name),
-					utils.LogAttr("isUnsupportedMethod", localRelayResult.IsUnsupportedMethod),
-					utils.LogAttr("isUserError", localRelayResult.IsUserError),
 				)
 			}
 


### PR DESCRIPTION
…user-input errors

User-input errors (Layer D: invalid params, bad hex, parse errors) were previously zero-CU like unsupported-method errors. This was wrong because user-error responses are NOT cached — the provider does real work on every call and should be compensated. Only unsupported-method responses (which ARE cached) justify the zero-CU carve-out.

- Remove SubCategoryUserError, IsUserError(), IsNonRetryableUserFacing()
- Remove IsUserInputError() classifier function
- Remove IsUserError field from RelayResult and NodeErrorClassification
- Remove IsNonRetryableUserFacingErrorType() (now redundant)
- Layer D codes keep Retryable=false (no retry) but SubCategory=None (normal CU)
- Zero-CU gate simplified: only IsUnsupportedMethod triggers it
- HasNonRetryableUserFacingErrors now uses IsNonRetryable flag directly

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage