### PR TITLE
feat: Added support of backup providers to WS/gRPC

### DIFF
--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -77,9 +77,13 @@ type DirectGRPCSubscriptionManager struct {
 	chainID        string
 	apiInterface   string
 
-	// Upstream gRPC endpoints
-	grpcEndpoints  []*common.NodeUrl
-	endpointsByURL map[string]*common.NodeUrl
+	// Upstream gRPC endpoints — two-tier separation matches HTTP backup model.
+	// Primary tier serves all selections; backup tier is only consulted when
+	// primary is exhausted (analogous to ConsumerSessionManager's
+	// pairing/backupProviders split).
+	grpcEndpoints       []*common.NodeUrl          // Primary tier — selected first
+	grpcBackupEndpoints []*common.NodeUrl          // Backup tier — used only when primary exhausted
+	endpointsByURL      map[string]*common.NodeUrl // Lookup across both tiers (sticky-session uniformity)
 
 	// Endpoint selection (can be nil)
 	optimizer WebSocketEndpointOptimizer
@@ -106,12 +110,17 @@ type DirectGRPCSubscriptionManager struct {
 	lock sync.RWMutex
 }
 
-// NewDirectGRPCSubscriptionManager creates a new gRPC subscription manager
+// NewDirectGRPCSubscriptionManager creates a new gRPC subscription manager.
+//
+// grpcEndpoints is the primary tier — selectEndpoint serves these first.
+// grpcBackupEndpoints is the backup tier — only consulted when primary is exhausted.
+// Either slice may be nil or empty, but at least one must be non-empty for selection to succeed.
 func NewDirectGRPCSubscriptionManager(
 	metricsManager metrics.ConsumerMetricsManagerInf,
 	chainID string,
 	apiInterface string,
 	grpcEndpoints []*common.NodeUrl,
+	grpcBackupEndpoints []*common.NodeUrl,
 	optimizer WebSocketEndpointOptimizer,
 	config *GRPCStreamingConfig,
 ) *DirectGRPCSubscriptionManager {
@@ -130,7 +139,8 @@ func NewDirectGRPCSubscriptionManager(
 		chainID:              chainID,
 		apiInterface:         apiInterface,
 		grpcEndpoints:        grpcEndpoints,
-		endpointsByURL:       make(map[string]*common.NodeUrl),
+		grpcBackupEndpoints:  grpcBackupEndpoints,
+		endpointsByURL:       make(map[string]*common.NodeUrl, len(grpcEndpoints)+len(grpcBackupEndpoints)),
 		optimizer:            optimizer,
 		config:               config,
 		rateLimiter:          NewGRPCClientRateLimiter(config),
@@ -140,8 +150,11 @@ func NewDirectGRPCSubscriptionManager(
 		cancel:               cancel,
 	}
 
-	// Build endpoint lookup map
+	// Build endpoint lookup map across both tiers
 	for _, endpoint := range grpcEndpoints {
+		manager.endpointsByURL[endpoint.Url] = endpoint
+	}
+	for _, endpoint := range grpcBackupEndpoints {
 		manager.endpointsByURL[endpoint.Url] = endpoint
 	}
 
@@ -385,7 +398,7 @@ func (dgm *DirectGRPCSubscriptionManager) createNewSubscription(
 	clientKey string,
 ) (*pairingtypes.RelayReply, <-chan *pairingtypes.RelayReply, error) {
 	// Select endpoint
-	endpoint, err := dgm.selectEndpoint(clientKey)
+	endpoint, err := dgm.selectEndpoint(ctx, clientKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to select endpoint: %w", err)
 	}
@@ -862,31 +875,73 @@ func (dgm *DirectGRPCSubscriptionManager) getOrCreatePool(ctx context.Context, e
 	return pool, nil
 }
 
-func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(clientKey string) (*common.NodeUrl, error) {
-	// Check sticky session
+// selectEndpoint picks a gRPC endpoint for the given client, with primary→backup cascade.
+// Mirrors DirectWSSubscriptionManager.selectEndpoint and the HTTP backup-fallback model
+// (consumer_session_manager.go:820-852).
+func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string) (*common.NodeUrl, error) {
+	// Tier 0: sticky (resolves across both tiers via endpointsByURL).
 	dgm.lock.RLock()
 	stickyURL, hasSticky := dgm.stickySessions[clientKey]
 	dgm.lock.RUnlock()
-
 	if hasSticky {
 		if endpoint, exists := dgm.endpointsByURL[stickyURL]; exists {
 			return endpoint, nil
 		}
 	}
 
-	// Select first available endpoint (could be enhanced with optimizer)
-	if len(dgm.grpcEndpoints) == 0 {
-		return nil, fmt.Errorf("no gRPC endpoints available")
+	// Tier 1: primary (optimizer-aware).
+	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcEndpoints); err == nil {
+		dgm.lock.Lock()
+		dgm.stickySessions[clientKey] = endpoint.Url
+		dgm.lock.Unlock()
+		return endpoint, nil
 	}
 
-	endpoint := dgm.grpcEndpoints[0]
+	// Tier 2: backup (only when primary is empty/unavailable).
+	utils.LavaFormatDebug("DirectGRPC: primary endpoints exhausted, falling back to backup",
+		utils.LogAttr("backupCount", len(dgm.grpcBackupEndpoints)),
+	)
+	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcBackupEndpoints); err == nil {
+		dgm.lock.Lock()
+		dgm.stickySessions[clientKey] = endpoint.Url
+		dgm.lock.Unlock()
+		return endpoint, nil
+	}
 
-	// Set sticky session
-	dgm.lock.Lock()
-	dgm.stickySessions[clientKey] = endpoint.Url
-	dgm.lock.Unlock()
+	return nil, fmt.Errorf("no gRPC endpoints available")
+}
 
-	return endpoint, nil
+// selectFromTier picks an endpoint from a single tier using the optimizer when
+// available, falling back to first-available. Tier-agnostic — the cascade order
+// is the caller's responsibility.
+func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl) (*common.NodeUrl, error) {
+	if len(tier) == 0 {
+		return nil, fmt.Errorf("tier is empty")
+	}
+
+	// Single endpoint or no optimizer: first-available.
+	if len(tier) == 1 || dgm.optimizer == nil {
+		return tier[0], nil
+	}
+
+	// Optimizer over this tier.
+	allURLs := make([]string, 0, len(tier))
+	for _, ep := range tier {
+		allURLs = append(allURLs, ep.Url)
+	}
+	// cu=1 and requestedBlock=LATEST_BLOCK (-2) are sensible defaults for subscriptions.
+	selectedURLs := dgm.optimizer.ChooseProvider(ctx, allURLs, nil, 1, -2)
+
+	if len(selectedURLs) == 0 {
+		// Optimizer returned nothing — fall back to first-available within tier.
+		return tier[0], nil
+	}
+
+	selectedURL := selectedURLs[0]
+	if endpoint, exists := dgm.endpointsByURL[selectedURL]; exists {
+		return endpoint, nil
+	}
+	return nil, fmt.Errorf("optimizer selected unknown endpoint: %s", selectedURL)
 }
 
 func (dgm *DirectGRPCSubscriptionManager) checkClientSubscriptionLimit(clientKey string) error {

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/chainlib"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcInterfaceMessages"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
@@ -94,8 +95,11 @@ type DirectGRPCSubscriptionManager struct {
 	// Rate limiting
 	rateLimiter *GRPCClientRateLimiter
 
-	// Sticky sessions (client -> endpoint affinity)
-	stickySessions map[string]string // clientKey -> endpoint URL
+	// Sticky sessions (client -> endpoint affinity).
+	// Written in createNewSubscription only after the upstream connection is
+	// established, so a primary that fails to connect doesn't pin the client
+	// and prevent the cascade from reaching the backup tier.
+	stickyStore *lavasession.StickySessionStore
 
 	// Total subscription counter
 	totalSubscriptions atomic.Int64
@@ -144,7 +148,7 @@ func NewDirectGRPCSubscriptionManager(
 		optimizer:            optimizer,
 		config:               config,
 		rateLimiter:          NewGRPCClientRateLimiter(config),
-		stickySessions:       make(map[string]string),
+		stickyStore:          lavasession.NewStickySessionStore(),
 		clientSubscriptions:  make(map[string]map[string]struct{}),
 		ctx:                  ctx,
 		cancel:               cancel,
@@ -398,7 +402,7 @@ func (dgm *DirectGRPCSubscriptionManager) createNewSubscription(
 	clientKey string,
 ) (*pairingtypes.RelayReply, <-chan *pairingtypes.RelayReply, error) {
 	// Select endpoint
-	endpoint, err := dgm.selectEndpoint(ctx, clientKey)
+	endpoint, err := dgm.selectEndpoint(ctx, clientKey, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to select endpoint: %w", err)
 	}
@@ -414,6 +418,14 @@ func (dgm *DirectGRPCSubscriptionManager) createNewSubscription(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get connection: %w", err)
 	}
+
+	// Connection established — pin client to this endpoint for future
+	// subscriptions. Mirrors DirectWSSubscriptionManager.startUpstreamSubscription
+	// (Epoch is unused for direct RPC — there's no provider rotation).
+	dgm.stickyStore.Set(clientKey, &lavasession.StickySession{
+		Provider: endpoint.Url,
+		Epoch:    0,
+	})
 
 	// Parse service and method
 	svc, methodName := rpcInterfaceMessages.ParseSymbol(methodPath)
@@ -801,8 +813,8 @@ func (dgm *DirectGRPCSubscriptionManager) UnsubscribeAll(
 	// Cleanup client tracking
 	dgm.lock.Lock()
 	delete(dgm.clientSubscriptions, clientKey)
-	delete(dgm.stickySessions, clientKey)
 	dgm.lock.Unlock()
+	dgm.stickyStore.Delete(clientKey)
 
 	dgm.rateLimiter.CleanupClient(clientKey)
 
@@ -876,24 +888,38 @@ func (dgm *DirectGRPCSubscriptionManager) getOrCreatePool(ctx context.Context, e
 }
 
 // selectEndpoint picks a gRPC endpoint for the given client, with primary→backup cascade.
+// Selection priority:
+//  1. Sticky session (any tier — endpointsByURL spans both)
+//  2. Primary tier (optimizer or first-available)
+//  3. Backup tier (optimizer or first-available) — only when primary is exhausted
+//
 // Mirrors DirectWSSubscriptionManager.selectEndpoint and the HTTP backup-fallback model
-// (consumer_session_manager.go:820-852).
-func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string) (*common.NodeUrl, error) {
-	// Tier 0: sticky (resolves across both tiers via endpointsByURL).
-	dgm.lock.RLock()
-	stickyURL, hasSticky := dgm.stickySessions[clientKey]
-	dgm.lock.RUnlock()
-	if hasSticky {
-		if endpoint, exists := dgm.endpointsByURL[stickyURL]; exists {
-			return endpoint, nil
+// (consumer_session_manager.go:820-852). Sticky writes happen in createNewSubscription
+// after the upstream connection is verified, not here, so a primary that fails to
+// connect doesn't pin the client and block the cascade.
+func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+	// Tier 0: sticky session for this client (resolves across both tiers).
+	if clientKey != "" {
+		if stickySession, exists := dgm.stickyStore.Get(clientKey); exists {
+			if stickyEndpoint, found := dgm.endpointsByURL[stickySession.Provider]; found {
+				if ignoredEndpoints == nil {
+					return stickyEndpoint, nil
+				}
+				if _, ignored := ignoredEndpoints[stickySession.Provider]; !ignored {
+					return stickyEndpoint, nil
+				}
+				// Sticky endpoint is ignored — clear and continue to cascade.
+				utils.LavaFormatDebug("DirectGRPC: sticky endpoint ignored, clearing affinity",
+					utils.LogAttr("clientKey", clientKey),
+					utils.LogAttr("ignoredEndpoint", stickySession.Provider),
+				)
+				dgm.stickyStore.Delete(clientKey)
+			}
 		}
 	}
 
 	// Tier 1: primary (optimizer-aware).
-	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcEndpoints); err == nil {
-		dgm.lock.Lock()
-		dgm.stickySessions[clientKey] = endpoint.Url
-		dgm.lock.Unlock()
+	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcEndpoints, ignoredEndpoints); err == nil {
 		return endpoint, nil
 	}
 
@@ -901,10 +927,7 @@ func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, cl
 	utils.LavaFormatDebug("DirectGRPC: primary endpoints exhausted, falling back to backup",
 		utils.LogAttr("backupCount", len(dgm.grpcBackupEndpoints)),
 	)
-	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcBackupEndpoints); err == nil {
-		dgm.lock.Lock()
-		dgm.stickySessions[clientKey] = endpoint.Url
-		dgm.lock.Unlock()
+	if endpoint, err := dgm.selectFromTier(ctx, dgm.grpcBackupEndpoints, ignoredEndpoints); err == nil {
 		return endpoint, nil
 	}
 
@@ -912,16 +935,24 @@ func (dgm *DirectGRPCSubscriptionManager) selectEndpoint(ctx context.Context, cl
 }
 
 // selectFromTier picks an endpoint from a single tier using the optimizer when
-// available, falling back to first-available. Tier-agnostic — the cascade order
-// is the caller's responsibility.
-func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl) (*common.NodeUrl, error) {
+// available, falling back to first-non-ignored. Tier-agnostic — the cascade
+// order is the caller's responsibility.
+func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
 	if len(tier) == 0 {
 		return nil, fmt.Errorf("tier is empty")
 	}
 
-	// Single endpoint or no optimizer: first-available.
+	// Single endpoint or no optimizer: first-non-ignored.
 	if len(tier) == 1 || dgm.optimizer == nil {
-		return tier[0], nil
+		for _, ep := range tier {
+			if ignoredEndpoints == nil {
+				return ep, nil
+			}
+			if _, ignored := ignoredEndpoints[ep.Url]; !ignored {
+				return ep, nil
+			}
+		}
+		return nil, fmt.Errorf("all endpoints in tier are ignored/unavailable")
 	}
 
 	// Optimizer over this tier.
@@ -930,11 +961,19 @@ func (dgm *DirectGRPCSubscriptionManager) selectFromTier(ctx context.Context, ti
 		allURLs = append(allURLs, ep.Url)
 	}
 	// cu=1 and requestedBlock=LATEST_BLOCK (-2) are sensible defaults for subscriptions.
-	selectedURLs := dgm.optimizer.ChooseProvider(ctx, allURLs, nil, 1, -2)
+	selectedURLs := dgm.optimizer.ChooseProvider(ctx, allURLs, ignoredEndpoints, 1, -2)
 
 	if len(selectedURLs) == 0 {
-		// Optimizer returned nothing — fall back to first-available within tier.
-		return tier[0], nil
+		// Optimizer returned nothing — fall back to first-non-ignored within tier.
+		for _, ep := range tier {
+			if ignoredEndpoints == nil {
+				return ep, nil
+			}
+			if _, ignored := ignoredEndpoints[ep.Url]; !ignored {
+				return ep, nil
+			}
+		}
+		return nil, fmt.Errorf("optimizer returned no endpoints and all fallbacks in tier are ignored")
 	}
 
 	selectedURL := selectedURLs[0]

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/lavasession"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func TestNewDirectGRPCSubscriptionManager(t *testing.T) {
 	assert.NotNil(t, manager.idMapper)
 	assert.NotNil(t, manager.config)
 	assert.NotNil(t, manager.rateLimiter)
-	assert.NotNil(t, manager.stickySessions)
+	assert.NotNil(t, manager.stickyStore)
 	assert.NotNil(t, manager.clientSubscriptions)
 }
 
@@ -260,18 +261,19 @@ func TestDirectGRPCSubscriptionManager_StickySessions(t *testing.T) {
 	)
 
 	// Initially no sticky sessions
-	assert.Empty(t, manager.stickySessions)
+	_, exists := manager.stickyStore.Get("client-1")
+	assert.False(t, exists)
 
 	// Simulate setting a sticky session
-	manager.lock.Lock()
-	manager.stickySessions["client-1"] = "grpc://node1:9090"
-	manager.stickySessions["client-2"] = "grpc://node2:9090"
-	manager.lock.Unlock()
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{Provider: "grpc://node1:9090"})
+	manager.stickyStore.Set("client-2", &lavasession.StickySession{Provider: "grpc://node2:9090"})
 
-	manager.lock.RLock()
-	assert.Equal(t, "grpc://node1:9090", manager.stickySessions["client-1"])
-	assert.Equal(t, "grpc://node2:9090", manager.stickySessions["client-2"])
-	manager.lock.RUnlock()
+	s1, ok1 := manager.stickyStore.Get("client-1")
+	require.True(t, ok1)
+	assert.Equal(t, "grpc://node1:9090", s1.Provider)
+	s2, ok2 := manager.stickyStore.Get("client-2")
+	require.True(t, ok2)
+	assert.Equal(t, "grpc://node2:9090", s2.Provider)
 }
 
 func TestDirectGRPCSubscriptionManager_ClientSubscriptionTracking(t *testing.T) {
@@ -425,7 +427,7 @@ func TestSelectEndpoint_GRPC_PrimaryOnly_NilBackup(t *testing.T) {
 		nil, // grpcBackupEndpoints — none
 		nil, nil,
 	)
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)
 }
@@ -438,13 +440,9 @@ func TestSelectEndpoint_GRPC_PrimaryEmpty_BackupOnly(t *testing.T) {
 		backup,
 		nil, nil,
 	)
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
-	// Sticky should be set to the backup URL.
-	manager.lock.RLock()
-	defer manager.lock.RUnlock()
-	assert.Equal(t, "grpc://backup-1.example.com:9090", manager.stickySessions["client-1"])
 }
 
 func TestSelectEndpoint_GRPC_StickyOnBackup_Returns(t *testing.T) {
@@ -458,11 +456,11 @@ func TestSelectEndpoint_GRPC_StickyOnBackup_Returns(t *testing.T) {
 	)
 
 	// Pre-seed sticky to point at the backup URL.
-	manager.lock.Lock()
-	manager.stickySessions["client-1"] = "grpc://backup-1.example.com:9090"
-	manager.lock.Unlock()
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{
+		Provider: "grpc://backup-1.example.com:9090",
+	})
 
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
 }
@@ -473,7 +471,7 @@ func TestSelectEndpoint_GRPC_BothEmpty_ReturnsError(t *testing.T) {
 		nil, nil,
 		nil, nil,
 	)
-	_, err := manager.selectEndpoint(context.Background(), "client-1")
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.Error(t, err)
 }
 
@@ -499,15 +497,11 @@ func TestSelectEndpoint_GRPC_OptimizerOverPrimary(t *testing.T) {
 		nil,
 	)
 
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "grpc://primary-2.example.com:9090", ep.Url)
 	// Optimizer must run exactly once (against primary tier).
 	assert.Equal(t, 1, calls)
-	// Sticky must be set to the optimizer-selected URL.
-	manager.lock.RLock()
-	defer manager.lock.RUnlock()
-	assert.Equal(t, "grpc://primary-2.example.com:9090", manager.stickySessions["client-1"])
 }
 
 func TestSelectEndpoint_GRPC_OptimizerOverBackup(t *testing.T) {
@@ -531,15 +525,12 @@ func TestSelectEndpoint_GRPC_OptimizerOverBackup(t *testing.T) {
 		nil,
 	)
 
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "grpc://backup-2.example.com:9090", ep.Url)
 	// Optimizer must run exactly once (against backup tier — primary is empty
 	// so selectFromTier returns "tier is empty" without invoking the optimizer).
 	assert.Equal(t, 1, calls)
-	manager.lock.RLock()
-	defer manager.lock.RUnlock()
-	assert.Equal(t, "grpc://backup-2.example.com:9090", manager.stickySessions["client-1"])
 }
 
 func TestSelectEndpoint_GRPC_OptimizerNil_FallsBackToFirst(t *testing.T) {
@@ -555,10 +546,97 @@ func TestSelectEndpoint_GRPC_OptimizerNil_FallsBackToFirst(t *testing.T) {
 		nil,
 	)
 
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	// No optimizer → selectFromTier returns tier[0] directly.
 	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)
+}
+
+func TestSelectEndpoint_GRPC_DoesNotWriteSticky(t *testing.T) {
+	// selectEndpoint must not write sticky sessions — the write must happen
+	// in createNewSubscription only after the upstream connection is verified.
+	// Otherwise a sticky entry pointing at a primary that fails to connect
+	// will pin the client to that dead URL on every subsequent call,
+	// preventing the cascade from ever reaching the backup tier.
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		backup,
+		nil, nil,
+	)
+
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+
+	_, exists := manager.stickyStore.Get("client-1")
+	assert.False(t, exists, "selectEndpoint must not write sticky sessions")
+}
+
+func TestSelectEndpoint_GRPC_IgnoredSticky_ClearsAndCascades(t *testing.T) {
+	// When the sticky URL is in ignoredEndpoints, sticky must be cleared and
+	// selection must fall through to the next tier. Mirrors WS behavior.
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		backup,
+		nil, nil,
+	)
+
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{
+		Provider: "grpc://primary-1.example.com:9090",
+	})
+
+	ignored := map[string]struct{}{
+		"grpc://primary-1.example.com:9090": {},
+	}
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.NoError(t, err)
+	// Primary is ignored → cascade to backup.
+	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
+	// Sticky must have been cleared so the next call re-cascades cleanly.
+	_, exists := manager.stickyStore.Get("client-1")
+	assert.False(t, exists, "ignored sticky endpoint must be cleared")
+}
+
+func TestSelectEndpoint_GRPC_IgnoredInPrimary_CascadesToBackup(t *testing.T) {
+	// When all primary endpoints are ignored, selection must reach the backup tier.
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		backup,
+		nil, nil,
+	)
+
+	ignored := map[string]struct{}{
+		"grpc://primary-1.example.com:9090": {},
+	}
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
+}
+
+func TestSelectEndpoint_GRPC_IgnoredEverywhere_ReturnsError(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		backup,
+		nil, nil,
+	)
+
+	ignored := map[string]struct{}{
+		"grpc://primary-1.example.com:9090": {},
+		"grpc://backup-1.example.com:9090":  {},
+	}
+	_, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.Error(t, err)
 }
 
 func TestSelectEndpoint_GRPC_OptimizerReturnsEmpty_FallsBackToFirst(t *testing.T) {
@@ -579,7 +657,7 @@ func TestSelectEndpoint_GRPC_OptimizerReturnsEmpty_FallsBackToFirst(t *testing.T
 		nil,
 	)
 
-	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
 	require.NoError(t, err)
 	// Optimizer returned empty → selectFromTier falls back to tier[0].
 	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)

--- a/protocol/rpcsmartrouter/direct_grpc_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_grpc_subscription_manager_test.go
@@ -24,6 +24,7 @@ func TestNewDirectGRPCSubscriptionManager(t *testing.T) {
 		chainID,
 		apiInterface,
 		endpoints,
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil, // optimizer
 		nil, // config (use defaults)
 	)
@@ -55,6 +56,7 @@ func TestNewDirectGRPCSubscriptionManager_WithConfig(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -71,6 +73,7 @@ func TestNewDirectGRPCSubscriptionManager_EmptyEndpoints(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{}, // Empty endpoints
+		nil,                 // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -92,6 +95,7 @@ func TestDirectGRPCSubscriptionManager_EndpointLookup(t *testing.T) {
 		"COSMOSHUB",
 		"grpc",
 		endpoints,
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -109,6 +113,7 @@ func TestDirectGRPCSubscriptionManager_StartStop(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -137,6 +142,7 @@ func TestDirectGRPCSubscriptionManager_Stop_Idempotent(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -155,6 +161,7 @@ func TestDirectGRPCSubscriptionManager_TotalSubscriptions(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -181,6 +188,7 @@ func TestDirectGRPCSubscriptionManager_RateLimiter(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -201,6 +209,7 @@ func TestDirectGRPCSubscriptionManager_IDMapper(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -245,6 +254,7 @@ func TestDirectGRPCSubscriptionManager_StickySessions(t *testing.T) {
 			{Url: "grpc://node1:9090"},
 			{Url: "grpc://node2:9090"},
 		},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -270,6 +280,7 @@ func TestDirectGRPCSubscriptionManager_ClientSubscriptionTracking(t *testing.T) 
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -312,6 +323,7 @@ func TestDirectGRPCSubscriptionManager_ContextCancellation(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -393,6 +405,7 @@ func TestDirectGRPCSubscriptionManager_DefaultConfig(t *testing.T) {
 		"ETH",
 		"grpc",
 		[]*common.NodeUrl{{Url: "grpc://localhost:9090"}},
+		nil, // grpcBackupEndpoints — none for primary-only test
 		nil,
 		nil, // nil config should use defaults
 	)
@@ -402,4 +415,172 @@ func TestDirectGRPCSubscriptionManager_DefaultConfig(t *testing.T) {
 	assert.Equal(t, 10000, manager.config.MaxTotalSubscriptions)
 	assert.Equal(t, "warn", manager.config.PerClientLimitEnforcement)
 	assert.True(t, manager.config.SubscriptionSharingEnabled)
+}
+
+func TestSelectEndpoint_GRPC_PrimaryOnly_NilBackup(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		nil, // grpcBackupEndpoints — none
+		nil, nil,
+	)
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)
+}
+
+func TestSelectEndpoint_GRPC_PrimaryEmpty_BackupOnly(t *testing.T) {
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		nil, // primary empty
+		backup,
+		nil, nil,
+	)
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
+	// Sticky should be set to the backup URL.
+	manager.lock.RLock()
+	defer manager.lock.RUnlock()
+	assert.Equal(t, "grpc://backup-1.example.com:9090", manager.stickySessions["client-1"])
+}
+
+func TestSelectEndpoint_GRPC_StickyOnBackup_Returns(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "grpc://primary-1.example.com:9090"}}
+	backup := []*common.NodeUrl{{Url: "grpc://backup-1.example.com:9090"}}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		backup,
+		nil, nil,
+	)
+
+	// Pre-seed sticky to point at the backup URL.
+	manager.lock.Lock()
+	manager.stickySessions["client-1"] = "grpc://backup-1.example.com:9090"
+	manager.lock.Unlock()
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://backup-1.example.com:9090", ep.Url)
+}
+
+func TestSelectEndpoint_GRPC_BothEmpty_ReturnsError(t *testing.T) {
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		nil, nil,
+		nil, nil,
+	)
+	_, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.Error(t, err)
+}
+
+func TestSelectEndpoint_GRPC_OptimizerOverPrimary(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "grpc://primary-1.example.com:9090"},
+		{Url: "grpc://primary-2.example.com:9090"},
+	}
+
+	calls := 0
+	opt := &fakeSubscriptionOptimizer{
+		chooseFn: func(addresses []string, _ map[string]struct{}) []string {
+			calls++
+			// Always return primary-2 — backup tier must never reach the optimizer.
+			return []string{"grpc://primary-2.example.com:9090"}
+		},
+	}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		nil, // grpcBackupEndpoints — none for primary-only test
+		opt,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://primary-2.example.com:9090", ep.Url)
+	// Optimizer must run exactly once (against primary tier).
+	assert.Equal(t, 1, calls)
+	// Sticky must be set to the optimizer-selected URL.
+	manager.lock.RLock()
+	defer manager.lock.RUnlock()
+	assert.Equal(t, "grpc://primary-2.example.com:9090", manager.stickySessions["client-1"])
+}
+
+func TestSelectEndpoint_GRPC_OptimizerOverBackup(t *testing.T) {
+	backup := []*common.NodeUrl{
+		{Url: "grpc://backup-1.example.com:9090"},
+		{Url: "grpc://backup-2.example.com:9090"},
+	}
+
+	calls := 0
+	opt := &fakeSubscriptionOptimizer{
+		chooseFn: func(addresses []string, _ map[string]struct{}) []string {
+			calls++
+			return []string{"grpc://backup-2.example.com:9090"}
+		},
+	}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		nil, // primary empty — cascade must reach backup tier
+		backup,
+		opt,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	assert.Equal(t, "grpc://backup-2.example.com:9090", ep.Url)
+	// Optimizer must run exactly once (against backup tier — primary is empty
+	// so selectFromTier returns "tier is empty" without invoking the optimizer).
+	assert.Equal(t, 1, calls)
+	manager.lock.RLock()
+	defer manager.lock.RUnlock()
+	assert.Equal(t, "grpc://backup-2.example.com:9090", manager.stickySessions["client-1"])
+}
+
+func TestSelectEndpoint_GRPC_OptimizerNil_FallsBackToFirst(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "grpc://primary-1.example.com:9090"},
+		{Url: "grpc://primary-2.example.com:9090"},
+	}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		nil, // grpcBackupEndpoints — none
+		nil, // optimizer nil — first-available branch
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	// No optimizer → selectFromTier returns tier[0] directly.
+	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)
+}
+
+func TestSelectEndpoint_GRPC_OptimizerReturnsEmpty_FallsBackToFirst(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "grpc://primary-1.example.com:9090"},
+		{Url: "grpc://primary-2.example.com:9090"},
+	}
+	opt := &fakeSubscriptionOptimizer{
+		chooseFn: func(_ []string, _ map[string]struct{}) []string {
+			return nil // simulate optimizer returning nothing
+		},
+	}
+	manager := NewDirectGRPCSubscriptionManager(
+		nil, "ETH", "grpc",
+		primary,
+		nil,
+		opt,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1")
+	require.NoError(t, err)
+	// Optimizer returned empty → selectFromTier falls back to tier[0].
+	assert.Equal(t, "grpc://primary-1.example.com:9090", ep.Url)
 }

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager.go
@@ -109,10 +109,13 @@ type DirectWSSubscriptionManager struct {
 	chainID        string
 	apiInterface   string
 
-	// Upstream endpoint configuration - multiple endpoints for optimizer selection
-	wsEndpoints    []*common.NodeUrl          // All available WebSocket endpoints
-	endpointsByURL map[string]*common.NodeUrl // Quick lookup by URL
-	optimizer      WebSocketEndpointOptimizer // Optimizer for endpoint selection (can be nil)
+	// Upstream endpoint configuration - two-tier separation matches HTTP backup model.
+	// Primary tier serves all selections; backup tier is only consulted when primary is
+	// exhausted (analogous to ConsumerSessionManager's pairing/backupProviders split).
+	wsEndpoints       []*common.NodeUrl          // Primary tier — selected first
+	wsBackupEndpoints []*common.NodeUrl          // Backup tier — used only when primary exhausted
+	endpointsByURL    map[string]*common.NodeUrl // Quick lookup by URL across both tiers (sticky-session uniformity)
+	optimizer         WebSocketEndpointOptimizer // Optimizer for endpoint selection (can be nil)
 
 	// Sticky sessions for subscription affinity - same client uses same endpoint
 	stickyStore *lavasession.StickySessionStore
@@ -142,18 +145,27 @@ type WebSocketEndpointOptimizer interface {
 
 // NewDirectWSSubscriptionManager creates a new direct WebSocket subscription manager.
 // If config is nil, DefaultWebsocketConfig() will be used.
+//
+// wsEndpoints is the primary tier — selectEndpoint serves these first.
+// wsBackupEndpoints is the backup tier — only consulted when primary is exhausted.
+// Either slice may be nil or empty; both must not be empty for selection to succeed.
 func NewDirectWSSubscriptionManager(
 	metricsManager metrics.ConsumerMetricsManagerInf,
 	connectionType string,
 	chainID string,
 	apiInterface string,
 	wsEndpoints []*common.NodeUrl,
+	wsBackupEndpoints []*common.NodeUrl,
 	optimizer WebSocketEndpointOptimizer,
 	config *WebsocketConfig,
 ) *DirectWSSubscriptionManager {
-	// Build URL lookup map
-	endpointsByURL := make(map[string]*common.NodeUrl, len(wsEndpoints))
+	// Build URL lookup map across both tiers so sticky-session lookups by URL
+	// work uniformly regardless of which tier the endpoint came from.
+	endpointsByURL := make(map[string]*common.NodeUrl, len(wsEndpoints)+len(wsBackupEndpoints))
 	for _, ep := range wsEndpoints {
+		endpointsByURL[ep.Url] = ep
+	}
+	for _, ep := range wsBackupEndpoints {
 		endpointsByURL[ep.Url] = ep
 	}
 
@@ -173,6 +185,7 @@ func NewDirectWSSubscriptionManager(
 		chainID:              chainID,
 		apiInterface:         apiInterface,
 		wsEndpoints:          wsEndpoints,
+		wsBackupEndpoints:    wsBackupEndpoints,
 		endpointsByURL:       endpointsByURL,
 		optimizer:            optimizer,
 		stickyStore:          lavasession.NewStickySessionStore(),
@@ -290,20 +303,18 @@ func (dwsm *DirectWSSubscriptionManager) performCleanup() {
 
 // selectEndpoint selects the best WebSocket endpoint for a client.
 // Selection priority:
-//  1. Sticky session (if client already has affinity to an endpoint)
-//  2. Optimizer-based selection (QoS, latency, etc.)
-//  3. First available endpoint (fallback)
+//  1. Sticky session (any tier — endpointsByURL spans both)
+//  2. Primary tier (optimizer or first-available)
+//  3. Backup tier (optimizer or first-available) — only when primary is exhausted
+//
+// Backup-tier consultation mirrors ConsumerSessionManager.getSessionWithProviderOrError
+// (see protocol/lavasession/consumer_session_manager.go:820-852).
 func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, clientKey string, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
-	if len(dwsm.wsEndpoints) == 0 {
-		return nil, fmt.Errorf("no WebSocket endpoints configured")
-	}
-
-	// Priority 1: Check sticky session for this client
+	// Tier 0: sticky session for this client (resolves across both tiers).
 	if clientKey != "" {
 		if stickySession, exists := dwsm.stickyStore.Get(clientKey); exists {
 			stickyEndpoint, found := dwsm.endpointsByURL[stickySession.Provider]
 			if found {
-				// Check if sticky endpoint is not ignored
 				if ignoredEndpoints == nil {
 					utils.LavaFormatDebug("DirectWS: using sticky session endpoint",
 						utils.LogAttr("clientKey", clientKey),
@@ -318,7 +329,7 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 					)
 					return stickyEndpoint, nil
 				}
-				// Sticky endpoint is ignored, clear it and continue to optimizer
+				// Sticky endpoint is ignored — clear and continue to cascade.
 				utils.LavaFormatDebug("DirectWS: sticky endpoint ignored, clearing affinity",
 					utils.LogAttr("clientKey", clientKey),
 					utils.LogAttr("ignoredEndpoint", sanitizeEndpointURL(stickySession.Provider)),
@@ -328,9 +339,36 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 		}
 	}
 
-	// Priority 2: If only one endpoint or no optimizer, use first available
-	if len(dwsm.wsEndpoints) == 1 || dwsm.optimizer == nil {
-		for _, ep := range dwsm.wsEndpoints {
+	// Tier 1: primary endpoints.
+	ep, primaryErr := dwsm.selectFromTier(ctx, dwsm.wsEndpoints, ignoredEndpoints)
+	if primaryErr == nil {
+		return ep, nil
+	}
+
+	// Tier 2: backup endpoints (only when primary is exhausted).
+	utils.LavaFormatDebug("DirectWS: primary endpoints exhausted, falling back to backup",
+		utils.LogAttr("primaryReason", primaryErr.Error()),
+		utils.LogAttr("backupCount", len(dwsm.wsBackupEndpoints)),
+	)
+	ep, backupErr := dwsm.selectFromTier(ctx, dwsm.wsBackupEndpoints, ignoredEndpoints)
+	if backupErr == nil {
+		return ep, nil
+	}
+
+	return nil, fmt.Errorf("no WebSocket endpoints available (primary and backup both exhausted)")
+}
+
+// selectFromTier picks one endpoint from the given tier's endpoint slice using
+// the optimizer when available, falling back to first-non-ignored. The caller is
+// responsible for cascade ordering — this helper is tier-agnostic.
+func (dwsm *DirectWSSubscriptionManager) selectFromTier(ctx context.Context, tier []*common.NodeUrl, ignoredEndpoints map[string]struct{}) (*common.NodeUrl, error) {
+	if len(tier) == 0 {
+		return nil, fmt.Errorf("tier is empty")
+	}
+
+	// Single endpoint or no optimizer: first-non-ignored.
+	if len(tier) == 1 || dwsm.optimizer == nil {
+		for _, ep := range tier {
 			if ignoredEndpoints == nil {
 				return ep, nil
 			}
@@ -338,21 +376,20 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 				return ep, nil
 			}
 		}
-		return nil, fmt.Errorf("all WebSocket endpoints are ignored/unavailable")
+		return nil, fmt.Errorf("all endpoints in tier are ignored/unavailable")
 	}
 
-	// Priority 3: Use optimizer to select best endpoint
-	allURLs := make([]string, 0, len(dwsm.wsEndpoints))
-	for _, ep := range dwsm.wsEndpoints {
+	// Optimizer over this tier.
+	allURLs := make([]string, 0, len(tier))
+	for _, ep := range tier {
 		allURLs = append(allURLs, ep.Url)
 	}
-
-	// cu=1 and requestedBlock=LATEST_BLOCK are sensible defaults for subscriptions
-	selectedURLs := dwsm.optimizer.ChooseProvider(ctx, allURLs, ignoredEndpoints, 1, -2) // -2 = LATEST_BLOCK
+	// cu=1 and requestedBlock=LATEST_BLOCK (-2) are sensible defaults for subscriptions.
+	selectedURLs := dwsm.optimizer.ChooseProvider(ctx, allURLs, ignoredEndpoints, 1, -2)
 
 	if len(selectedURLs) == 0 {
-		// Optimizer returned nothing, fall back to first non-ignored
-		for _, ep := range dwsm.wsEndpoints {
+		// Optimizer returned nothing — fall back to first-non-ignored within tier.
+		for _, ep := range tier {
 			if ignoredEndpoints == nil {
 				return ep, nil
 			}
@@ -360,7 +397,7 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 				return ep, nil
 			}
 		}
-		return nil, fmt.Errorf("optimizer returned no endpoints and all fallbacks are ignored")
+		return nil, fmt.Errorf("optimizer returned no endpoints and all fallbacks in tier are ignored")
 	}
 
 	selectedURL := selectedURLs[0]
@@ -371,7 +408,7 @@ func (dwsm *DirectWSSubscriptionManager) selectEndpoint(ctx context.Context, cli
 
 	utils.LavaFormatDebug("DirectWS: selected endpoint via optimizer",
 		utils.LogAttr("endpoint", sanitizeEndpointURL(selectedURL)),
-		utils.LogAttr("totalEndpoints", len(dwsm.wsEndpoints)),
+		utils.LogAttr("tierSize", len(tier)),
 	)
 
 	return selectedEndpoint, nil

--- a/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
+++ b/protocol/rpcsmartrouter/direct_ws_subscription_manager_test.go
@@ -17,6 +17,7 @@ import (
 	rpcclient "github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
 	"github.com/lavanet/lava/v5/protocol/chainlib/extensionslib"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
@@ -285,6 +286,7 @@ func TestNewDirectWSSubscriptionManager(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil, // No optimizer for basic test
 		nil, // Use default WebSocket config
 	)
@@ -320,6 +322,7 @@ func TestGetOrCreatePool(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil, // Use default WebSocket config
 	)
@@ -356,6 +359,7 @@ func TestDirectWSSubscriptionManager_UnsubscribeAll_NoSubscriptions(t *testing.T
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil, // Use default WebSocket config
 	)
@@ -379,6 +383,7 @@ func TestDirectWSSubscriptionManager_Unsubscribe_NoSubscriptions(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil, // Use default WebSocket config
 	)
@@ -409,6 +414,7 @@ func TestDirectWSSubscriptionManager_StartSubscription_ConnectionFailure(t *test
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil, // Use default WebSocket config
 	)
@@ -533,6 +539,7 @@ func TestActiveSubscriptionTracksPerClientRouterIDs(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -612,6 +619,7 @@ func TestUnsubscribeRateLimiting(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -669,6 +677,7 @@ func TestUnsubscribeAllNotRateLimited(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -705,6 +714,7 @@ func TestMultiClientJoinExistingSubscription(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -814,6 +824,7 @@ func TestMultiClientIndependentUnsubscribe(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -948,6 +959,7 @@ func TestRouteMessageToClientsPerClientID(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -1041,6 +1053,7 @@ func TestReconnectionUpdatesConnectionBookkeeping(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -1163,6 +1176,7 @@ func TestUnsubscribeRouterIDOwnershipValidation(t *testing.T) {
 		"ETH",
 		"jsonrpc",
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		config,
 	)
@@ -1394,6 +1408,7 @@ func TestDirectWSSubscriptionManager_TendermintAPIInterface(t *testing.T) {
 		"COSMOSHUB",
 		"tendermintrpc", // Tendermint API interface
 		wsEndpoints,
+		nil, // wsBackupEndpoints — none for primary-only test
 		nil,
 		nil,
 	)
@@ -1586,4 +1601,321 @@ func TestTendermintSubscriptionEndToEnd(t *testing.T) {
 		// Should NOT have the router ID injected
 		assert.NotContains(t, string(rewritten), "some-router-id")
 	})
+}
+
+// fakeSubscriptionOptimizer is a minimal WebSocketEndpointOptimizer for cascade tests.
+// Used by both DirectWSSubscriptionManager and DirectGRPCSubscriptionManager test suites
+// (the interface is shared across both subscription managers despite its name).
+// It returns a configurable address from ChooseProvider; relay-data callbacks are no-ops.
+type fakeSubscriptionOptimizer struct {
+	chooseFn func(allAddresses []string, ignored map[string]struct{}) []string
+}
+
+func (f *fakeSubscriptionOptimizer) ChooseProvider(_ context.Context, allAddresses []string, ignored map[string]struct{}, _ uint64, _ int64) []string {
+	if f.chooseFn != nil {
+		return f.chooseFn(allAddresses, ignored)
+	}
+	return nil
+}
+
+func (f *fakeSubscriptionOptimizer) AppendRelayData(_ string, _ time.Duration, _, _ uint64) {}
+func (f *fakeSubscriptionOptimizer) AppendRelayFailure(_ string)                            {}
+
+func TestSelectEndpoint_WS_PrimaryOnly_NilBackup(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "wss://primary-1.example.com"},
+		{Url: "wss://primary-2.example.com"},
+	}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		nil, // wsBackupEndpoints — none
+		nil, // optimizer
+		nil, // config
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	// First-available branch with no optimizer and no ignored set returns first endpoint.
+	assert.Equal(t, "wss://primary-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_PrimaryOnly_EmptyBackup(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		[]*common.NodeUrl{}, // empty backup, regression guard for nil-vs-empty equivalence
+		nil,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "wss://primary-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_PrimaryExhausted_FallsBackToBackup(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "wss://primary-1.example.com"},
+		{Url: "wss://primary-2.example.com"},
+	}
+	backup := []*common.NodeUrl{
+		{Url: "wss://backup-1.example.com"},
+	}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil, // optimizer nil — first-available branch
+		nil,
+	)
+
+	ignored := map[string]struct{}{
+		"wss://primary-1.example.com": {},
+		"wss://primary-2.example.com": {},
+	}
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	assert.Equal(t, "wss://backup-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_PrimaryEmpty_BackupOnly(t *testing.T) {
+	backup := []*common.NodeUrl{
+		{Url: "wss://backup-1.example.com"},
+		{Url: "wss://backup-2.example.com"},
+	}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		nil, // primary empty
+		backup,
+		nil,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	assert.Equal(t, "wss://backup-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_BothExhausted_ReturnsError(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil,
+		nil,
+	)
+
+	ignored := map[string]struct{}{
+		"wss://primary-1.example.com": {},
+		"wss://backup-1.example.com":  {},
+	}
+	_, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary and backup both exhausted")
+}
+
+func TestSelectEndpoint_WS_BothEmpty_ReturnsError(t *testing.T) {
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	_, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.Error(t, err)
+}
+
+func TestSelectEndpoint_WS_StickyOnPrimary_Returns(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil,
+		nil,
+	)
+
+	// Manually set a sticky entry pointing at the primary.
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{Provider: "wss://primary-1.example.com"})
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "wss://primary-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_StickyOnBackup_Returns(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil,
+		nil,
+	)
+
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{Provider: "wss://backup-1.example.com"})
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	// Sticky-on-backup must resolve directly via endpointsByURL (which spans both tiers).
+	assert.Equal(t, "wss://backup-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_StickyIgnored_FallsThroughCascade(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil,
+		nil,
+	)
+
+	manager.stickyStore.Set("client-1", &lavasession.StickySession{Provider: "wss://primary-1.example.com"})
+
+	ignored := map[string]struct{}{
+		"wss://primary-1.example.com": {},
+	}
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.NoError(t, err)
+	assert.Equal(t, "wss://backup-1.example.com", ep.Url)
+}
+
+func TestSelectEndpoint_WS_OptimizerOverPrimary_NotConsultedForBackup(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "wss://primary-1.example.com"},
+		{Url: "wss://primary-2.example.com"},
+	}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+
+	calls := 0
+	opt := &fakeSubscriptionOptimizer{
+		chooseFn: func(addresses []string, _ map[string]struct{}) []string {
+			calls++
+			// Always return the second primary URL — backup must never reach the optimizer.
+			return []string{"wss://primary-2.example.com"}
+		},
+	}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		opt,
+		nil,
+	)
+
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "wss://primary-2.example.com", ep.Url)
+	// Optimizer must run exactly once (against primary tier). If the cascade
+	// erroneously fell into the backup tier, the optimizer would be invoked twice.
+	assert.Equal(t, 1, calls)
+}
+
+func TestSelectEndpoint_WS_OptimizerOverBackup(t *testing.T) {
+	primary := []*common.NodeUrl{
+		{Url: "wss://primary-1.example.com"},
+		{Url: "wss://primary-2.example.com"},
+	}
+	backup := []*common.NodeUrl{
+		{Url: "wss://backup-1.example.com"},
+		{Url: "wss://backup-2.example.com"},
+	}
+
+	calls := 0
+	opt := &fakeSubscriptionOptimizer{
+		chooseFn: func(addresses []string, ignored map[string]struct{}) []string {
+			calls++
+			// When invoked over the backup tier, return backup-2.
+			// When invoked over the primary tier (with both primaries ignored),
+			// return nothing so the cascade falls through.
+			for _, addr := range addresses {
+				if addr == "wss://backup-2.example.com" {
+					return []string{"wss://backup-2.example.com"}
+				}
+			}
+			return nil
+		},
+	}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		opt,
+		nil,
+	)
+
+	ignored := map[string]struct{}{
+		"wss://primary-1.example.com": {},
+		"wss://primary-2.example.com": {},
+	}
+	ep, err := manager.selectEndpoint(context.Background(), "client-1", ignored)
+	require.NoError(t, err)
+	assert.Equal(t, "wss://backup-2.example.com", ep.Url)
+	// Optimizer must be consulted for both tiers: once over primary (returns nil
+	// → cascade falls through), then once over backup (returns backup-2).
+	assert.Equal(t, 2, calls)
+}
+
+func TestSelectEndpoint_WS_EndpointsByURL_IncludesBothTiers(t *testing.T) {
+	primary := []*common.NodeUrl{{Url: "wss://primary-1.example.com"}}
+	backup := []*common.NodeUrl{{Url: "wss://backup-1.example.com"}}
+	manager := NewDirectWSSubscriptionManager(
+		getTestMetricsManager(),
+		"jsonrpc",
+		"ETH",
+		"jsonrpc",
+		primary,
+		backup,
+		nil,
+		nil,
+	)
+
+	require.Len(t, manager.endpointsByURL, 2)
+	assert.NotNil(t, manager.endpointsByURL["wss://primary-1.example.com"])
+	assert.NotNil(t, manager.endpointsByURL["wss://backup-1.example.com"])
 }

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1096,6 +1096,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			rpcEndpoint.ChainID,
 			rpcEndpoint.ApiInterface,
 			wsEndpoints,
+			nil,       // wsBackupEndpoints — Phase 2 will populate from relevantBackupProviderList
 			optimizer, // Pass optimizer for endpoint selection
 			nil,       // Use default WebSocket config (configurable via CLI flags later)
 		)
@@ -1146,6 +1147,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			rpcEndpoint.ChainID,
 			rpcEndpoint.ApiInterface,
 			grpcEndpoints,
+			nil,       // grpcBackupEndpoints — Phase 2 will populate from relevantBackupProviderList
 			optimizer, // Pass optimizer for endpoint selection (same as WS manager)
 			nil,       // Use default GRPCStreamingConfig
 		)

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1070,33 +1070,21 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	// and direct RPC (DirectWSSubscriptionManager) implementations
 	var wsSubscriptionManager chainlib.WSSubscriptionManager
 
-	// Collect ALL WebSocket-capable endpoints from static providers for direct subscriptions
-	// WebSocket URLs are identified by ws:// or wss:// prefix
-	var wsEndpoints []*common.NodeUrl
-	for _, provider := range healthyStaticProviders {
-		for i := range provider.NodeUrls {
-			url := strings.ToLower(provider.NodeUrls[i].Url)
-			if strings.HasPrefix(url, "ws://") || strings.HasPrefix(url, "wss://") {
-				wsEndpoints = append(wsEndpoints, &provider.NodeUrls[i])
-				utils.LavaFormatInfo("Found WebSocket endpoint for direct subscriptions",
-					utils.LogAttr("url", provider.NodeUrls[i].Url),
-					utils.LogAttr("provider", provider.Name),
-					utils.LogAttr("chainID", provider.ChainID),
-				)
-			}
-		}
-	}
+	// Collect WebSocket-capable endpoints for direct subscriptions.
+	// Primary tier serves all selections; backup tier is consulted on primary exhaustion.
+	wsEndpoints := collectWSEndpoints(healthyStaticProviders, "primary")
+	wsBackupEndpoints := collectWSEndpoints(healthyBackupProviders, "backup")
 
-	// Create DirectWSSubscriptionManager if WebSocket endpoints are available
-	// Otherwise fall back to provider-based subscription manager
-	if len(wsEndpoints) > 0 {
+	// Create DirectWSSubscriptionManager if any WebSocket endpoints are available
+	// (primary or backup); otherwise install the NoOp manager.
+	if len(wsEndpoints) > 0 || len(wsBackupEndpoints) > 0 {
 		directWSManager := NewDirectWSSubscriptionManager(
 			smartRouterMetricsManager,
 			spectypes.APIInterfaceJsonRPC, // WebSocket subscriptions use JSON-RPC
 			rpcEndpoint.ChainID,
 			rpcEndpoint.ApiInterface,
 			wsEndpoints,
-			nil,       // wsBackupEndpoints — Phase 2 will populate from relevantBackupProviderList
+			wsBackupEndpoints,
 			optimizer, // Pass optimizer for endpoint selection
 			nil,       // Use default WebSocket config (configurable via CLI flags later)
 		)
@@ -1107,6 +1095,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			utils.LogAttr("chainID", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
 			utils.LogAttr("wsEndpointCount", len(wsEndpoints)),
+			utils.LogAttr("wsBackupEndpointCount", len(wsBackupEndpoints)),
 			utils.LogAttr("optimizerEnabled", optimizer != nil),
 		)
 	} else {
@@ -1122,32 +1111,23 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 	}
 
 	// Create gRPC streaming subscription manager for gRPC server-streaming methods
-	// This supports Cosmos Event Streaming, Solana Geyser, and other gRPC streaming protocols
-	var grpcEndpoints []*common.NodeUrl
+	// This supports Cosmos Event Streaming, Solana Geyser, and other gRPC streaming protocols.
+	// Primary tier from healthy static providers; backup tier from healthy backup providers.
+	var grpcEndpoints, grpcBackupEndpoints []*common.NodeUrl
 	if rpcEndpoint.ApiInterface == spectypes.APIInterfaceGrpc {
-		// Collect gRPC endpoints from static providers
-		for _, provider := range healthyStaticProviders {
-			if provider.ApiInterface == spectypes.APIInterfaceGrpc {
-				for i := range provider.NodeUrls {
-					grpcEndpoints = append(grpcEndpoints, &provider.NodeUrls[i])
-					utils.LavaFormatInfo("Found gRPC endpoint for streaming subscriptions",
-						utils.LogAttr("url", provider.NodeUrls[i].Url),
-						utils.LogAttr("provider", provider.Name),
-						utils.LogAttr("chainID", provider.ChainID),
-					)
-				}
-			}
-		}
+		grpcEndpoints = collectGRPCEndpoints(healthyStaticProviders, "primary")
+		grpcBackupEndpoints = collectGRPCEndpoints(healthyBackupProviders, "backup")
 	}
 
-	// Initialize DirectGRPCSubscriptionManager if gRPC endpoints are available
-	if len(grpcEndpoints) > 0 {
+	// Initialize DirectGRPCSubscriptionManager if any gRPC endpoints are available
+	// (primary or backup).
+	if len(grpcEndpoints) > 0 || len(grpcBackupEndpoints) > 0 {
 		grpcSubManager := NewDirectGRPCSubscriptionManager(
 			smartRouterMetricsManager, // Metrics manager for tracking
 			rpcEndpoint.ChainID,
 			rpcEndpoint.ApiInterface,
 			grpcEndpoints,
-			nil,       // grpcBackupEndpoints — Phase 2 will populate from relevantBackupProviderList
+			grpcBackupEndpoints,
 			optimizer, // Pass optimizer for endpoint selection (same as WS manager)
 			nil,       // Use default GRPCStreamingConfig
 		)
@@ -1158,6 +1138,7 @@ func (rpsr *RPCSmartRouter) CreateSmartRouterEndpoint(
 			utils.LogAttr("chainID", rpcEndpoint.ChainID),
 			utils.LogAttr("apiInterface", rpcEndpoint.ApiInterface),
 			utils.LogAttr("grpcEndpointCount", len(grpcEndpoints)),
+			utils.LogAttr("grpcBackupEndpointCount", len(grpcBackupEndpoints)),
 			utils.LogAttr("optimizerEnabled", optimizer != nil),
 		)
 	}
@@ -2039,4 +2020,47 @@ func testModeWarn(desc string) {
 	utils.LavaFormatWarning("------------------------------test mode --------------------------------\n\t\t\t"+
 		desc+"\n\t\t\t"+
 		"------------------------------test mode --------------------------------\n", nil)
+}
+
+// collectWSEndpoints returns every ws://|wss:// NodeUrl from the given providers.
+// tierLabel ("primary" / "backup") is logged so operators can see which tier each
+// endpoint came from.
+func collectWSEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tierLabel string) []*common.NodeUrl {
+	var endpoints []*common.NodeUrl
+	for _, provider := range providers {
+		for i := range provider.NodeUrls {
+			url := strings.ToLower(provider.NodeUrls[i].Url)
+			if strings.HasPrefix(url, "ws://") || strings.HasPrefix(url, "wss://") {
+				endpoints = append(endpoints, &provider.NodeUrls[i])
+				utils.LavaFormatInfo("Found WebSocket endpoint for direct subscriptions",
+					utils.LogAttr("tier", tierLabel),
+					utils.LogAttr("url", provider.NodeUrls[i].Url),
+					utils.LogAttr("provider", provider.Name),
+					utils.LogAttr("chainID", provider.ChainID),
+				)
+			}
+		}
+	}
+	return endpoints
+}
+
+// collectGRPCEndpoints returns every NodeUrl from providers whose ApiInterface is gRPC.
+// tierLabel ("primary" / "backup") is logged for operator visibility.
+func collectGRPCEndpoints(providers []*lavasession.RPCStaticProviderEndpoint, tierLabel string) []*common.NodeUrl {
+	var endpoints []*common.NodeUrl
+	for _, provider := range providers {
+		if provider.ApiInterface != spectypes.APIInterfaceGrpc {
+			continue
+		}
+		for i := range provider.NodeUrls {
+			endpoints = append(endpoints, &provider.NodeUrls[i])
+			utils.LavaFormatInfo("Found gRPC endpoint for streaming subscriptions",
+				utils.LogAttr("tier", tierLabel),
+				utils.LogAttr("url", provider.NodeUrls[i].Url),
+				utils.LogAttr("provider", provider.Name),
+				utils.LogAttr("chainID", provider.ChainID),
+			)
+		}
+	}
+	return endpoints
 }


### PR DESCRIPTION
# Description

- Adds a two-tier (primary → backup) endpoint cascade to `DirectWSSubscriptionManager` and `DirectGRPCSubscriptionManager`, matching the HTTP backup-provider model already used by `ConsumerSessionManager`.
- Backup endpoints are consulted only when the primary tier is exhausted; sticky-session lookups span both tiers via a unified URL map.
- `CreateSmartRouterEndpoint` now harvests WS/gRPC URLs from `healthyBackupProviders` in addition to `healthyStaticProviders` and wires them into the new manager constructors. Endpoint collection is factored into shared `collectWSEndpoints` / `collectGRPCEndpoints` helpers that log the tier each endpoint came from.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage