### PR TITLE
feat(headers): add lava-cu-used response header

### DIFF
--- a/protocol/common/endpoints.go
+++ b/protocol/common/endpoints.go
@@ -29,6 +29,7 @@ const (
 	REPORTED_PROVIDERS_HEADER_NAME                  = "Lava-Reported-Providers"
 	LAVA_RELAY_PROTOCOL_HEADER_NAME                 = "Lava-Relay-Protocol"
 	USER_REQUEST_TYPE                               = "lava-user-request-type"
+	LAVA_CU_USED_HEADER                             = "lava-cu-used"
 	STATEFUL_API_HEADER                             = "lava-stateful-api"
 	STATEFUL_ALL_PROVIDERS_HEADER_NAME              = "lava-fast-tx-participants"
 	REQUESTED_BLOCK_HEADER_NAME                     = "lava-parsed-requested-block"

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -2145,6 +2145,16 @@ func (rpccs *RPCConsumerServer) appendHeadersToRelayResult(ctx context.Context, 
 			Value: apiName,
 		})
 
+	cuUsed := chainlib.GetComputeUnits(protocolMessage)
+	if relayResult.IsUnsupportedMethod {
+		cuUsed = 0
+	}
+	metadataReply = append(metadataReply,
+		pairingtypes.Metadata{
+			Name:  common.LAVA_CU_USED_HEADER,
+			Value: strconv.FormatUint(cuUsed, 10),
+		})
+
 	// add is node error flag
 	if relayResult.IsNodeError {
 		metadataReply = append(metadataReply,

--- a/protocol/rpcconsumer/rpcconsumer_server_test.go
+++ b/protocol/rpcconsumer/rpcconsumer_server_test.go
@@ -284,8 +284,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true, false)
 
-		// Verify the result - should have single provider header + user request type header
-		require.Len(t, relayResult.Reply.Metadata, 2)
+		// Verify the result - should have single provider header + user request type header + CU used header
+		require.Len(t, relayResult.Reply.Metadata, 3)
 
 		// Find the provider address header
 		var providerHeader *pairingtypes.Metadata
@@ -330,8 +330,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, false, false)
 
-		// Verify the result - should have status, all-providers, agreeing-providers, and user request type headers
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have status, all-providers, agreeing-providers, user request type, CU used headers
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -392,8 +392,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true, false)
 
-		// Verify the result - should have 4 headers: status, all-providers, agreeing-providers, user-request-type
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have 5 headers: status, all-providers, agreeing-providers, user-request-type, cu-used
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find all CV headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -455,8 +455,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, false, false)
 
-		// Verify the result - should have 4 headers (status, all-providers, agreeing-providers, user-request-type)
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have 5 headers (status, all-providers, agreeing-providers, user-request-type, cu-used)
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -710,6 +710,67 @@ func TestRetryCountHeader(t *testing.T) {
 	})
 }
 
