### PR TITLE
fix(statetracker): return error from NewStateTracker instead of nil-deref

### DIFF
--- a/protocol/statetracker/state_tracker.go
+++ b/protocol/statetracker/state_tracker.go
@@ -284,9 +284,11 @@ func NewStateTracker(ctx context.Context, txFactory tx.Factory, stateQuery *upda
 	cst.AverageBlockTime = chainTrackerConfig.AverageBlockTime
 	cst.chainTracker, err = chaintracker.NewChainTracker(ctx, chainFetcher, chainTrackerConfig)
 	if err != nil {
-		return nil, err
+		return nil, utils.LavaFormatError("failed setting up chain tracker", err)
 	}
-	cst.chainTracker.StartAndServe(ctx)
+	if err := cst.chainTracker.StartAndServe(ctx); err != nil {
+		return nil, utils.LavaFormatError("failed starting chain tracker", err)
+	}
 	cst.chainTracker.RegisterForBlockTimeUpdates(cst) // registering for block time updates.
 	return cst, nil
 }

--- a/protocol/statetracker/state_tracker.go
+++ b/protocol/statetracker/state_tracker.go
@@ -283,9 +283,12 @@ func NewStateTracker(ctx context.Context, txFactory tx.Factory, stateQuery *upda
 	}
 	cst.AverageBlockTime = chainTrackerConfig.AverageBlockTime
 	cst.chainTracker, err = chaintracker.NewChainTracker(ctx, chainFetcher, chainTrackerConfig)
+	if err != nil {
+		return nil, err
+	}
 	cst.chainTracker.StartAndServe(ctx)
 	cst.chainTracker.RegisterForBlockTimeUpdates(cst) // registering for block time updates.
-	return cst, err
+	return cst, nil
 }
 
 func (st *StateTracker) UpdateBlockTime(blockTime time.Duration) {


### PR DESCRIPTION
Fixes #2282.

`NewStateTracker` ignored the error from `chaintracker.NewChainTracker` and immediately called `StartAndServe` on the returned tracker. When NewChainTracker fails (e.g., bad node URL), `cst.chainTracker` is nil and the next line panics during `lavap` startup. Return the error instead.