### PR TITLE
fix(chaintracker): track Solana slot instead of block height

### DIFF
--- a/protocol/chainlib/svm_block_hash_retry.go
+++ b/protocol/chainlib/svm_block_hash_retry.go
@@ -76,20 +76,25 @@ func FetchBlockHashWithSolanaRetry(ctx context.Context, blockNum int64, retryDel
 	return "", blockNum, lastErr
 }
 
-// IsBlockNotAvailableError checks if a JSON-RPC response contains error code -32004
-// ("Block not available for slot X"), indicating a skipped slot or propagation delay.
-// The caller is responsible for gating this check to the appropriate chain family.
+// IsBlockNotAvailableError reports whether a Solana JSON-RPC response classifies as
+// LavaErrorChainBlockNotFound (e.g. -32004 "Block not available for slot X"), via the
+// chain-aware error registry. Callers must gate invocation to Solana-family chains.
 func IsBlockNotAvailableError(responseData []byte) bool {
 	if len(responseData) == 0 {
 		return false
 	}
 	var resp struct {
 		Error *struct {
-			Code int `json:"code"`
+			Code    int    `json:"code"`
+			Message string `json:"message"`
 		} `json:"error,omitempty"`
 	}
 	if err := json.Unmarshal(responseData, &resp); err != nil {
 		return false
 	}
-	return resp.Error != nil && resp.Error.Code == common.SolanaBlockNotAvailableCode
+	if resp.Error == nil {
+		return false
+	}
+	classified := common.ClassifyError(nil, common.ChainFamilySolana, common.TransportJsonRPC, resp.Error.Code, resp.Error.Message)
+	return classified == common.LavaErrorChainBlockNotFound
 }