+// TestCuUsedHeader verifies that the lava-cu-used header reflects the spec
+// CU per request, except for unsupported-method node errors where it must be
+// 0 to match the on-chain billing carve-out.
+func TestCuUsedHeader(t *testing.T) {
+	ctx := context.Background()
+
+	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+		for i := range metadata {
+			if metadata[i].Name == name {
+				return &metadata[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("supported method - header reports spec CU", func(t *testing.T) {
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"}},
+			},
+		}
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcConsumerServer := &RPCConsumerServer{}
+		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber", ComputeUnits: 10},
+		}, "eth_blockNumber", nil, true, false)
+
+		cuHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_CU_USED_HEADER)
+		require.NotNil(t, cuHeader)
+		require.Equal(t, "10", cuHeader.Value)
+	})
+
+	t.Run("unsupported method - header reports 0 CU", func(t *testing.T) {
+		relayProcessor := &MockRelayProcessorForHeaders{
+			nodeErrors: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"}},
+			},
+		}
+		relayResult := &common.RelayResult{
+			ProviderInfo:        common.ProviderInfo{ProviderAddress: "lava@provider1"},
+			Reply:               &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+			IsNodeError:         true,
+			IsUnsupportedMethod: true,
+			IsNonRetryable:      true,
+		}
+
+		rpcConsumerServer := &RPCConsumerServer{}
+		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "seth_blockNumber", ComputeUnits: 10},
+		}, "seth_blockNumber", nil, false, false)
+
+		cuHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_CU_USED_HEADER)
+		require.NotNil(t, cuHeader)
+		require.Equal(t, "0", cuHeader.Value)
+	})
+}
+
 // TestStatefulRelayTargetsHeader tests the stateful API header functionality
 func TestStatefulRelayTargetsHeader(t *testing.T) {
 	ctx := context.Background()
@@ -757,7 +818,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		// 2. Stateful API header
 		// 3. Stateful all providers header
 		// 4. User request type header
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// 5. CU used header
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify the stateful API header
 		var statefulHeader *pairingtypes.Metadata
@@ -823,7 +885,7 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_sendRawTransaction", nil, true, false)
 
 		// Verify the result
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify the stateful all providers header
 		var allProvidersHeader *pairingtypes.Metadata
@@ -873,8 +935,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_sendTransaction", nil, true, false)
 
 		// Verify the result - should NOT have stateful all providers header (empty list)
-		// Should have: single provider header, stateful API header, user request type header
-		require.Len(t, relayResult.Reply.Metadata, 3)
+		// Should have: single provider header, stateful API header, user request type header, CU used header
+		require.Len(t, relayResult.Reply.Metadata, 4)
 
 		// Verify stateful all providers header is NOT present
 		for _, meta := range relayResult.Reply.Metadata {
@@ -928,8 +990,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		// Call the function
 		rpcConsumerServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_getBlockByNumber", nil, true, false)
 
-		// Verify the result - should only have: single provider header + user request type header
-		require.Len(t, relayResult.Reply.Metadata, 2)
+		// Verify the result - should only have: single provider header + user request type header + CU used header
+		require.Len(t, relayResult.Reply.Metadata, 3)
 
 		// Verify NO stateful headers are present
 		for _, meta := range relayResult.Reply.Metadata {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -2263,6 +2263,16 @@ func (rpcss *RPCSmartRouterServer) appendHeadersToRelayResult(ctx context.Contex
 			Value: apiName,
 		})
 
+	cuUsed := chainlib.GetComputeUnits(protocolMessage)
+	if relayResult.IsUnsupportedMethod {
+		cuUsed = 0
+	}
+	metadataReply = append(metadataReply,
+		pairingtypes.Metadata{
+			Name:  common.LAVA_CU_USED_HEADER,
+			Value: strconv.FormatUint(cuUsed, 10),
+		})
+
 	// add is node error flag
 	if relayResult.IsNodeError {
 		metadataReply = append(metadataReply,

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server_test.go
@@ -94,8 +94,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true)
 
-		// Verify the result - should have single provider header + user request type header
-		require.Len(t, relayResult.Reply.Metadata, 2)
+		// Verify the result - should have single provider header + user request type header + CU used header
+		require.Len(t, relayResult.Reply.Metadata, 3)
 
 		// Find the provider address header
 		var providerHeader *pairingtypes.Metadata
@@ -141,8 +141,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true)
 
-		// Verify the result - should have status, all-providers, agreeing-providers, and user request type headers
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have status, all-providers, agreeing-providers, user request type, CU used headers
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -204,8 +204,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true)
 
-		// Verify the result - should have 4 headers: status, all-providers, agreeing-providers, user-request-type
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have 5 headers: status, all-providers, agreeing-providers, user-request-type, cu-used
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find all CV headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -267,8 +267,8 @@ func TestAppendHeadersToRelayResultIntegration(t *testing.T) {
 		// Call the function
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "test-api", nil, true)
 
-		// Verify the result - should have 4 headers (status, all-providers, agreeing-providers, user-request-type)
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// Verify the result - should have 5 headers (status, all-providers, agreeing-providers, user-request-type, cu-used)
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify headers
 		var statusHeader, allProvidersHeader, agreeingProvidersHeader *pairingtypes.Metadata
@@ -519,6 +519,67 @@ func TestRetryCountHeader(t *testing.T) {
 	})
 }
 
+// TestCuUsedHeader verifies that the lava-cu-used header reflects the spec
+// CU per request, except for unsupported-method node errors where it must be
+// 0 to match the on-chain billing carve-out.
+func TestCuUsedHeader(t *testing.T) {
+	ctx := context.Background()
+
+	findHeader := func(metadata []pairingtypes.Metadata, name string) *pairingtypes.Metadata {
+		for i := range metadata {
+			if metadata[i].Name == name {
+				return &metadata[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("supported method - header reports spec CU", func(t *testing.T) {
+		relayProcessor := &MockRelayProcessorForHeaders{
+			successResults: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"}},
+			},
+		}
+		relayResult := &common.RelayResult{
+			ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"},
+			Reply:        &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "eth_blockNumber", ComputeUnits: 10},
+		}, "eth_blockNumber", nil, true)
+
+		cuHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_CU_USED_HEADER)
+		require.NotNil(t, cuHeader)
+		require.Equal(t, "10", cuHeader.Value)
+	})
+
+	t.Run("unsupported method - header reports 0 CU", func(t *testing.T) {
+		relayProcessor := &MockRelayProcessorForHeaders{
+			nodeErrors: []common.RelayResult{
+				{ProviderInfo: common.ProviderInfo{ProviderAddress: "lava@provider1"}},
+			},
+		}
+		relayResult := &common.RelayResult{
+			ProviderInfo:        common.ProviderInfo{ProviderAddress: "lava@provider1"},
+			Reply:               &pairingtypes.RelayReply{Metadata: []pairingtypes.Metadata{}},
+			IsNodeError:         true,
+			IsUnsupportedMethod: true,
+			IsNonRetryable:      true,
+		}
+
+		rpcSmartRouterServer := &RPCSmartRouterServer{}
+		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, &MockProtocolMessage{
+			api: &spectypes.Api{Name: "seth_blockNumber", ComputeUnits: 10},
+		}, "seth_blockNumber", nil, false)
+
+		cuHeader := findHeader(relayResult.Reply.Metadata, common.LAVA_CU_USED_HEADER)
+		require.NotNil(t, cuHeader)
+		require.Equal(t, "0", cuHeader.Value)
+	})
+}
+
 // TestStatefulRelayTargetsHeader tests the stateful API header functionality
 func TestStatefulRelayTargetsHeader(t *testing.T) {
 	ctx := context.Background()
@@ -566,7 +627,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		// 2. Stateful API header
 		// 3. Stateful all providers header
 		// 4. User request type header
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		// 5. CU used header
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify the stateful API header
 		var statefulHeader *pairingtypes.Metadata
@@ -632,7 +694,7 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_sendRawTransaction", nil, true)
 
 		// Verify the result
-		require.Len(t, relayResult.Reply.Metadata, 4)
+		require.Len(t, relayResult.Reply.Metadata, 5)
 
 		// Find and verify the stateful all providers header
 		var allProvidersHeader *pairingtypes.Metadata
@@ -682,8 +744,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_sendTransaction", nil, true)
 
 		// Verify the result - should NOT have stateful all providers header (empty list)
-		// Should have: single provider header, stateful API header, user request type header
-		require.Len(t, relayResult.Reply.Metadata, 3)
+		// Should have: single provider header, stateful API header, user request type header, CU used header
+		require.Len(t, relayResult.Reply.Metadata, 4)
 
 		// Verify stateful all providers header is NOT present
 		for _, meta := range relayResult.Reply.Metadata {
@@ -737,8 +799,8 @@ func TestStatefulRelayTargetsHeader(t *testing.T) {
 		// Call the function
 		rpcSmartRouterServer.appendHeadersToRelayResult(ctx, relayResult, 0, relayProcessor, mockProtocolMessage, "eth_getBlockByNumber", nil, true)
 
-		// Verify the result - should only have: single provider header + user request type header
-		require.Len(t, relayResult.Reply.Metadata, 2)
+		// Verify the result - should only have: single provider header + user request type header + CU used header
+		require.Len(t, relayResult.Reply.Metadata, 3)
 
 		// Verify NO stateful headers are present
 		for _, meta := range relayResult.Reply.Metadata {


### PR DESCRIPTION
## Summary
- Adds `lava-cu-used` response header (alongside the existing `lava-user-request-type`) reporting the CU charged for each relay, in both `rpcconsumer` and `rpcsmartrouter` paths.
- Reports `chainlib.GetComputeUnits(protocolMessage)` per request, zeroed for `IsUnsupportedMethod` to mirror the on-chain billing carve-out in the retry state machine.
- Cache hits intentionally report full spec CU — per the policy of "charge per request to the consumer."

## Test plan
- [x] `go test ./protocol/rpcconsumer/ -count=1` (passes, 77s)
- [x] `go test ./protocol/rpcsmartrouter/ -count=1` (passes, 75s)
- [x] New `TestCuUsedHeader` covers both branches (supported method → spec CU, unsupported method → 0)
- [x] Existing `TestAppendHeadersToRelayResultIntegration` and `TestStatefulRelayTargetsHeader` updated for the additional header

🤖 Generated with [Claude Code](https://claude.com/claude-code)