### PR TITLE
feat: Added OpenTelemetry tracing for Lava

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/tidwall/gjson v1.16.0
 	github.com/tidwall/sjson v1.2.5
 	go.opentelemetry.io/contrib/exporters/autoexport v0.63.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
 	go.opentelemetry.io/otel/log v0.14.0
@@ -154,7 +155,6 @@ require (
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.63.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0 // indirect

--- a/protocol/chainlib/chainproxy/connector.go
+++ b/protocol/chainlib/chainproxy/connector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/utils/sigs"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -253,7 +254,7 @@ func (connector *GRPCConnector) increaseNumberOfClients(ctx context.Context, num
 	var err error
 	for connectionAttempt := 0; connectionAttempt < MaximumNumberOfParallelConnectionsAttempts; connectionAttempt++ {
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
-		grpcClient, err = grpc.DialContext(nctx, connector.nodeUrl.Url, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+		grpcClient, err = grpc.DialContext(nctx, connector.nodeUrl.Url, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 		if err != nil {
 			utils.LavaFormatDebug("increaseNumberOfClients, Could not connect to the node, retrying", []utils.Attribute{{Key: "err", Value: err.Error()}, {Key: "Number Of Attempts", Value: connectionAttempt}, {Key: "nodeUrl", Value: connector.nodeUrl.UrlStr()}}...)
 			cancel()
@@ -400,7 +401,7 @@ func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl co
 			return nil, ctx.Err()
 		}
 		nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
-		rpcClient, err = grpc.DialContext(nctx, addr, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+		rpcClient, err = grpc.DialContext(nctx, addr, grpc.WithBlock(), connector.getTransportCredentials(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 		cancel()
 		if err == nil {
 			return rpcClient, nil
@@ -414,7 +415,7 @@ func (connector *GRPCConnector) createConnection(ctx context.Context, nodeUrl co
 			}
 			nctx, cancel := connector.nodeUrl.LowerContextTimeoutWithDuration(ctx, common.AverageWorldLatency*2)
 			var errNew error
-			rpcClient, errNew = grpc.DialContext(nctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(credentialsToConnect), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)))
+			rpcClient, errNew = grpc.DialContext(nctx, addr, grpc.WithBlock(), grpc.WithTransportCredentials(credentialsToConnect), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallRecvMsgSize)), grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 			cancel()
 			if errNew == nil {
 				// this means our endpoint is TLS, and we support upgrading even if the config didn't explicitly say it

--- a/protocol/chainlib/chainproxy/rpcclient/headers.go
+++ b/protocol/chainlib/chainproxy/rpcclient/headers.go
@@ -1,0 +1,33 @@
+package rpcclient
+
+import (
+	"context"
+	"net/http"
+)
+
+type headersCtxKey struct{}
+
+// WithHeaders returns a new context carrying per-request HTTP headers that
+// will be merged with the client's default headers on the next CallContext /
+// BatchCallContext call. Use this for per-request data (e.g. W3C trace
+// context) that must not leak across concurrent calls on the shared client
+// — SetHeader mutates connection-wide state and races under concurrency.
+//
+// Headers set here take precedence over equally-named defaults set via
+// (*Client).SetHeader.
+func WithHeaders(ctx context.Context, headers http.Header) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, headersCtxKey{}, headers)
+}
+
+// headersFromContext returns the per-request headers attached via WithHeaders.
+// Returns nil when none are set. Internal to the package.
+func headersFromContext(ctx context.Context) http.Header {
+	if ctx == nil {
+		return nil
+	}
+	h, _ := ctx.Value(headersCtxKey{}).(http.Header)
+	return h
+}

--- a/protocol/chainlib/chainproxy/rpcclient/headers_test.go
+++ b/protocol/chainlib/chainproxy/rpcclient/headers_test.go
@@ -1,0 +1,68 @@
+package rpcclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentRequestsCarryOwnHeaders is the regression test for the
+// traceparent-race fix: under concurrent CallContext calls on a shared
+// client, each request must receive only the headers attached to its own
+// ctx, with no leakage from concurrent calls.
+func TestConcurrentRequestsCarryOwnHeaders(t *testing.T) {
+	const N = 50
+
+	// Collect traceparent headers seen by the server, one entry per request.
+	var (
+		mu         sync.Mutex
+		gotHeaders []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tp := r.Header.Get("traceparent")
+		mu.Lock()
+		gotHeaders = append(gotHeaders, tp)
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	client, err := DialHTTP(srv.URL)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			h := http.Header{}
+			tp := fmt.Sprintf("00-00000000000000000000000000%06d-1234567890abcdef-01", idx)
+			h.Set("traceparent", tp)
+			ctx := WithHeaders(context.Background(), h)
+			_, _ = client.CallContext(ctx, []byte("1"), "test_method", []interface{}{idx}, true, false)
+		}(i)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, gotHeaders, N, "expected %d requests to reach the server", N)
+
+	// Every traceparent must be distinct — if headers leaked across goroutines,
+	// we'd see duplicates or mismatched values.
+	distinct := make(map[string]struct{}, N)
+	for _, tp := range gotHeaders {
+		distinct[tp] = struct{}{}
+	}
+	require.Equal(t, N, len(distinct),
+		"concurrent requests leaked headers — saw %d requests but only %d distinct traceparents",
+		N, len(distinct))
+}

--- a/protocol/chainlib/chainproxy/rpcclient/http.go
+++ b/protocol/chainlib/chainproxy/rpcclient/http.go
@@ -232,6 +232,16 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}, isJsonRPC bo
 	req.Header = hc.headers.Clone()
 	hc.mu.Unlock()
 
+	// Merge per-request headers (e.g. W3C trace context) without touching the
+	// shared client state — safe under concurrent calls on this client.
+	if reqHeaders := headersFromContext(ctx); reqHeaders != nil {
+		for k, vv := range reqHeaders {
+			for _, v := range vv {
+				req.Header.Set(k, v)
+			}
+		}
+	}
+
 	// do request
 	resp, err := hc.client.Do(req)
 	if resp != nil {

--- a/protocol/chainlib/common.go
+++ b/protocol/chainlib/common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
 	common "github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/protocol/metrics"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
@@ -480,6 +481,7 @@ func createAndSetupBaseAppListener(cmdFlags common.ConsumerCmdFlags, healthCheck
 		JSONDecoder: json.Unmarshal,
 	})
 	app.Use(favicon.New())
+	app.Use(tracing.FiberMiddleware())
 	applyResponseCompression(app, cmdFlags.ResponseCompression)
 	app.Use(func(c *fiber.Ctx) error {
 		// we set up wild card by default.

--- a/protocol/chainlib/consumer_ws_subscription_tracing_test.go
+++ b/protocol/chainlib/consumer_ws_subscription_tracing_test.go
@@ -1,0 +1,88 @@
+package chainlib
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWSPushEventForwardingHasNoTracing is a regression guard for the OTel
+// tracing design: server-pushed subscription events (the long-lived stream
+// from provider to consumer to WS client) must NOT create per-message spans.
+// Each pushed event in a high-volume subscription (e.g. eth_subscribe newHeads
+// on a busy chain) would otherwise produce ~10-15 spans, flooding the trace
+// backend.
+//
+// The test parses consumer_ws_subscription_manager.go and asserts that the
+// push-event-forwarding functions contain no calls to tracing.Start* helpers.
+// If a future change accidentally adds tracing on the push path, this test
+// fails before the change ships.
+//
+// Functions audited:
+//   - listenForSubscriptionMessages: contains the replyServer.RecvMsg loop
+//     that reads pushed events from the provider's gRPC stream.
+//   - handleIncomingSubscriptionNodeMessage: called for each received reply
+//     to forward it to the WS client.
+//   - verifySubscriptionMessage: signature verification on each pushed reply.
+//
+// Client-initiated message paths (e.g. StartSubscription, Unsubscribe,
+// sendUnsubscribeMessage) are NOT audited — those represent real client
+// operations that SHOULD be traced via ParseRelay/SendParsedRelay, matching
+// the spec's "trace handshake-class events" intent.
+func TestWSPushEventForwardingHasNoTracing(t *testing.T) {
+	const file = "consumer_ws_subscription_manager.go"
+	pushEventFunctions := map[string]bool{
+		"listenForSubscriptionMessages":        true,
+		"handleIncomingSubscriptionNodeMessage": true,
+		"verifySubscriptionMessage":            true,
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
+	require.NoError(t, err, "could not parse %s — has the file moved?", file)
+
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || fn.Name == nil {
+			continue
+		}
+		if !pushEventFunctions[fn.Name.Name] {
+			continue
+		}
+
+		// Walk the function body looking for tracing.Start* call expressions.
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if pkg.Name == "tracing" && strings.HasPrefix(sel.Sel.Name, "Start") {
+				pos := fset.Position(call.Pos())
+				t.Errorf(
+					"%s:%d — found tracing.%s call inside %s; push-event forwarding must not produce per-message spans (see spec section 3.5)",
+					pos.Filename, pos.Line, sel.Sel.Name, fn.Name.Name,
+				)
+			}
+			return true
+		})
+
+		delete(pushEventFunctions, fn.Name.Name)
+	}
+
+	// Catch renames: every audited function must have been found.
+	for fnName := range pushEventFunctions {
+		t.Errorf("audited function %q not found in %s — has it been renamed? Update the test or the rename is a real bug.", fnName, file)
+	}
+}

--- a/protocol/chainlib/consumer_ws_subscription_tracing_test.go
+++ b/protocol/chainlib/consumer_ws_subscription_tracing_test.go
@@ -36,9 +36,9 @@ import (
 func TestWSPushEventForwardingHasNoTracing(t *testing.T) {
 	const file = "consumer_ws_subscription_manager.go"
 	pushEventFunctions := map[string]bool{
-		"listenForSubscriptionMessages":        true,
+		"listenForSubscriptionMessages":         true,
 		"handleIncomingSubscriptionNodeMessage": true,
-		"verifySubscriptionMessage":            true,
+		"verifySubscriptionMessage":             true,
 	}
 
 	fset := token.NewFileSet()

--- a/protocol/chainlib/grpc.go
+++ b/protocol/chainlib/grpc.go
@@ -35,6 +35,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
@@ -416,6 +417,13 @@ func newGrpcChainProxy(ctx context.Context, averageBlockTime time.Duration, pars
 }
 
 func (cp *GrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *RelayReplyWrapper, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
+	ctx, span := tracing.StartClientSpan(ctx, tracing.SpanChainproxyGRPC)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	if ch != nil {
 		return nil, "", nil, utils.LavaFormatError("Subscribe is not allowed on grpc", nil, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: utils.KEY_REQUEST_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TASK_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TRANSACTION_ID, Value: ctx})
 	}

--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/utils"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
@@ -37,7 +38,13 @@ func NewGRPCProxy(cb ProxyCallBack, healthCheckPath string, cmdFlags common.Cons
 // This enables tools like grpcurl to work with the smart router.
 func NewGRPCProxyWithReflection(cb ProxyCallBack, healthCheckPath string, cmdFlags common.ConsumerCmdFlags, healthReporter HealthReporter, reflectionCallback ReflectionProxyCallback) (*grpc.Server, *http.Server, error) {
 	serverReceiveMaxMessageSize := grpc.MaxRecvMsgSize(MaxCallRecvMsgSize) // setting receive size to 32mb instead of 4mb default
-	s := grpc.NewServer(grpc.UnknownServiceHandler(makeProxyFunc(cb)), grpc.ForceServerCodec(RawBytesCodec{}), serverReceiveMaxMessageSize)
+	serverOpts := []grpc.ServerOption{
+		grpc.UnknownServiceHandler(makeProxyFunc(cb)),
+		grpc.ForceServerCodec(RawBytesCodec{}),
+		serverReceiveMaxMessageSize,
+	}
+	serverOpts = append(serverOpts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
+	s := grpc.NewServer(serverOpts...)
 	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
 
 	wrappedServer := grpcweb.WrapServer(s)

--- a/protocol/chainlib/jsonRPC.go
+++ b/protocol/chainlib/jsonRPC.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
 	"github.com/lavanet/lava/v5/protocol/parser"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
@@ -426,7 +427,7 @@ func (apil *JsonRPCChainListener) Serve(ctx context.Context, cmdFlags common.Con
 		dappID := extractDappIDFromFiberContext(fiberCtx)
 		metricsData := metrics.NewRelayAnalytics(dappID, chainID, apiInterface)
 		metricsData.SetProcessingTimestampBeforeRelay(startTime)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(fiberCtx.UserContext())
 		defer cancel()
 		guid := utils.GenerateUniqueIdentifier()
 		ctx = utils.WithUniqueIdentifier(ctx, guid)
@@ -664,6 +665,13 @@ func (cp *JrpcChainProxy) sendBatchMessage(ctx context.Context, nodeMessage *rpc
 }
 
 func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *RelayReplyWrapper, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
+	ctx, span := tracing.StartClientSpan(ctx, tracing.SpanChainproxyJSONRPC)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	rpcInputMessage := chainMessage.GetRPCMessage()
 	nodeMessage, ok := rpcInputMessage.(*rpcInterfaceMessages.JsonrpcMessage)
 	if !ok {
@@ -702,6 +710,19 @@ func (cp *JrpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, 
 				defer rpc.SetHeader(metadata.Name, "")
 			}
 		}
+	}
+	// Inject W3C trace context as per-request headers via context. Using
+	// rpc.SetHeader for this would race under concurrent relays since the
+	// rpcclient is shared (Connector.GetRpc returns the same instance) — the
+	// (set, send, clear) sequence isn't atomic.
+	otelHeaders := map[string]string{}
+	tracing.InjectGRPC(ctx, otelHeaders)
+	if len(otelHeaders) > 0 {
+		h := make(http.Header, len(otelHeaders))
+		for k, v := range otelHeaders {
+			h.Set(k, v)
+		}
+		ctx = rpcclient.WithHeaders(ctx, h)
 	}
 	var nodeErr error
 	if ch != nil {

--- a/protocol/chainlib/rest.go
+++ b/protocol/chainlib/rest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/chainlib/extensionslib"
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/parser"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -275,7 +276,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		// Cache headers once at the start to avoid repeated lookups
 		metadataValues := fiberCtx.GetReqHeaders()
 		restHeaders := convertToMetadataMap(metadataValues)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(fiberCtx.UserContext())
 		ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())
 		ctx = utils.ExtractWantedHeadersFromCachedMap(metadataValues, ctx)
 		defer cancel() // incase there's a problem make sure to cancel the connection
@@ -351,7 +352,7 @@ func (apil *RestChainListener) Serve(ctx context.Context, cmdFlags common.Consum
 		// Cache headers once at the start to avoid repeated lookups
 		metadataValues := fiberCtx.GetReqHeaders()
 		restHeaders := convertToMetadataMap(metadataValues)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(fiberCtx.UserContext())
 		ctx = utils.WithUniqueIdentifier(ctx, utils.GenerateUniqueIdentifier())
 		ctx = utils.ExtractWantedHeadersFromCachedMap(metadataValues, ctx)
 		guid, found := utils.GetUniqueIdentifier(ctx)
@@ -451,6 +452,13 @@ func NewRestChainProxy(ctx context.Context, nConns uint, rpcProviderEndpoint lav
 }
 
 func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *RelayReplyWrapper, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
+	ctx, span := tracing.StartClientSpan(ctx, tracing.SpanChainproxyREST)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	if ch != nil {
 		return nil, "", nil, utils.LavaFormatError("Subscribe is not allowed on rest", nil)
 	}
@@ -508,6 +516,12 @@ func (rcp *RestChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{},
 		utils.LogAttr("apiInterface", "rest"),
 	)
 
+	// Inject W3C trace context into outbound upstream-node HTTP headers.
+	otelHeaders := map[string]string{}
+	tracing.InjectGRPC(ctx, otelHeaders)
+	for name, value := range otelHeaders {
+		req.Header.Set(name, value)
+	}
 	res, err := httpClient.Do(req)
 	if res != nil {
 		// resp can be non nil on error

--- a/protocol/chainlib/tendermintRPC.go
+++ b/protocol/chainlib/tendermintRPC.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
 	"github.com/lavanet/lava/v5/protocol/parser"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
@@ -447,7 +448,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 		dappID := extractDappIDFromFiberContext(fiberCtx)
 		metricsData := metrics.NewRelayAnalytics(dappID, chainID, apiInterface)
 		metricsData.SetProcessingTimestampBeforeRelay(startTime)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(fiberCtx.UserContext())
 		guid := utils.GenerateUniqueIdentifier()
 		ctx = utils.WithUniqueIdentifier(ctx, guid)
 		defer cancel() // incase there's a problem make sure to cancel the connection
@@ -525,7 +526,7 @@ func (apil *TendermintRpcChainListener) Serve(ctx context.Context, cmdFlags comm
 		query := "?" + string(fiberCtx.Request().URI().QueryString())
 		path := fiberCtx.Params("*")
 		dappID := extractDappIDFromFiberContext(fiberCtx)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(fiberCtx.UserContext())
 		guid := utils.GenerateUniqueIdentifier()
 		ctx = utils.WithUniqueIdentifier(ctx, guid)
 		defer cancel() // incase there's a problem make sure to cancel the connection
@@ -628,6 +629,13 @@ func NewtendermintRpcChainProxy(ctx context.Context, nConns uint, rpcProviderEnd
 }
 
 func (cp *tendermintRpcChainProxy) SendNodeMsg(ctx context.Context, ch chan interface{}, chainMessage ChainMessageForSend) (relayReply *RelayReplyWrapper, subscriptionID string, relayReplyServer *rpcclient.ClientSubscription, err error) {
+	ctx, span := tracing.StartClientSpan(ctx, tracing.SpanChainproxyTendermintRPC)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	rpcInputMessage := chainMessage.GetRPCMessage()
 	nodeMessage, ok := rpcInputMessage.(*rpcInterfaceMessages.TendermintrpcMessage)
 	if !ok {
@@ -697,6 +705,13 @@ func (cp *tendermintRpcChainProxy) SendURI(ctx context.Context, nodeMessage *rpc
 	cp.NodeUrl.SetAuthHeaders(ctx, req.Header.Set)
 
 	cp.NodeUrl.SetIpForwardingIfNecessary(ctx, req.Header.Set)
+
+	// Inject W3C trace context into outbound upstream-node HTTP headers.
+	otelHeaders := map[string]string{}
+	tracing.InjectGRPC(ctx, otelHeaders)
+	for name, value := range otelHeaders {
+		req.Header.Set(name, value)
+	}
 	// send the http request and get the response
 	res, err := httpClient.Do(req)
 	if res != nil {
@@ -761,6 +776,21 @@ func (cp *tendermintRpcChainProxy) SendRPC(ctx context.Context, nodeMessage *rpc
 			rpc.SetHeader(metadata.Name, metadata.Value)
 			// clear this header upon function completion so it doesn't last in the next usage from the rpc pool
 			defer rpc.SetHeader(metadata.Name, "")
+		}
+	}
+	// Inject W3C trace context as per-request headers via context. Using
+	// rpc.SetHeader for this would race under concurrent relays since the
+	// rpcclient is shared (Connector.GetRpc returns the same instance) — the
+	// (set, send, clear) sequence isn't atomic.
+	{
+		otelHeaders := map[string]string{}
+		tracing.InjectGRPC(ctx, otelHeaders)
+		if len(otelHeaders) > 0 {
+			h := make(http.Header, len(otelHeaders))
+			for k, v := range otelHeaders {
+				h.Set(k, v)
+			}
+			ctx = rpcclient.WithHeaders(ctx, h)
 		}
 	}
 	// If ch is not nil do subscription

--- a/protocol/lavasession/common.go
+++ b/protocol/lavasession/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/x/pairing/keeper/scores"
 	planstypes "github.com/lavanet/lava/v5/x/plans/types"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -98,6 +99,8 @@ func ConnectGRPCClient(ctx context.Context, address string, allowInsecure bool, 
 			grpc.UseCompressor(gzip.Name), // Use gzip compression for provider consumer communication
 		))
 	}
+
+	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 
 	conn, err := grpc.DialContext(ctx, address, opts...)
 	return conn, err

--- a/protocol/rpcconsumer/README.md
+++ b/protocol/rpcconsumer/README.md
@@ -240,3 +240,46 @@ See the `config/consumer_examples/` directory for complete configuration example
 - [Consumer Configuration Guide](../../config/consumer_examples/)
 - [RPC Smart Router](../rpcsmartrouter) - Centralized alternative
 - [Protocol Overview](../README.md)
+
+## Observability / Tracing
+
+Both `rpcconsumer` and `rpcprovider` emit OpenTelemetry traces by default
+when an OTLP endpoint is configured. Disable with `OTEL_SDK_DISABLED=true`
+or `OTEL_TRACES_EXPORTER=none`.
+
+### Quick start
+
+```bash
+OTEL_SERVICE_NAME=my-consumer-eu \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com:4317 \
+./lavap rpcconsumer ...
+```
+
+### Recording request/response bodies
+
+Add `--otel-trace-body` to record relay request and response bodies on
+spans. Body size is bounded by `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+(default: unlimited; set to e.g. `4096` for 4 KiB cap).
+
+### Same-machine deployments
+
+If consumer and provider run on the same host, **do not** set
+`OTEL_SERVICE_NAME` in a shared environment file. Each binary's
+in-code default (`lava-consumer`, `lava-provider`) gives them
+distinct service identities.
+
+For per-deployment labelling without overriding service.name:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=region=eu-west-1,deployment=prod-1
+```
+
+### Sampling
+
+Defaults to `parentbased_always_on`. For high-volume deployments tune via:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1   # 10% of root spans
+```

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/relaycore"
 	"github.com/lavanet/lava/v5/protocol/statetracker"
 	"github.com/lavanet/lava/v5/protocol/statetracker/updaters"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/protocol/upgrade"
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/utils/rand"
@@ -670,6 +671,22 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 			// handle flags, pass necessary fields
 			ctx := context.Background()
 
+			// Initialise OTel tracing. Standard OTel SDK environment variables drive
+			// all configuration (endpoint, sampler, service name, etc.); see the
+			// tracing.TraceBodyFlag doc-comment for the full list. The SDK is enabled
+			// unless OTEL_SDK_DISABLED=true or OTEL_TRACES_EXPORTER=none; when no OTLP
+			// endpoint is configured the SDK falls back to the spec default
+			// (localhost:4317 for gRPC, localhost:4318 for HTTP).
+			traceCfg := tracing.TraceConfig{
+				DefaultServiceName: "lava-consumer",
+				TraceBody:          viper.GetBool(tracing.TraceBodyFlag),
+			}
+			traceManager, err := tracing.New(ctx, traceCfg)
+			if err != nil {
+				return err
+			}
+			defer traceManager.Shutdown()
+
 			networkChainId := viper.GetString(flags.FlagChainID)
 			if networkChainId == app.Name {
 				clientTomlConfig, err := config.ReadFromClientConfig(clientCtx)
@@ -934,6 +951,22 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 	// batch request size limit
 	cmdRPCConsumer.Flags().IntVar(&chainlib.MaxBatchRequestSize, common.MaxBatchRequestSizeFlag, common.DefaultMaxBatchRequestSize, "max number of requests allowed within a batch request, 0 means unlimited")
 	cmdRPCConsumer.Flags().BoolVar(&relaycore.DisableBatchRequestRetry, common.DisableBatchRequestRetryFlag, true, "disable retries for batch requests (JSON-RPC batches)")
+
+	// OpenTelemetry tracing.
+	// All standard OTel knobs (endpoint, sampler, service name, TLS, headers, etc.)
+	// come from OTEL_* environment variables per the SDK spec — see the
+	// tracing.TraceBodyFlag doc-comment for the full list. Tracing is enabled
+	// unless OTEL_SDK_DISABLED=true or OTEL_TRACES_EXPORTER=none; when no OTLP
+	// endpoint is configured the SDK falls back to the spec default
+	// (localhost:4317 for gRPC, localhost:4318 for HTTP).
+	// --otel-trace-body is the only Lava-specific knob, exposed as a CLI flag
+	// because it's a per-invocation debug toggle rather than deployment
+	// configuration. Body size is delegated to the SDK via
+	// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT (SDK default: unlimited).
+	cmdRPCConsumer.Flags().Bool(tracing.TraceBodyFlag, false, "record request/response bodies on trace spans (size limit delegated to OTel SDK via OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT)")
+	if err := viper.BindPFlag(tracing.TraceBodyFlag, cmdRPCConsumer.Flags().Lookup(tracing.TraceBodyFlag)); err != nil {
+		utils.LavaFormatFatal("failed binding otel-trace-body flag", err)
+	}
 
 	common.AddRollingLogConfig(cmdRPCConsumer)
 	return cmdRPCConsumer

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/performance"
 	"github.com/lavanet/lava/v5/protocol/relaycore"
 	"github.com/lavanet/lava/v5/protocol/relaypolicy"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 
 	"github.com/lavanet/lava/v5/protocol/upgrade"
 	"github.com/lavanet/lava/v5/utils"
@@ -415,6 +416,17 @@ func (rpccs *RPCConsumerServer) SendRelay(
 	analytics *metrics.RelayMetrics,
 	metadata []pairingtypes.Metadata,
 ) (relayResult *common.RelayResult, errRet error) {
+	guid, _ := utils.GetUniqueIdentifier(ctx)
+	ctx, span := tracing.StartConsumerSendRelay(ctx, guid, rpccs.listenEndpoint.ChainID, rpccs.listenEndpoint.ApiInterface)
+	defer span.End()
+	if tracing.IsTraceBodyEnabled() {
+		tracing.RecordBody(span, tracing.AttrRelayRequestBody, []byte(req))
+	}
+	defer func() {
+		if errRet != nil {
+			tracing.RecordError(span, errRet)
+		}
+	}()
 	protocolMessage, err := rpccs.ParseRelay(ctx, url, req, connectionType, dappID, consumerIp, metadata)
 	if err != nil {
 		return nil, err
@@ -432,6 +444,8 @@ func (rpccs *RPCConsumerServer) ParseRelay(
 	consumerIp string,
 	metadata []pairingtypes.Metadata,
 ) (protocolMessage chainlib.ProtocolMessage, err error) {
+	ctx, span := tracing.StartConsumerParseRelay(ctx)
+	defer span.End()
 	// gets the relay request data from the ChainListener
 	// parses the request into an APIMessage, and validating it corresponds to the spec currently in use
 	// construct the common data for a relay message, common data is identical across multiple sends and data reliability
@@ -471,6 +485,13 @@ func (rpccs *RPCConsumerServer) SendParsedRelay(
 	// compares the result with other providers if defined so
 	// compares the response with other consumer wallets if defined so
 	// asynchronously sends data reliability if necessary
+	ctx, span := tracing.StartConsumerSendParsedRelay(ctx)
+	defer span.End()
+	defer func() {
+		if errRet != nil {
+			tracing.RecordError(span, errRet)
+		}
+	}()
 
 	relaySentTime := time.Now()
 	relayProcessor, err := rpccs.ProcessRelaySend(ctx, protocolMessage, analytics)
@@ -482,7 +503,15 @@ func (rpccs *RPCConsumerServer) SendParsedRelay(
 		return nil, err
 	}
 
+	// Leaf span: ProcessingResult() doesn't take ctx and creates no further
+	// instrumented work, so the new ctx returned by StartConsumerProcessingResult
+	// is intentionally discarded.
+	_, spanResult := tracing.StartConsumerProcessingResult(ctx)
 	returnedResult, err := relayProcessor.ProcessingResult()
+	if err != nil {
+		tracing.RecordError(spanResult, err)
+	}
+	spanResult.End()
 	consistencyEnforced := protocolMessage.RelayPrivateData().SeenBlock > 0
 	rpccs.appendHeadersToRelayResult(ctx, returnedResult, relayProcessor.ProtocolErrors(), relayProcessor, protocolMessage, protocolMessage.GetApi().GetName(), analytics, err == nil, consistencyEnforced)
 	if err != nil {
@@ -514,10 +543,15 @@ func (rpccs *RPCConsumerServer) GetChainIdAndApiInterface() (string, string) {
 }
 
 func (rpccs *RPCConsumerServer) ProcessRelaySend(ctx context.Context, protocolMessage chainlib.ProtocolMessage, analytics *metrics.RelayMetrics) (*relaycore.RelayProcessor, error) {
+	ctx, span := tracing.StartConsumerProcessRelaySend(ctx)
+	defer span.End()
 	// make sure all of the child contexts are cancelled when we exit
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	usedProviders := lavasession.NewUsedProviders(protocolMessage)
+	defer func() {
+		tracing.RecordRetryCount(span, usedProviders.BatchNumber()-1)
+	}()
 	usedProviders.SetChainID(rpccs.listenEndpoint.ChainID)
 	usedProviders.SetEligibilityFunc(relaypolicy.DecideEligibility)
 
@@ -896,6 +930,7 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 						utils.LogAttr("lookupFinalized", lookupFinalized),
 					)
 
+					cacheCtx, spanCache := tracing.StartConsumerCacheLookup(cacheCtx)
 					cacheStart := time.Now()
 					cacheReply, cacheError = rpccs.cache.GetEntry(cacheCtx, &pairingtypes.RelayCacheGet{
 						RequestHash:           hashKey,
@@ -909,6 +944,9 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 					}) // caching in the consumer doesn't care about hashes, and we don't have data on finalization yet
 					cancel()
 					cacheLatencyMs := float64(time.Since(cacheStart).Milliseconds())
+					cacheHit := cacheError == nil && cacheReply != nil && cacheReply.GetReply() != nil
+					tracing.RecordCacheLookup(cacheCtx, spanCache, "consumer", cacheHit, cacheLatencyMs)
+					spanCache.End()
 
 					// Generate the actual cache key that will be used for lookup
 					actualLookupCacheKey := make([]byte, len(hashKey))
@@ -1017,7 +1055,10 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 		utils.LavaFormatTrace("found stickiness header", utils.LogAttr("id", stickiness), utils.LogAttr("GUID", ctx))
 	}
 
-	sessions, err := rpccs.consumerSessionManager.GetSessions(ctx, numOfProviders, chainlib.GetComputeUnits(protocolMessage), usedProviders, reqBlock, addon, extensions, chainlib.GetStateful(protocolMessage), virtualEpoch, stickiness, "")
+	ctxSess, spanSess := tracing.StartConsumerGetSessions(ctx, numOfProviders)
+	sessions, err := rpccs.consumerSessionManager.GetSessions(ctxSess, numOfProviders, chainlib.GetComputeUnits(protocolMessage), usedProviders, reqBlock, addon, extensions, chainlib.GetStateful(protocolMessage), virtualEpoch, stickiness, "")
+	tracing.RecordSessionStats(spanSess, numOfProviders, len(sessions))
+	spanSess.End()
 	if err != nil {
 		if lavasession.PairingListEmptyError.Is(err) {
 			if addon != "" {
@@ -1102,11 +1143,12 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 				ConflictHandler: sessionInfo.Session.Parent,
 			}
 			var errResponse error
-			goroutineCtx, goroutineCtxCancel := context.WithCancel(context.Background())
-			guid, found := utils.GetUniqueIdentifier(ctx)
-			if found {
-				goroutineCtx = utils.WithUniqueIdentifier(goroutineCtx, guid)
-			}
+			// WithoutCancel carries the OTel trace context (set by chainlib.FiberMiddleware
+			// and consumer.SendRelay) into the goroutine, but breaks the cancellation
+			// chain — a client hangup must NOT abort an in-flight relay attempt because
+			// the deferred OnSessionDone/OnSessionFailure path needs to run cleanly to
+			// release the session. WithCancel on top preserves the explicit goroutineCtxCancel.
+			goroutineCtx, goroutineCtxCancel := context.WithCancel(context.WithoutCancel(ctx))
 
 			// Track if session was properly handled (OnSessionDone/OnSessionFailure called)
 			// to prevent session leaks on early returns
@@ -1220,7 +1262,7 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 				}
 			}
 			// send relay
-			relayLatency, errResponse, _ := rpccs.relayInner(goroutineCtx, singleConsumerSession, localRelayResult, processingTimeout, protocolMessage, consumerToken, analytics)
+			relayLatency, errResponse, _ := rpccs.relayInner(goroutineCtx, singleConsumerSession, localRelayResult, processingTimeout, protocolMessage, consumerToken, analytics, relayProcessor.GetUsedProviders().BatchNumber())
 			if errResponse != nil {
 				// CRITICAL: Release session IMMEDIATELY to prevent session exhaustion
 				sessionHandled.Store(true) // Mark session as handled before OnSessionFailure
@@ -1441,11 +1483,18 @@ func (rpccs *RPCConsumerServer) sendRelayToProvider(
 	return nil
 }
 
-func (rpccs *RPCConsumerServer) relayInner(ctx context.Context, singleConsumerSession *lavasession.SingleConsumerSession, relayResult *common.RelayResult, relayTimeout time.Duration, chainMessage chainlib.ChainMessage, consumerToken string, analytics *metrics.RelayMetrics) (relayLatency time.Duration, err error, needsBackoff bool) {
+func (rpccs *RPCConsumerServer) relayInner(ctx context.Context, singleConsumerSession *lavasession.SingleConsumerSession, relayResult *common.RelayResult, relayTimeout time.Duration, chainMessage chainlib.ChainMessage, consumerToken string, analytics *metrics.RelayMetrics, attempt int) (relayLatency time.Duration, err error, needsBackoff bool) {
 	existingSessionLatestBlock := singleConsumerSession.LatestBlock // we read it now because singleConsumerSession is locked, and later it's not
 	endpointClient := singleConsumerSession.EndpointConnection.Client
 	providerPublicAddress := relayResult.ProviderInfo.ProviderAddress
 	relayRequest := relayResult.Request
+	ctx, span := tracing.StartConsumerRelayInner(ctx, providerPublicAddress, attempt)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	if rpccs.debugRelays {
 		utils.LavaFormatDebug("Sending relay", utils.LogAttr("timeout", relayTimeout), utils.LogAttr("requestedBlock", relayRequest.RelayData.RequestBlock), utils.LogAttr("GUID", ctx), utils.LogAttr("provider", relayRequest.RelaySession.Provider))
 	}

--- a/protocol/rpcconsumer/rpcconsumer_server.go
+++ b/protocol/rpcconsumer/rpcconsumer_server.go
@@ -432,6 +432,10 @@ func (rpccs *RPCConsumerServer) SendRelay(
 		return nil, err
 	}
 
+	if api := protocolMessage.GetApi(); api != nil {
+		tracing.RecordRelayMethod(span, api.Name)
+	}
+
 	return rpccs.SendParsedRelay(ctx, analytics, protocolMessage)
 }
 

--- a/protocol/rpcconsumer/rpcconsumer_server_test.go
+++ b/protocol/rpcconsumer/rpcconsumer_server_test.go
@@ -192,7 +192,7 @@ func TestRelayInnerProviderUniqueIdFlow(t *testing.T) {
 	callRelayInner := func() error {
 		// Reset the trailer before each call to ensure the mock sets it fresh
 		relayResult.ProviderTrailer = nil
-		_, err, _ := rpcConsumerServer.relayInner(context.Background(), singleConsumerSession, relayResult, 1, chainMsg, "", nil)
+		_, err, _ := rpcConsumerServer.relayInner(context.Background(), singleConsumerSession, relayResult, 1, chainMsg, "", nil, 0)
 		return err
 	}
 

--- a/protocol/rpcprovider/README.md
+++ b/protocol/rpcprovider/README.md
@@ -1,0 +1,72 @@
+# RPC Provider
+
+The RPC Provider serves blockchain RPC requests from consumers on the Lava network.
+
+## Observability / Tracing
+
+`rpcprovider` emits OpenTelemetry traces by default when an OTLP endpoint is
+configured. Disable with `OTEL_SDK_DISABLED=true` or `OTEL_TRACES_EXPORTER=none`.
+
+Spans cover the relay pipeline (handle, validate, cache lookup, consistency
+wait, upstream call, finalize) plus background lava-chain communication
+(`lavachain.Query` for spec/pairing fetches, `lavachain.SubmitTx` for
+relay-payment claims). Trace context arrives via the consumer→provider gRPC
+hop and is propagated into the upstream chain-node call as a `traceparent`
+HTTP header (or gRPC metadata).
+
+### Quick start
+
+```bash
+OTEL_SERVICE_NAME=my-provider-eu-1 \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com:4317 \
+./lavap rpcprovider ...
+```
+
+If `OTEL_SERVICE_NAME` is unset, the binary uses `lava-provider` as its in-code
+default, which keeps it distinct from `lava-consumer` even when both run on
+the same host.
+
+### Recording request/response bodies
+
+Add `--otel-trace-body` to record relay request and response bodies on the
+provider's relay spans. Body size is bounded by
+`OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` (default: unlimited; set to e.g.
+`4096` for 4 KiB cap).
+
+**Caution for production providers:** relay payloads can be large (e.g.
+`eth_getLogs` responses in megabytes). Enabling body recording on a high-volume
+provider materially increases trace-export bandwidth and collector ingestion
+cost. Pair with a non-unlimited length limit or restrict to debug sessions.
+
+### Cache backend
+
+If running with `--cache-be <addr>`, the cache-lookup span carries
+`cache.hit=true|false` and a millisecond latency attribute. With no cache
+backend running, the provider correctly bypasses caching entirely — no
+`provider.CacheLookup` span is created for non-finalized methods, and
+finalized methods produce a span with `cache.hit=false` (no error).
+
+### Same-machine deployments
+
+If consumer and provider run on the same host, **do not** set
+`OTEL_SERVICE_NAME` in a shared environment file. Each binary's in-code
+default (`lava-consumer` / `lava-provider`) gives them distinct service
+identities. For per-deployment labelling without overriding `service.name`:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=region=eu-west-1,deployment=prod-1
+```
+
+### Sampling
+
+Defaults to `parentbased_always_on`. For high-volume providers, tune via:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1   # 10% of root spans
+```
+
+The `parentbased_*` family honors the consumer's sampling decision when a
+trace originates from a traced consumer relay, so consumer↔provider sampling
+stays consistent.

--- a/protocol/rpcprovider/provider_listener.go
+++ b/protocol/rpcprovider/provider_listener.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	grpc "google.golang.org/grpc"
@@ -66,6 +67,7 @@ func NewProviderListener(ctx context.Context, networkAddress lavasession.Network
 	opts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(1024 * 1024 * 512), // setting receive size to 512mb for large debug responses
 		grpc.MaxSendMsgSize(1024 * 1024 * 512), // setting send size to 512mb for large debug responses
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	}
 	grpcServer := grpc.NewServer(opts...)
 	wrappedServer := grpcweb.WrapServer(grpcServer)

--- a/protocol/rpcprovider/rpcprovider.go
+++ b/protocol/rpcprovider/rpcprovider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/rpcprovider/rewardserver"
 	"github.com/lavanet/lava/v5/protocol/statetracker"
 	"github.com/lavanet/lava/v5/protocol/statetracker/updaters"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/protocol/upgrade"
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/utils/lavaslices"
@@ -889,6 +890,19 @@ rpcprovider 127.0.0.1:3333 OSMOSIS tendermintrpc "wss://www.node-path.com:80,htt
 			// handle flags, pass necessary fields
 			ctx := context.Background()
 
+			// Initialise OTel tracing. Standard OTel SDK environment variables drive
+			// all configuration (endpoint, sampler, service name, etc.); see the
+			// tracing.TraceBodyFlag doc-comment for the full list.
+			traceCfg := tracing.TraceConfig{
+				DefaultServiceName: "lava-provider",
+				TraceBody:          viper.GetBool(tracing.TraceBodyFlag),
+			}
+			traceManager, err := tracing.New(ctx, traceCfg)
+			if err != nil {
+				return err
+			}
+			defer traceManager.Shutdown()
+
 			networkChainId := viper.GetString(flags.FlagChainID)
 			if networkChainId == app.Name {
 				clientTomlConfig, err := config.ReadFromClientConfig(clientCtx)
@@ -1132,6 +1146,18 @@ rpcprovider 127.0.0.1:3333 OSMOSIS tendermintrpc "wss://www.node-path.com:80,htt
 	cmdRPCProvider.Flags().Int("heavy-queue-size", 5, "Queue size for heavy methods")
 	cmdRPCProvider.Flags().Int64("normal-max-concurrent", 100, "Max concurrent normal method calls")
 	cmdRPCProvider.Flags().Bool("disable-consistency-checks", false, "Disable provider-side consistency checks (consistency checks are enabled by default)")
+
+	// OpenTelemetry tracing.
+	// All standard OTel knobs (endpoint, sampler, service name, TLS, headers, etc.)
+	// come from OTEL_* environment variables per the SDK spec — see the
+	// tracing.TraceBodyFlag doc-comment for the full list.
+	// --otel-trace-body is the only Lava-specific knob, exposed as a CLI flag
+	// because it's a per-invocation debug toggle rather than deployment configuration.
+	cmdRPCProvider.Flags().Bool(tracing.TraceBodyFlag, false, "record request/response bodies on trace spans (size limit delegated to OTel SDK via OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT)")
+	if err := viper.BindPFlag(tracing.TraceBodyFlag, cmdRPCProvider.Flags().Lookup(tracing.TraceBodyFlag)); err != nil {
+		utils.LavaFormatFatal("failed binding --otel-trace-body flag", err)
+	}
+
 	common.AddRollingLogConfig(cmdRPCProvider)
 	return cmdRPCProvider
 }

--- a/protocol/rpcprovider/rpcprovider_server.go
+++ b/protocol/rpcprovider/rpcprovider_server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lavanet/lava/v5/protocol/performance"
 	"github.com/lavanet/lava/v5/protocol/provideroptimizer"
 	rewardserver "github.com/lavanet/lava/v5/protocol/rpcprovider/rewardserver"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	"github.com/lavanet/lava/v5/protocol/upgrade"
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/utils/lavaslices"
@@ -270,6 +271,21 @@ func (rpcps *RPCProviderServer) Relay(ctx context.Context, request *pairingtypes
 	if txId := lavaprotocol.GetTxId(request.RelayData); txId != "" {
 		ctx = utils.AppendTxId(ctx, txId)
 	}
+	guid, _ := utils.GetUniqueIdentifier(ctx)
+	if guid == 0 {
+		guid = utils.GenerateUniqueIdentifier()
+		ctx = utils.WithUniqueIdentifier(ctx, guid)
+	}
+	ctx, span := tracing.StartProviderHandleRelay(ctx, guid, rpcps.rpcProviderEndpoint.ChainID, rpcps.rpcProviderEndpoint.ApiInterface)
+	defer span.End()
+	if tracing.IsTraceBodyEnabled() && request.RelayData != nil {
+		tracing.RecordBody(span, tracing.AttrRelayRequestBody, request.RelayData.Data)
+	}
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	startTime := time.Now()
 
 	utils.LavaFormatInfo("Got relay request from consumer",
@@ -470,6 +486,9 @@ func (rpcps *RPCProviderServer) Relay(ctx context.Context, request *pairingtypes
 }
 
 func (rpcps *RPCProviderServer) finalizeSession(isRelayError bool, ctx context.Context, consumerAddress sdk.AccAddress, reply *pairingtypes.RelayReply, chainMessage chainlib.ChainMessage, relaySession *lavasession.SingleProviderSession, request *pairingtypes.RelayRequest, replyWrapper *chainlib.RelayReplyWrapper, err error) error {
+	ctx, span := tracing.StartProviderFinalizeSession(ctx)
+	defer span.End()
+
 	if isRelayError {
 		// failed to send relay. we need to adjust session state. cuSum and relayNumber.
 		relayFailureError := rpcps.providerSessionManager.OnSessionFailure(relaySession, request.RelaySession.RelayNum)
@@ -538,6 +557,13 @@ func (rpcps *RPCProviderServer) finalizeSession(isRelayError bool, ctx context.C
 }
 
 func (rpcps *RPCProviderServer) initRelay(ctx context.Context, request *pairingtypes.RelayRequest) (relaySession *lavasession.SingleProviderSession, consumerAddress sdk.AccAddress, chainMessage chainlib.ChainMessage, err error) {
+	ctx, span := tracing.StartProviderInitRelay(ctx)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	relaySession, consumerAddress, err = rpcps.verifyRelaySession(ctx, request)
 	if err != nil {
 		return nil, nil, nil, err
@@ -585,6 +611,8 @@ func (rpcps *RPCProviderServer) ValidateAddonsExtensions(addon string, extension
 }
 
 func (rpcps *RPCProviderServer) ValidateRequest(chainMessage chainlib.ChainMessage, request *pairingtypes.RelayRequest, ctx context.Context) error {
+	ctx, span := tracing.StartProviderValidateRequest(ctx)
+	defer span.End()
 	if request.RelayData.RequestBlock == spectypes.NOT_APPLICABLE {
 		return nil
 	}
@@ -637,7 +665,13 @@ func (rpcps *RPCProviderServer) RelaySubscribe(request *pairingtypes.RelayReques
 		return common.LogCodedError("invalid relay subscribe request, internal fields are nil", nil, common.LavaErrorInvalidRelayRequest, rpcps.rpcProviderEndpoint.ChainID, 0, "")
 	}
 
-	ctx := utils.AppendUniqueIdentifier(context.Background(), lavaprotocol.GetSalt(request.RelayData))
+	// WithoutCancel keeps the OTel trace context flowing from otelgrpc's
+	// auto-created SERVER span, but breaks the cancellation chain — when the
+	// subscription client disconnects srv.Context() cancels, and any deferred
+	// RemoveConsumer / unsubscribeNodeSubscription path needs an un-canceled
+	// ctx for its WithTimeout cleanup to actually wait. Trace values still
+	// propagate; only cancellation is gated.
+	ctx := utils.AppendUniqueIdentifier(context.WithoutCancel(srv.Context()), lavaprotocol.GetSalt(request.RelayData))
 	utils.LavaFormatDebug("Provider got relay subscribe request",
 		utils.LogAttr("request.SessionId", request.RelaySession.SessionId),
 		utils.LogAttr("request.relayNumber", request.RelaySession.RelayNum),
@@ -949,7 +983,15 @@ func (rpcps *RPCProviderServer) handleRelayErrorStatus(err error) error {
 	return err
 }
 
-func (rpcps *RPCProviderServer) TryRelayWithWrapper(ctx context.Context, request *pairingtypes.RelayRequest, consumerAddr sdk.AccAddress, chainMsg chainlib.ChainMessage) (*pairingtypes.RelayReply, *chainlib.RelayReplyWrapper, error) {
+func (rpcps *RPCProviderServer) TryRelayWithWrapper(ctx context.Context, request *pairingtypes.RelayRequest, consumerAddr sdk.AccAddress, chainMsg chainlib.ChainMessage) (reply *pairingtypes.RelayReply, replyWrapper *chainlib.RelayReplyWrapper, err error) {
+	ctx, span := tracing.StartProviderTryRelay(ctx)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
+
 	errV := rpcps.ValidateRequest(chainMsg, request, ctx)
 	if errV != nil {
 		return nil, nil, errV
@@ -965,7 +1007,6 @@ func (rpcps *RPCProviderServer) TryRelayWithWrapper(ctx context.Context, request
 	relayTimeout := chainlib.GetRelayTimeout(chainMsg, averageBlockTime)
 
 	// Handle consistency: wait for chain tracker to catch up with consumer's seenBlock if needed (if enabled via CLI flag)
-	var err error
 	var latestBlock int64
 	if rpcps.enableConsistency {
 		latestBlock, _, err = rpcps.handleConsistency(
@@ -992,9 +1033,7 @@ func (rpcps *RPCProviderServer) TryRelayWithWrapper(ctx context.Context, request
 	requestedBlockHash, finalized = rpcps.GetParametersForCache(ctx, request, latestBlock, blockDistanceToFinalization)
 
 	// currently used when cache hits.
-	var reply *pairingtypes.RelayReply
 	var ignoredMetadata []pairingtypes.Metadata
-	var replyWrapper *chainlib.RelayReplyWrapper
 
 	if requestedBlockHash != nil || finalized { // try get reply from cache
 		utils.LavaFormatDebug("cache: attempting lookup",
@@ -1057,7 +1096,19 @@ func (rpcps *RPCProviderServer) TryRelayWithWrapper(ctx context.Context, request
 	return reply, replyWrapper, nil
 }
 
-func (rpcps *RPCProviderServer) tryGetRelayReplyFromCache(ctx context.Context, request *pairingtypes.RelayRequest, requestedBlockHash []byte, finalized bool) (*pairingtypes.RelayReply, []pairingtypes.Metadata, error) {
+func (rpcps *RPCProviderServer) tryGetRelayReplyFromCache(ctx context.Context, request *pairingtypes.RelayRequest, requestedBlockHash []byte, finalized bool) (reply *pairingtypes.RelayReply, ignoredMetadata []pairingtypes.Metadata, err error) {
+	ctx, span := tracing.StartProviderCacheLookup(ctx)
+	defer span.End()
+	cacheStart := time.Now()
+	hit := false
+	defer func() {
+		// Cache misses (including "backend not running") are not span errors —
+		// they just mean "no cache result, fall back to upstream". The cache.hit
+		// attribute and latency carry the operator signal. Matches the
+		// consumer-side pattern in sendRelayToProvider.
+		tracing.RecordCacheLookup(ctx, span, "provider", hit, float64(time.Since(cacheStart).Milliseconds()))
+	}()
+
 	cache := rpcps.cache
 	hashKey, outPutFormatter, hashErr := chainlib.HashCacheRequest(request.RelayData, rpcps.rpcProviderEndpoint.ChainID)
 	if hashErr != nil {
@@ -1080,8 +1131,9 @@ func (rpcps *RPCProviderServer) tryGetRelayReplyFromCache(ctx context.Context, r
 		return nil, nil, err
 	}
 
-	reply := cacheReply.GetReply()
+	reply = cacheReply.GetReply()
 	if reply != nil {
+		hit = true
 		reply.Data = outPutFormatter(reply.Data) // setting request id back to reply.
 		utils.LavaFormatDebug("cache hit",
 			utils.LogAttr("chainID", rpcps.rpcProviderEndpoint.ChainID),
@@ -1100,12 +1152,15 @@ func (rpcps *RPCProviderServer) tryGetRelayReplyFromCache(ctx context.Context, r
 		)
 	}
 
-	ignoredMetadata := cacheReply.GetOptionalMetadata()
+	ignoredMetadata = cacheReply.GetOptionalMetadata()
 
 	return reply, ignoredMetadata, err
 }
 
 func (rpcps *RPCProviderServer) trySetRelayReplyInCache(ctx context.Context, request *pairingtypes.RelayRequest, chainMsg chainlib.ChainMessage, replyWrapper *chainlib.RelayReplyWrapper, latestBlock int64, averageBlockTime time.Duration, requestedBlockHash []byte, finalized bool, ignoredMetadata []pairingtypes.Metadata) {
+	ctx, span := tracing.StartProviderCacheStore(ctx)
+	defer span.End()
+
 	cache := rpcps.cache
 	reply := replyWrapper.RelayReply
 
@@ -1207,6 +1262,19 @@ func (rpcps *RPCProviderServer) GetParametersForCache(ctx context.Context, reque
 // handleConsistency waits for the chain tracker to catch up with the consumer's seen block if needed
 // This ensures the provider doesn't return stale data when the consumer has already seen a newer block
 func (rpcps *RPCProviderServer) handleConsistency(ctx context.Context, baseRelayTimeout time.Duration, seenBlock int64, requestBlock int64, averageBlockTime time.Duration, blockLagForQosSync int64, blockDistanceToFinalization uint32, blocksInFinalizationData uint32) (latestBlock int64, timeSlept time.Duration, err error) {
+	target := requestBlock
+	if seenBlock > requestBlock {
+		target = seenBlock
+	}
+	ctx, span := tracing.StartProviderHandleConsistency(ctx, target)
+	defer span.End()
+	bailed := false
+	defer func() {
+		tracing.RecordHandleConsistencyResult(span, timeSlept.Milliseconds(), bailed)
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
 	latestBlock, changeTime := rpcps.chainTracker.GetLatestBlockNum()
 	if requestBlock == spectypes.LATEST_BLOCK && seenBlock > latestBlock {
 		// we can't just replace requested block here with what we have, it must be with at least seen block
@@ -1248,6 +1316,7 @@ func (rpcps *RPCProviderServer) handleConsistency(ctx context.Context, baseRelay
 	}
 	// we only bail if there is no chance for the provider to get to the requested block and the consumer has already got a response from a different provider with that block
 	if (blockGap > blockLagForQosSync*2 || (blockGap > 1 && probabilityBlockError > 0.4)) && (seenBlock >= latestBlock) {
+		bailed = true
 		return latestBlock, 0, utils.LavaFormatWarning("Requested a block that is too new", protocolerrors.ConsistencyError, utils.Attribute{Key: "blockGap", Value: blockGap}, utils.Attribute{Key: "probabilityBlockError", Value: probabilityBlockError}, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: utils.KEY_REQUEST_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TASK_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TRANSACTION_ID, Value: ctx}, utils.Attribute{Key: "seenBlock", Value: seenBlock}, utils.Attribute{Key: "requestedBlock", Value: requestBlock}, utils.Attribute{Key: "latestBlock", Value: latestBlock}, utils.Attribute{Key: "chainID", Value: rpcps.rpcProviderEndpoint.ChainID})
 	}
 
@@ -1269,6 +1338,7 @@ func (rpcps *RPCProviderServer) handleConsistency(ctx context.Context, baseRelay
 	latestBlock, _ = rpcps.chainTracker.GetLatestBlockNum()
 	if requestBlock > latestBlock && seenBlock > latestBlock {
 		// meaning we can't guarantee it will work since chainTracker didn't see this requested block yet
+		bailed = true
 		return 0, sleptTime, utils.LavaFormatWarning("requested block is too new", nil, utils.Attribute{Key: "sleptTime", Value: sleptTime}, utils.Attribute{Key: "requested", Value: requestBlock}, utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: utils.KEY_REQUEST_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TASK_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TRANSACTION_ID, Value: ctx}, utils.Attribute{Key: "latestBlock", Value: latestBlock}, utils.Attribute{Key: "chainID", Value: rpcps.rpcProviderEndpoint.ChainID}, utils.Attribute{Key: "seenBlock", Value: seenBlock})
 	}
 	if debugConsistency {
@@ -1324,7 +1394,15 @@ func (rpcps *RPCProviderServer) GetLatestBlockData(ctx context.Context, blockDis
 	return latestBlock, requestedHashes, changeTime, err
 }
 
-func (rpcps *RPCProviderServer) sendRelayMessageToNode(ctx context.Context, request *pairingtypes.RelayRequest, chainMsg chainlib.ChainMessage, consumerAddr sdk.AccAddress) (*chainlib.RelayReplyWrapper, error) {
+func (rpcps *RPCProviderServer) sendRelayMessageToNode(ctx context.Context, request *pairingtypes.RelayRequest, chainMsg chainlib.ChainMessage, consumerAddr sdk.AccAddress) (replyWrapper *chainlib.RelayReplyWrapper, err error) {
+	ctx, span := tracing.StartProviderSendUpstream(ctx)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
+
 	if debugLatency {
 		utils.LavaFormatDebug("sending relay to node", utils.Attribute{Key: "GUID", Value: ctx}, utils.Attribute{Key: utils.KEY_REQUEST_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TASK_ID, Value: ctx}, utils.Attribute{Key: utils.KEY_TRANSACTION_ID, Value: ctx}, utils.Attribute{Key: "specID", Value: rpcps.rpcProviderEndpoint.ChainID})
 	}
@@ -1340,11 +1418,12 @@ func (rpcps *RPCProviderServer) sendRelayMessageToNode(ctx context.Context, requ
 	}
 
 	// use the provider state machine to send the messages
-	relayReplayWrapper, latency, err := rpcps.providerStateMachine.SendNodeMessage(ctx, chainMsg, request)
+	var latency time.Duration
+	replyWrapper, latency, err = rpcps.providerStateMachine.SendNodeMessage(ctx, chainMsg, request)
 	if latency.Milliseconds() != 0 { // if node error empty time is returned
 		go rpcps.metrics.AddFunctionLatency(chainMsg.GetApi().Name, latency)
 	}
-	return relayReplayWrapper, err
+	return replyWrapper, err
 }
 
 func (rpcps *RPCProviderServer) TryRelayUnsubscribe(ctx context.Context, request *pairingtypes.RelayRequest, consumerAddress sdk.AccAddress, chainMessage chainlib.ChainMessage) (*pairingtypes.RelayReply, error) {

--- a/protocol/rpcsmartrouter/rpcsmartrouter.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter.go
@@ -1583,7 +1583,8 @@ rpcsmartrouter smartrouter_examples/full_smartrouter_example.yml --cache-be "127
 			// endpoint is configured the SDK falls back to the spec default
 			// (localhost:4317 for gRPC, localhost:4318 for HTTP).
 			traceCfg := tracing.TraceConfig{
-				TraceBody: viper.GetBool(tracing.TraceBodyFlag),
+				DefaultServiceName: "lava-smartrouter",
+				TraceBody:          viper.GetBool(tracing.TraceBodyFlag),
 			}
 			traceManager, err := tracing.New(ctx, traceCfg)
 			if err != nil {

--- a/protocol/rpcsmartrouter/rpcsmartrouter_server.go
+++ b/protocol/rpcsmartrouter/rpcsmartrouter_server.go
@@ -456,17 +456,13 @@ func (rpcss *RPCSmartRouterServer) SendRelay(
 		ctx = grpcmetadata.NewIncomingContext(ctx, md)
 	}
 
-	// Extract W3C TraceContext (traceparent/tracestate) from incoming request headers
-	// so that the relay span becomes a child of the caller's trace when present.
-	ctx = tracing.ExtractHTTP(ctx, metadata)
-
-	// Start the inbound SERVER span. It covers the full relay lifecycle
-	// including parsing — all downstream helpers create child spans from
-	// the resulting context. We also pin the span on the context via
-	// WithRelaySpan so deeply nested helpers (e.g. cache lookup) can decorate
-	// it directly without plumbing the span through every signature.
-	ctx, span := tracing.StartServerSpan(ctx, tracing.SpanSendRelay)
+	// chainlib FiberMiddleware has already created the SERVER root span and
+	// extracted trace context. SR adds an app-level child span carrying
+	// relay-specific attributes.
+	ctx, span := tracing.StartInternalSpan(ctx, tracing.SpanSendRelay)
 	defer span.End()
+	// Pin the child span so deeply nested helpers (e.g. cache lookup) can
+	// decorate it directly without plumbing the span through every signature.
 	ctx = tracing.WithRelaySpan(ctx, span)
 
 	chainId, apiInterface := rpcss.GetChainIdAndApiInterface()

--- a/protocol/statetracker/tx_sender.go
+++ b/protocol/statetracker/tx_sender.go
@@ -19,6 +19,7 @@ import (
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 
 	updaters "github.com/lavanet/lava/v5/protocol/statetracker/updaters"
 	"github.com/lavanet/lava/v5/utils"
@@ -106,7 +107,7 @@ func (ts *TxSender) SimulateAndBroadCastTxWithRetryOnSeqMismatch(ctx context.Con
 			return utils.LavaFormatError("Failed Simulating transaction", err)
 		}
 		// incase we got an error the tx result is basically the error
-		latestResult, err = ts.SendTxAndVerifyCommit(txfactory, msg)
+		latestResult, err = ts.SendTxAndVerifyCommit(ctx, txfactory, msg)
 		transactionResult := latestResult.RawLog
 		if err == nil { // if we get some other code which isn't 0 then keep retrying
 			success = true
@@ -184,19 +185,31 @@ func (ts *TxSender) simulateTxWithRetry(clientCtx client.Context, txfactory tx.F
 	return txfactory, 0, utils.LavaFormatError("Failed Calculating gas for reward transaction", nil)
 }
 
-func (ts *TxSender) SendTxAndVerifyCommit(txfactory tx.Factory, msg sdk.Msg) (parsedResult common.TxResultData, err error) {
+func (ts *TxSender) SendTxAndVerifyCommit(ctx context.Context, txfactory tx.Factory, msg sdk.Msg) (parsedResult common.TxResultData, err error) {
+	_, span := tracing.StartLavaChainTx(ctx, sdk.MsgTypeURL(msg))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err)
+		}
+	}()
+
+	broadcastStart := time.Now()
 	myWriter := bytes.Buffer{}
 	clientCtx := ts.clientCtx
 	clientCtx.Output = &myWriter
 	clientCtx.OutputFormat = "json"
 	err = tx.GenerateOrBroadcastTxWithFactory(clientCtx, txfactory, msg)
+	broadcastMs := time.Since(broadcastStart).Milliseconds()
 	if err != nil {
 		utils.LavaFormatWarning("Sending CheckProfitabilityAndBroadCastTx failed", err, utils.Attribute{Key: "msg", Value: msg})
+		tracing.RecordLavaChainTxResult(span, broadcastMs, 0, 0, "")
 		return common.TxResultData{}, err
 	}
 	jsonParsedResult := map[string]any{}
 	err = json.Unmarshal(myWriter.Bytes(), &jsonParsedResult)
 	if err != nil {
+		tracing.RecordLavaChainTxResult(span, broadcastMs, 0, 0, "")
 		return common.TxResultData{}, utils.LavaFormatInfo("Failed unmarshaling transaction results", utils.Attribute{Key: "transactionResult", Value: myWriter.String()})
 	}
 	myWriter.Reset()
@@ -206,13 +219,19 @@ func (ts *TxSender) SendTxAndVerifyCommit(txfactory tx.Factory, msg sdk.Msg) (pa
 	resultData, err := common.ParseTransactionResult(jsonParsedResult)
 	utils.LavaFormatInfo("Sent Transaction", utils.LogAttr("Hash", hex.EncodeToString(resultData.Txhash)))
 	if err != nil {
+		tracing.RecordLavaChainTxResult(span, broadcastMs, 0, 0, hex.EncodeToString(resultData.Txhash))
 		return common.TxResultData{}, err
 	}
 	if resultData.Code != 0 {
+		tracing.RecordLavaChainTxResult(span, broadcastMs, 0, 0, hex.EncodeToString(resultData.Txhash))
 		return resultData, utils.LavaFormatInfo("Failed sending transaction, code is not 0", utils.Attribute{Key: "resultData", Value: resultData})
 	}
+
 	// now that our Tx was sent to the mempool successfully, we want to see it's result on chain
+	commitStart := time.Now()
 	resultData, err = ts.waitForTxCommit(resultData)
+	commitMs := time.Since(commitStart).Milliseconds()
+	tracing.RecordLavaChainTxResult(span, broadcastMs, commitMs, 0, hex.EncodeToString(resultData.Txhash))
 	return resultData, err
 }
 

--- a/protocol/statetracker/updaters/state_query.go
+++ b/protocol/statetracker/updaters/state_query.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	hybrid_client "github.com/lavanet/lava/v5/protocol/statetracker/hybridclient"
+	"github.com/lavanet/lava/v5/protocol/tracing"
 	downtimev1 "github.com/lavanet/lava/v5/x/downtime/v1"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -59,7 +60,12 @@ func NewStateQueryAccessInst(clientCtx client.Context) *StateQueryAccessInst {
 	if !ok {
 		utils.LavaFormatFatal("failed casting tendermint rpc from client context", nil)
 	}
-	sq := &StateQueryAccessInst{ClientConn: clientCtx, tendermintRPC: tenderRpc, TendermintRPC: clientCtx.Client, clientCtx: clientCtx}
+	sq := &StateQueryAccessInst{
+		ClientConn:    tracing.WrapClientConn(clientCtx),
+		tendermintRPC: tenderRpc,
+		TendermintRPC: clientCtx.Client,
+		clientCtx:     clientCtx,
+	}
 	sq.TryConnectingClients()
 	return sq
 }

--- a/protocol/tracing/middleware.go
+++ b/protocol/tracing/middleware.go
@@ -1,0 +1,64 @@
+package tracing
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// FiberMiddleware returns a Fiber middleware that creates the root SERVER span
+// for every inbound HTTP request, extracting any external W3C trace context
+// from the request headers. Designed to be installed once via app.Use(...)
+// near the top of every chainlib listener.
+//
+// The created span uses tracing.SpanChainlibHTTP as its name and carries
+// http.method and http.route attributes. Span status is set to Error when
+// the handler returns a non-nil error or a 5xx status.
+func FiberMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		// Extract trace context from inbound headers.
+		carrier := propagation.MapCarrier{}
+		c.Request().Header.VisitAll(func(k, v []byte) {
+			carrier[strings.ToLower(string(k))] = string(v)
+		})
+		ctx := otel.GetTextMapPropagator().Extract(c.UserContext(), carrier)
+
+		// http.route is the route TEMPLATE (e.g. "/*", "/users/:id") per OTel
+		// semconv — using the raw request path here would explode the cardinality
+		// of any metrics-from-traces pipeline (Tempo metrics-generator, etc.)
+		// since REST/Tendermint listeners typically register wildcard handlers
+		// and the raw path contains addresses, block hashes, etc. The actual
+		// request path goes under `url.path` (current OTel HTTP semconv).
+		route := "/"
+		if r := c.Route(); r != nil {
+			route = r.Path
+		}
+		ctx, span := otel.Tracer(tracerName).Start(ctx, SpanChainlibHTTP,
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(
+				attribute.String("http.method", c.Method()),
+				attribute.String("http.route", route),
+				attribute.String("url.path", c.Path()),
+			),
+		)
+		defer span.End()
+
+		c.SetUserContext(ctx)
+
+		err := c.Next()
+		status := c.Response().StatusCode()
+		span.SetAttributes(attribute.Int("http.status_code", status))
+		if err != nil {
+			span.SetStatus(otelcodes.Error, err.Error())
+			span.RecordError(err)
+		} else if status >= 500 {
+			span.SetStatus(otelcodes.Error, "server error")
+		}
+		return err
+	}
+}

--- a/protocol/tracing/middleware_test.go
+++ b/protocol/tracing/middleware_test.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestFiberMiddleware_CreatesRootSpan(t *testing.T) {
+	sr := setupTestTracer(t)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+	app := fiber.New()
+	app.Use(FiberMiddleware())
+	app.Post("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(200)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanChainlibHTTP, spans[0].Name())
+}
+
+func TestFiberMiddleware_ExtractsExternalTraceParent(t *testing.T) {
+	sr := setupTestTracer(t)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+	app := fiber.New()
+	app.Use(FiberMiddleware())
+	app.Post("/test", func(c *fiber.Ctx) error {
+		return c.SendStatus(200)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+	_, err := app.Test(req)
+	require.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "0af7651916cd43dd8448eb211c80319c", spans[0].SpanContext().TraceID().String())
+}
+
+// TestFiberMiddleware_RoundtripPropagatesTraceID verifies the full propagation
+// path: FiberMiddleware creates the root span, a handler picks up the trace
+// context from fiberCtx.UserContext(), and InjectGRPC carries the same trace
+// ID into outgoing headers — the same plumbing consumer→provider relies on.
+func TestFiberMiddleware_RoundtripPropagatesTraceID(t *testing.T) {
+	sr := setupTestTracer(t)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+	var downstreamTraceParent string
+	app := fiber.New()
+	app.Use(FiberMiddleware())
+	app.Post("/test", func(c *fiber.Ctx) error {
+		// Simulate a downstream call: handler grabs the OTel context from
+		// fiberCtx.UserContext() and injects it into outgoing metadata, the
+		// same way the chainproxy SendNodeMsg path does.
+		headers := map[string]string{}
+		InjectGRPC(c.UserContext(), headers)
+		downstreamTraceParent = headers["traceparent"]
+		return c.SendStatus(200)
+	})
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	_, err := app.Test(req)
+	require.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	rootTraceID := spans[0].SpanContext().TraceID().String()
+
+	require.NotEmpty(t, downstreamTraceParent, "InjectGRPC produced no traceparent — context did not propagate from middleware to handler")
+	require.Contains(t, downstreamTraceParent, rootTraceID, "injected traceparent does not carry the SERVER span's trace ID")
+}

--- a/protocol/tracing/propagation.go
+++ b/protocol/tracing/propagation.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	"google.golang.org/grpc/metadata"
 
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 )
@@ -54,6 +55,28 @@ func InjectGRPC(ctx context.Context, headers map[string]string) {
 	for k, v := range carrier {
 		headers[k] = v
 	}
+}
+
+// ExtractGRPC reads W3C trace context from gRPC incoming-context metadata into ctx,
+// returning a new context that carries the remote span as parent. Returns ctx
+// unchanged when no metadata is present.
+//
+// For multi-valued metadata keys, only the first value is used. This is
+// sufficient for W3C trace context (traceparent/tracestate/baggage are
+// single-valued per spec); non-conforming senders that repeat these headers
+// will have additional values silently dropped.
+func ExtractGRPC(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	headers := make(map[string]string, md.Len())
+	for k, vs := range md {
+		if len(vs) > 0 {
+			headers[strings.ToLower(k)] = vs[0]
+		}
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(headers))
 }
 
 // ExtractHTTP reads W3C trace context from a Metadata slice into ctx,

--- a/protocol/tracing/propagation_test.go
+++ b/protocol/tracing/propagation_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
 
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
 )
@@ -373,6 +374,31 @@ func TestRoundTrip_GRPC(t *testing.T) {
 	sc := trace.SpanContextFromContext(extracted)
 	require.True(t, sc.IsValid())
 	require.Equal(t, span.SpanContext().TraceID(), sc.TraceID())
+}
+
+func TestExtractGRPC_PullsTraceParent(t *testing.T) {
+	_ = setupTestTracing(t) // installs TraceContext propagator + registers cleanup
+
+	md := metadata.New(map[string]string{
+		"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	extracted := ExtractGRPC(ctx)
+	sc := trace.SpanContextFromContext(extracted)
+	require.True(t, sc.IsValid())
+	require.True(t, sc.IsRemote())
+	require.Equal(t, "0af7651916cd43dd8448eb211c80319c", sc.TraceID().String())
+	require.Equal(t, "b7ad6b7169203331", sc.SpanID().String())
+}
+
+func TestExtractGRPC_NoMetadata(t *testing.T) {
+	_ = setupTestTracing(t)
+
+	ctx := context.Background()
+	extracted := ExtractGRPC(ctx)
+	sc := trace.SpanContextFromContext(extracted)
+	require.False(t, sc.IsValid())
 }
 
 // findMetadata returns the value of the first metadata entry matching the given name.

--- a/protocol/tracing/span_names.go
+++ b/protocol/tracing/span_names.go
@@ -16,6 +16,53 @@ const (
 	SpanSendGRPCRelay                = "smartrouter.sendGRPCRelay"
 )
 
+// Chainlib listener root spans (extract trace context from external clients).
+const (
+	SpanChainlibHTTP = "chainlib.HandleHTTP"
+	SpanChainlibGRPC = "chainlib.HandleGRPC"
+)
+
+// Consumer pipeline spans.
+const (
+	SpanConsumerSendRelay        = "consumer.SendRelay"
+	SpanConsumerParseRelay       = "consumer.ParseRelay"
+	SpanConsumerSendParsedRelay  = "consumer.SendParsedRelay"
+	SpanConsumerProcessRelaySend = "consumer.ProcessRelaySend"
+	SpanConsumerCacheLookup      = "consumer.CacheLookup"
+	SpanConsumerGetSessions      = "consumer.GetSessions"
+	SpanConsumerRelayInner       = "consumer.relayInner"
+	SpanConsumerProcessingResult = "consumer.ProcessingResult"
+)
+
+// Provider pipeline spans.
+const (
+	SpanProviderHandleRelay       = "provider.HandleRelay"
+	SpanProviderInitRelay         = "provider.InitRelay"
+	SpanProviderValidateRequest   = "provider.ValidateRequest"
+	SpanProviderCacheLookup       = "provider.CacheLookup"
+	SpanProviderHandleConsistency = "provider.HandleConsistency"
+	SpanProviderTryRelay          = "provider.TryRelay"
+	SpanProviderSendUpstream      = "provider.SendUpstream"
+	SpanProviderCacheStore        = "provider.CacheStore"
+	SpanProviderFinalizeSession   = "provider.FinalizeSession"
+)
+
+// Chainproxy outbound spans — child of provider.SendUpstream when invoked
+// from the provider relay path, or child of the caller's span otherwise.
+// Each wraps an actual outbound HTTP/gRPC call to the upstream chain node.
+const (
+	SpanChainproxyJSONRPC       = "chainlib.sendJSONRPCRelay"
+	SpanChainproxyREST          = "chainlib.sendRESTRelay"
+	SpanChainproxyGRPC          = "chainlib.sendGRPCRelay"
+	SpanChainproxyTendermintRPC = "chainlib.sendTendermintRPCRelay"
+)
+
+// Lava-chain communication spans.
+const (
+	SpanLavaChainQuery    = "lavachain.Query"
+	SpanLavaChainSubmitTx = "lavachain.SubmitTx"
+)
+
 // Span attribute keys.
 const (
 	// Body recording attributes (gated by --otel-trace-body, set from
@@ -57,4 +104,26 @@ const (
 	attrConsistencyTotal    = "consistency.total"
 	attrConsistencyPassed   = "consistency.passed"
 	attrConsistencyRejected = "consistency.rejected"
+)
+
+const (
+	// New cache attribute (existing cache.* keys gain a role suffix to
+	// disambiguate consumer vs provider cache spans on the same trace).
+	attrCacheRole = "cache.role"
+
+	// Provider HandleConsistency attributes.
+	attrConsistencyTargetBlock = "consistency.target_block"
+	attrConsistencyWaitedMs    = "consistency.waited_ms"
+	attrConsistencyBailed      = "consistency.bailed"
+
+	// Lava-chain query attributes.
+	attrLavaChainMethod = "lavachain.method"
+	attrLavaChainCode   = "lavachain.code"
+
+	// Lava-chain tx attributes.
+	attrLavaChainMsgType     = "lavachain.msg_type"
+	attrLavaChainBroadcastMs = "lavachain.broadcast_ms"
+	attrLavaChainCommitMs    = "lavachain.commit_ms"
+	attrLavaChainHeight      = "lavachain.height"
+	attrLavaChainTxHash      = "lavachain.tx_hash"
 )

--- a/protocol/tracing/spans_chainlib.go
+++ b/protocol/tracing/spans_chainlib.go
@@ -1,0 +1,33 @@
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartChainlibHTTP starts the root SERVER span for an inbound HTTP request
+// at a chainlib listener (jsonRPC or REST). Trace context extraction from
+// inbound headers is handled by the caller (Fiber middleware) before this
+// helper is invoked, so ctx is already parent-aware.
+func StartChainlibHTTP(ctx context.Context, method, route string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanChainlibHTTP,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("http.method", method),
+			attribute.String("http.route", route),
+		),
+	)
+}
+
+// StartChainlibGRPC starts the root SERVER span for an inbound gRPC request
+// at chainlib's gRPC proxy listener. Used when the otelgrpc server interceptor
+// is not in play (rare — the interceptor is the preferred mechanism).
+func StartChainlibGRPC(ctx context.Context, method string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanChainlibGRPC,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(attribute.String("rpc.method", method)),
+	)
+}

--- a/protocol/tracing/spans_chainlib_test.go
+++ b/protocol/tracing/spans_chainlib_test.go
@@ -1,0 +1,26 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestStartChainlibHTTP_CreatesServerSpan(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	ctx, span := StartChainlibHTTP(context.Background(), "POST", "/eth_blockNumber")
+	require.NotNil(t, ctx)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanChainlibHTTP, spans[0].Name())
+	require.Equal(t, trace.SpanKindServer, spans[0].SpanKind())
+
+	method, ok := findStringAttr(spans[0].Attributes(), "http.method")
+	require.True(t, ok)
+	require.Equal(t, "POST", method)
+}

--- a/protocol/tracing/spans_consumer.go
+++ b/protocol/tracing/spans_consumer.go
@@ -1,0 +1,89 @@
+package tracing
+
+import (
+	"context"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartConsumerSendRelay starts the top-level consumer relay span. The caller
+// is the chainlib middleware's already-rooted ctx (so this span is a child
+// of chainlib.HandleHTTP). Caller `defer span.End()` and use Record* helpers.
+func StartConsumerSendRelay(ctx context.Context, guid uint64, chainID, apiInterface string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerSendRelay,
+		trace.WithAttributes(
+			attribute.String(attrRelayGUID, strconv.FormatUint(guid, 10)),
+			attribute.String(attrRelayChainID, chainID),
+			attribute.String(attrRelayAPIInterface, apiInterface),
+		),
+	)
+}
+
+// StartConsumerParseRelay starts the parse-relay span (child of SendRelay).
+func StartConsumerParseRelay(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerParseRelay)
+}
+
+// StartConsumerSendParsedRelay starts the send-parsed-relay span (parent for ProcessRelaySend).
+func StartConsumerSendParsedRelay(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerSendParsedRelay)
+}
+
+// StartConsumerProcessRelaySend wraps the state-machine retry loop. Caller sets
+// relay.retry_count via the existing RecordRetryCount helper (in span_helpers.go)
+// once the loop has resolved.
+func StartConsumerProcessRelaySend(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerProcessRelaySend)
+}
+
+// StartConsumerCacheLookup starts the consumer-side cache-lookup span.
+// Caller fills attributes with RecordCacheLookup.
+func StartConsumerCacheLookup(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerCacheLookup)
+}
+
+// StartConsumerGetSessions starts the session-acquisition span.
+// Caller records via RecordSessionStats (from span_helpers.go) once the optimizer returns.
+func StartConsumerGetSessions(ctx context.Context, requested int) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerGetSessions,
+		trace.WithAttributes(attribute.Int(attrSessionRequested, requested)),
+	)
+}
+
+// StartConsumerRelayInner starts the per-attempt span around the gRPC call to
+// the provider. The CLIENT span (auto-created by otelgrpc on the underlying
+// dial) will be nested under this span.
+//
+// The caller passes the current batch number (1-indexed), typically derived
+// from `relayProcessor.GetUsedProviders().BatchNumber()` — same pattern SR
+// uses in rpcsmartrouter_server.go:838.
+func StartConsumerRelayInner(ctx context.Context, providerAddr string, attempt int) (context.Context, trace.Span) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, SpanConsumerRelayInner,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attribute.String(attrProviderAddress, providerAddr)),
+	)
+	RecordRelayAttempt(span, attempt) // existing helper in span_helpers.go
+	return ctx, span
+}
+
+// StartConsumerProcessingResult starts the consensus / finalization span.
+func StartConsumerProcessingResult(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanConsumerProcessingResult)
+}
+
+// RecordCacheLookup attaches role + hit + latency to a cache-lookup span and
+// bubbles cache.hit to the surrounding relay span via context (the existing
+// behavior of RecordCacheResult in span_helpers.go). Use this for both
+// consumer- and provider-side cache spans: role disambiguates them on a
+// single trace.
+//
+// role is "consumer" or "provider".
+func RecordCacheLookup(ctx context.Context, span trace.Span, role string, hit bool, latencyMs float64) {
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String(attrCacheRole, role))
+	}
+	RecordCacheResult(ctx, span, hit, latencyMs)
+}

--- a/protocol/tracing/spans_consumer_test.go
+++ b/protocol/tracing/spans_consumer_test.go
@@ -1,0 +1,45 @@
+package tracing
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartConsumerSendRelay_RecordsRelayAttrs(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	ctx, span := StartConsumerSendRelay(context.Background(), 12345, "ETH1", "jsonrpc")
+	require.NotNil(t, ctx)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanConsumerSendRelay, spans[0].Name())
+
+	guid, ok := findStringAttr(spans[0].Attributes(), attrRelayGUID)
+	require.True(t, ok)
+	require.Equal(t, strconv.FormatUint(12345, 10), guid)
+
+	chainID, ok := findStringAttr(spans[0].Attributes(), attrRelayChainID)
+	require.True(t, ok)
+	require.Equal(t, "ETH1", chainID)
+}
+
+func TestStartConsumerCacheLookup_RecordsResult(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	ctx, span := StartConsumerCacheLookup(context.Background())
+	RecordCacheLookup(ctx, span, "consumer", true, 3.0)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanConsumerCacheLookup, spans[0].Name())
+
+	role, ok := findStringAttr(spans[0].Attributes(), attrCacheRole)
+	require.True(t, ok)
+	require.Equal(t, "consumer", role)
+}

--- a/protocol/tracing/spans_lavachain.go
+++ b/protocol/tracing/spans_lavachain.go
@@ -1,0 +1,107 @@
+package tracing
+
+import (
+	"context"
+
+	grpc1 "github.com/cosmos/gogoproto/grpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// tracerName is the OTel tracer name (instrumentation library identifier)
+// used by all helpers in this package. Distinct from the smartrouter scope
+// to make span source readily identifiable in the trace UI.
+const tracerName = "github.com/lavanet/lava/v5/protocol/tracing"
+
+// WrapClientConn wraps a gogoproto-style ClientConn so every Invoke and
+// NewStream call emits a `lavachain.Query` span. Used at the seam between
+// Lava code and the Cosmos SDK client.Context — Cosmos SDK adapts a
+// gRPC-shaped interface to a Tendermint RPC ABCI transport, so an
+// otelgrpc.UnaryClientInterceptor (which only fires on real grpc.Dial calls)
+// does not apply here.
+func WrapClientConn(inner grpc1.ClientConn) grpc1.ClientConn {
+	return &tracedClientConn{inner: inner}
+}
+
+type tracedClientConn struct {
+	inner grpc1.ClientConn
+}
+
+func (t *tracedClientConn) Invoke(
+	ctx context.Context,
+	method string,
+	args, reply interface{},
+	opts ...grpc.CallOption,
+) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, SpanLavaChainQuery,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String(attrLavaChainMethod, method)),
+	)
+	defer span.End()
+
+	err := t.inner.Invoke(ctx, method, args, reply, opts...)
+	span.SetAttributes(attribute.String(attrLavaChainCode, status.Code(err).String()))
+	if err != nil {
+		span.SetStatus(otelcodes.Error, err.Error())
+		span.RecordError(err)
+	}
+	return err
+}
+
+func (t *tracedClientConn) NewStream(
+	ctx context.Context,
+	desc *grpc.StreamDesc,
+	method string,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, SpanLavaChainQuery,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String(attrLavaChainMethod, method)),
+	)
+	stream, err := t.inner.NewStream(ctx, desc, method, opts...)
+	if err != nil {
+		span.SetAttributes(attribute.String(attrLavaChainCode, status.Code(err).String()))
+		span.SetStatus(otelcodes.Error, err.Error())
+		span.RecordError(err)
+		span.End()
+		return nil, err
+	}
+	// Stream lifetime is owned by the caller. This goroutine parks on
+	// stream.Context().Done() and ends the span when the stream closes;
+	// its lifetime is bounded by the stream's lifetime, NOT a leak. For
+	// long-lived state-tracker subscription streams the goroutine stays
+	// parked until binary shutdown — that's intentional and correct.
+	go func() {
+		<-stream.Context().Done()
+		span.SetAttributes(attribute.String(attrLavaChainCode, codes.OK.String()))
+		span.End()
+	}()
+	return stream, nil
+}
+
+// StartLavaChainTx starts a span around a Cosmos SDK transaction broadcast
+// to lavad. Caller sets broadcast/commit timings and tx hash via
+// RecordLavaChainTxResult as those values become available, then
+// `defer span.End()`.
+func StartLavaChainTx(ctx context.Context, msgType string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanLavaChainSubmitTx,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String(attrLavaChainMsgType, msgType)),
+	)
+}
+
+// RecordLavaChainTxResult attaches the broadcast/commit timing and result
+// data to a `lavachain.SubmitTx` span. Safe to call on a non-recording span.
+func RecordLavaChainTxResult(span trace.Span, broadcastMs, commitMs int64, height int64, txHash string) {
+	span.SetAttributes(
+		attribute.Int64(attrLavaChainBroadcastMs, broadcastMs),
+		attribute.Int64(attrLavaChainCommitMs, commitMs),
+		attribute.Int64(attrLavaChainHeight, height),
+		attribute.String(attrLavaChainTxHash, txHash),
+	)
+}

--- a/protocol/tracing/spans_lavachain_test.go
+++ b/protocol/tracing/spans_lavachain_test.go
@@ -1,0 +1,118 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeClientConn struct {
+	invokeErr error
+	method    string
+}
+
+func (f *fakeClientConn) Invoke(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error {
+	f.method = method
+	return f.invokeErr
+}
+
+func (f *fakeClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	f.method = method
+	return nil, f.invokeErr
+}
+
+func setupTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prevTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		_ = tp.Shutdown(context.Background())
+	})
+	return sr
+}
+
+func TestWrapClientConn_InvokeSuccessRecordsSpan(t *testing.T) {
+	sr := setupTestTracer(t)
+	inner := &fakeClientConn{}
+	wrapped := WrapClientConn(inner)
+
+	err := wrapped.Invoke(context.Background(), "/lavanet.lava.pairing.Query/GetPairing", nil, nil)
+	require.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanLavaChainQuery, spans[0].Name())
+
+	attrs := spans[0].Attributes()
+	method, ok := findStringAttr(attrs, attrLavaChainMethod)
+	require.True(t, ok)
+	require.Equal(t, "/lavanet.lava.pairing.Query/GetPairing", method)
+
+	code, ok := findStringAttr(attrs, attrLavaChainCode)
+	require.True(t, ok)
+	require.Equal(t, codes.OK.String(), code)
+}
+
+func TestWrapClientConn_InvokeErrorRecordsCode(t *testing.T) {
+	sr := setupTestTracer(t)
+	inner := &fakeClientConn{invokeErr: status.Error(codes.Unavailable, "node unreachable")}
+	wrapped := WrapClientConn(inner)
+
+	err := wrapped.Invoke(context.Background(), "/foo.Bar/Baz", nil, nil)
+	require.Error(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	code, ok := findStringAttr(spans[0].Attributes(), attrLavaChainCode)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable.String(), code)
+}
+
+func TestStartLavaChainTx_RecordsMsgType(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	ctx, span := StartLavaChainTx(context.Background(), "/lavanet.lava.pairing.MsgRelayPayment")
+	require.NotNil(t, ctx)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanLavaChainSubmitTx, spans[0].Name())
+
+	msg, ok := findStringAttr(spans[0].Attributes(), attrLavaChainMsgType)
+	require.True(t, ok)
+	require.Equal(t, "/lavanet.lava.pairing.MsgRelayPayment", msg)
+}
+
+func TestStartLavaChainTx_RecordError(t *testing.T) {
+	sr := setupTestTracer(t)
+	_, span := StartLavaChainTx(context.Background(), "/foo.Bar/MsgX")
+	RecordError(span, errors.New("simulate failed"))
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.NotEqual(t, "", spans[0].Status().Description)
+}
+
+// findStringAttr returns the string value of the first attribute matching key.
+func findStringAttr(attrs []attribute.KeyValue, key string) (string, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}

--- a/protocol/tracing/spans_provider.go
+++ b/protocol/tracing/spans_provider.go
@@ -1,0 +1,82 @@
+package tracing
+
+import (
+	"context"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartProviderHandleRelay starts the top-level provider relay span. The
+// caller is the otelgrpc server interceptor's already-rooted ctx (so this
+// span is a child of the auto-generated SERVER span).
+func StartProviderHandleRelay(ctx context.Context, guid uint64, chainID, apiInterface string) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderHandleRelay,
+		trace.WithAttributes(
+			attribute.String(attrRelayGUID, strconv.FormatUint(guid, 10)),
+			attribute.String(attrRelayChainID, chainID),
+			attribute.String(attrRelayAPIInterface, apiInterface),
+		),
+	)
+}
+
+// StartProviderInitRelay starts the initRelay span (parsing + session lookup).
+func StartProviderInitRelay(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderInitRelay)
+}
+
+// StartProviderValidateRequest starts the validation span (signature, addons).
+func StartProviderValidateRequest(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderValidateRequest)
+}
+
+// StartProviderCacheLookup starts the provider-side cache-lookup span.
+// Caller fills attributes with RecordCacheLookup from spans_consumer.go
+// (passing "provider" as the role).
+func StartProviderCacheLookup(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderCacheLookup)
+}
+
+// StartProviderHandleConsistency starts the block-wait span. targetBlock is
+// the requestBlock or seenBlock the provider must reach.
+func StartProviderHandleConsistency(ctx context.Context, targetBlock int64) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderHandleConsistency,
+		trace.WithAttributes(attribute.Int64(attrConsistencyTargetBlock, targetBlock)),
+	)
+}
+
+// StartProviderTryRelay starts the relay-execution span (parent for SendUpstream).
+func StartProviderTryRelay(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderTryRelay)
+}
+
+// StartProviderSendUpstream starts the chainlib upstream-call span. The
+// chainlib-internal sendJSONRPCRelay/sendRESTRelay/sendGRPCRelay spans
+// (already shared between SR and provider) become children of this span.
+func StartProviderSendUpstream(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderSendUpstream)
+}
+
+// StartProviderCacheStore starts the cache-write span.
+func StartProviderCacheStore(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderCacheStore)
+}
+
+// StartProviderFinalizeSession starts the session-finalize span (accounting + signing).
+func StartProviderFinalizeSession(ctx context.Context) (context.Context, trace.Span) {
+	return otel.Tracer(tracerName).Start(ctx, SpanProviderFinalizeSession)
+}
+
+// RecordHandleConsistencyResult attaches consistency.waited_ms and consistency.bailed
+// to a HandleConsistency span once the wait loop returns.
+//
+// Distinct from RecordConsistencyStats (in span_helpers.go), which is for
+// the consumer's cross-validation total/passed/rejected counts.
+func RecordHandleConsistencyResult(span trace.Span, waitedMs int64, bailed bool) {
+	span.SetAttributes(
+		attribute.Int64(attrConsistencyWaitedMs, waitedMs),
+		attribute.Bool(attrConsistencyBailed, bailed),
+	)
+}

--- a/protocol/tracing/spans_provider_test.go
+++ b/protocol/tracing/spans_provider_test.go
@@ -1,0 +1,58 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestStartProviderHandleRelay_RecordsAttrs(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	_, span := StartProviderHandleRelay(context.Background(), 999, "ETH1", "jsonrpc")
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanProviderHandleRelay, spans[0].Name())
+}
+
+func TestStartProviderHandleConsistency_RecordsTimingAttrs(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	_, span := StartProviderHandleConsistency(context.Background(), 1500)
+	RecordHandleConsistencyResult(span, 25, false)
+	span.End()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, SpanProviderHandleConsistency, spans[0].Name())
+
+	target, ok := findInt64Attr(spans[0].Attributes(), attrConsistencyTargetBlock)
+	require.True(t, ok)
+	require.Equal(t, int64(1500), target)
+
+	bailed, ok := findBoolAttr(spans[0].Attributes(), attrConsistencyBailed)
+	require.True(t, ok)
+	require.False(t, bailed)
+}
+
+func findInt64Attr(attrs []attribute.KeyValue, key string) (int64, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func findBoolAttr(attrs []attribute.KeyValue, key string) (bool, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsBool(), true
+		}
+	}
+	return false, false
+}

--- a/protocol/tracing/trace_manager.go
+++ b/protocol/tracing/trace_manager.go
@@ -59,14 +59,17 @@ import (
 //	  (each has a TRACES_-prefixed per-signal variant)
 const TraceBodyFlag = "otel-trace-body"
 
-// defaultServiceName is used when OTEL_SERVICE_NAME is not set.
-const defaultServiceName = "lava-smartrouter"
-
 const shutdownTimeout = 5 * time.Second
 
 // TraceConfig holds Lava-specific tracing configuration.
 // Standard OTel knobs are read from environment variables — see TraceBodyFlag doc.
 type TraceConfig struct {
+	// DefaultServiceName is the in-code default for the OTel `service.name`
+	// resource attribute. Each binary supplies its own (e.g. "lava-consumer",
+	// "lava-provider", "lava-smartrouter"). The OTel `OTEL_SERVICE_NAME` env
+	// var still wins via resource.WithFromEnv() if set. Required.
+	DefaultServiceName string
+
 	// TraceBody enables recording of request/response bodies as span attributes.
 	// Body size truncation is delegated to the SDK via SpanLimits, which
 	// reads OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited).
@@ -97,6 +100,13 @@ type TraceManager struct {
 // New initialises the OTel SDK based on standard environment variables.
 // See TraceBodyFlag for the full env var contract.
 func New(ctx context.Context, cfg TraceConfig) (*TraceManager, error) {
+	if cfg.DefaultServiceName == "" {
+		return nil, utils.LavaFormatError(
+			"TraceConfig.DefaultServiceName is required",
+			nil,
+		)
+	}
+
 	if isSDKDisabled() {
 		warnIfBodySetButTracingOff(cfg)
 		return newNoop(), nil
@@ -126,7 +136,7 @@ func New(ctx context.Context, cfg TraceConfig) (*TraceManager, error) {
 	bodyAttrLimit = sdktrace.NewSpanLimits().AttributeValueLengthLimit
 
 	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(defaultServiceName)),
+		resource.WithAttributes(semconv.ServiceName(cfg.DefaultServiceName)),
 		resource.WithFromEnv(), // OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES
 	)
 	if err != nil {

--- a/protocol/tracing/trace_manager_test.go
+++ b/protocol/tracing/trace_manager_test.go
@@ -43,7 +43,7 @@ func TestNew_Disabled(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			tm, err := New(context.Background(), TraceConfig{TraceBody: true})
+			tm, err := New(context.Background(), TraceConfig{DefaultServiceName: "lava-test-binary", TraceBody: true})
 			require.NoError(t, err)
 			require.NotNil(t, tm)
 
@@ -227,6 +227,25 @@ func clearTracingEnv(t *testing.T) {
 		t.Setenv(k, "") // register cleanup
 		os.Unsetenv(k)  // then actually unset for the test body
 	}
+}
+
+func TestNew_DefaultServiceName(t *testing.T) {
+	clearTracingEnv(t)
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	tm, err := New(context.Background(), TraceConfig{DefaultServiceName: "lava-test-binary"})
+	require.NoError(t, err)
+	require.NotNil(t, tm)
+	tm.Shutdown()
+}
+
+func TestNew_DefaultServiceNameRequired(t *testing.T) {
+	clearTracingEnv(t)
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	_, err := New(context.Background(), TraceConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DefaultServiceName")
 }
 
 func TestBuildPropagatorFromEnv(t *testing.T) {


### PR DESCRIPTION
# Description

- **End-to-end trace stitching** consumer → provider → upstream chain node via Fiber HTTP middleware (`chainlib.HandleHTTP`), `otelgrpc` stats handlers on the consumer↔provider gRPC hop, and `chainlib.sendJSONRPCRelay/sendRESTRelay/sendGRPCRelay/sendTendermintRPCRelay` spans wrapping the upstream call.
- **Lava-chain visibility** without touching `lavad`: `tracing.WrapClientConn` emits `lavachain.Query` spans on every Cosmos SDK ABCI query; `tracing.StartLavaChainTx` wraps `TxSender.SendTxAndVerifyCommit`.
- **W3C `traceparent` propagation** at every hop, including outbound HTTP/gRPC requests to upstream chain nodes (per-request, race-free via `rpcclient.WithHeaders`).
- **Per-binary `service.name`** (`lava-consumer` / `lava-provider` / `lava-smartrouter`) so co-located processes show as distinct services in tracing UIs.
- **WebSocket subscriptions** trace handshake-class events only; server-pushed stream events produce no spans (regression-guarded by AST test).