--- a/protocol/chainlib/svm_block_hash_retry_test.go
+++ b/protocol/chainlib/svm_block_hash_retry_test.go
@@ -65,7 +65,7 @@ func TestIsBlockNotAvailableError_SolanaErrorCode(t *testing.T) {
 		{
 			name:     "EVM -32004 method not supported (same code different chain)",
 			response: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"Method not supported"}}`),
-			expected: true, // The function only checks the code, chain filtering is done by the caller
+			expected: true, // Classified via ChainFamilySolana (callers gate by chain); -32004 → BlockNotFound in Solana tier.
 		},
 	}
 

--- a/protocol/chaintracker/svm_chain_tracker.go
+++ b/protocol/chaintracker/svm_chain_tracker.go
@@ -62,21 +62,22 @@ func (cs *SVMChainTracker) fetchLatestBlockNumInner(ctx context.Context) (int64,
 		return 0, fmt.Errorf("failed to unmarshal response: %v", err)
 	}
 
-	blockNum := response.Result.Value.LastValidBlockHeight
+	// Solana uses slot (not block height) as the canonical chain-position primitive.
+	// Provider spec parsing also reads context.slot, so the tracker's "seen" value
+	// must track slot to keep consistency validation apples-to-apples.
 	slot := response.Result.Context.Slot
 	blockHash := response.Result.Value.BlockHash
 
-	atomic.StoreInt64(&cs.seenBlock, blockNum)
-	cs.slotCache.SetWithTTL(blockNum, slot, 1, slotCacheTTL)
-	cs.hashCache.SetWithTTL(blockNum, blockHash, 1, hashCacheTTL)
+	atomic.StoreInt64(&cs.seenBlock, slot)
+	cs.slotCache.SetWithTTL(slot, slot, 1, slotCacheTTL)
+	cs.hashCache.SetWithTTL(slot, blockHash, 1, hashCacheTTL)
 
-	utils.LavaFormatTrace("[SVMChainTracker] fetching latest block num",
+	utils.LavaFormatTrace("[SVMChainTracker] fetching latest slot",
 		utils.LogAttr("slot", slot),
-		utils.LogAttr("block_num", blockNum),
 		utils.LogAttr("block_hash", blockHash),
 	)
 
-	return blockNum, nil
+	return slot, nil
 }
 
 func (cs *SVMChainTracker) FetchLatestBlockNum(ctx context.Context) (int64, error) {
@@ -91,42 +92,39 @@ func (cs *SVMChainTracker) FetchLatestBlockNum(ctx context.Context) (int64, erro
 	return latestBlockNum, nil
 }
 
-func (cs *SVMChainTracker) FetchBlockHashByNum(ctx context.Context, blockNum int64) (string, error) {
-	if blockNum < cs.dataFetcher.GetAtomicLatestBlockNum()-int64(cs.dataFetcher.GetServerBlockMemory()) {
-		return "", ErrorFailedToFetchTooEarlyBlock.Wrapf("requested Block: %d, latest block: %d, server memory %d", blockNum, cs.dataFetcher.GetAtomicLatestBlockNum(), cs.dataFetcher.GetServerBlockMemory())
+// On Solana the interface's `blockNum` parameter is a slot.
+func (cs *SVMChainTracker) FetchBlockHashByNum(ctx context.Context, slot int64) (string, error) {
+	if slot < cs.dataFetcher.GetAtomicLatestBlockNum()-int64(cs.dataFetcher.GetServerBlockMemory()) {
+		return "", ErrorFailedToFetchTooEarlyBlock.Wrapf("requested slot: %d, latest slot: %d, server memory %d", slot, cs.dataFetcher.GetAtomicLatestBlockNum(), cs.dataFetcher.GetServerBlockMemory())
 	}
-	blockHash, ok := cs.hashCache.Get(blockNum)
-	if ok {
-		utils.LavaFormatTrace("[SVMChainTracker] FetchBlockHashByNum found block hash in cache", utils.LogAttr("block_num", blockNum), utils.LogAttr("hash", blockHash))
+	if blockHash, ok := cs.hashCache.Get(slot); ok {
+		utils.LavaFormatTrace("[SVMChainTracker] FetchBlockHashByNum found hash in cache", utils.LogAttr("slot", slot), utils.LogAttr("hash", blockHash))
 		return blockHash, nil
 	}
 
-	// In SVM, the block hash is fetched by slot instead of block.
-	// We need to get the slot which is related to this block number.
-	slot, err := cs.tryGetSlotFromCache(blockNum)
-	if err != nil {
+	if err := cs.waitForSlotVisible(slot); err != nil {
 		return "", err
 	}
 
-	utils.LavaFormatTrace("[SVMChainTracker] FetchBlockHashByNum found slot in cache", utils.LogAttr("block_num", blockNum), utils.LogAttr("slot", slot))
 	hash, err := cs.chainFetcher.FetchBlockHashByNum(ctx, slot)
 	if err == nil {
-		utils.LavaFormatTrace("[SVMChainTracker] FetchBlockHashByNum succeeded", utils.LogAttr("block_num", blockNum), utils.LogAttr("hash", hash), utils.LogAttr("slot", slot))
+		utils.LavaFormatTrace("[SVMChainTracker] FetchBlockHashByNum succeeded", utils.LogAttr("slot", slot), utils.LogAttr("hash", hash))
 	}
 	return hash, err
 }
 
-func (cs *SVMChainTracker) tryGetSlotFromCache(blockNum int64) (int64, error) {
-	if blockNum <= atomic.LoadInt64(&cs.seenBlock) {
-		for i := 0; i < getSlotFromCacheMaxRetries; i++ {
-			slot, ok := cs.slotCache.Get(blockNum)
-			if ok {
-				return slot, nil
+// waitForSlotVisible blocks briefly until the tracker has observed `slot` at least once.
+// Handles the bootstrap race where a hash lookup can arrive before the tracker has seen that slot.
+func (cs *SVMChainTracker) waitForSlotVisible(slot int64) error {
+	if slot <= atomic.LoadInt64(&cs.seenBlock) {
+		for range getSlotFromCacheMaxRetries {
+			if _, ok := cs.slotCache.Get(slot); ok {
+				return nil
 			}
 			time.Sleep(getSlotFromCacheSleepDuration)
 		}
 	}
 
-	return 0, fmt.Errorf("slot not found in cache. This error can happen on bootstrap and should resolve by itself, if persists please let the dev team know. "+
-		"block: %d, latest_block: %d, server_memory: %d", blockNum, cs.dataFetcher.GetAtomicLatestBlockNum(), cs.dataFetcher.GetServerBlockMemory())
+	return fmt.Errorf("slot not yet visible. This can happen on bootstrap and should resolve by itself, if persists please let the dev team know. "+
+		"slot: %d, latest_slot: %d, server_memory: %d", slot, cs.dataFetcher.GetAtomicLatestBlockNum(), cs.dataFetcher.GetServerBlockMemory())
 }

--- a/protocol/common/svm.go
+++ b/protocol/common/svm.go
@@ -1,9 +1,5 @@
 package common
 
-// SolanaBlockNotAvailableCode is the JSON-RPC error code for
-// "Block not available for slot X", indicating a skipped slot or propagation delay.
-const SolanaBlockNotAvailableCode = -32004
-
 // IsSolanaFamily returns true if the chain ID belongs to the Solana/SVM family.
 // These chains use slot-based block numbering where slots can be skipped or
 // not yet propagated, requiring special handling in block fetching.


### PR DESCRIPTION
The SVM chain tracker extracted `LastValidBlockHeight` into `seenBlock`, while provider spec parsing (specs/mainnet-1/specs/solana.json) reads `context.slot` for the same "latest block" signal. On Solana these diverge significantly (slot > block_height by the skip rate, ~22M on mainnet), so the consistency pre-validation in relaycore computed lag = seenBlock - endpointLatestBlock ≈ 22M every time, tripping the 50-slot threshold and returning "No pairings available" to clients.

Track slot on both sides so the comparison is apples-to-apples. Also rename local vars/helper for clarity (blockNum -> slot, tryGetSlotFromCache -> waitForSlotVisible) since on Solana the interface's blockNum arg is semantically a slot.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage