### PR TITLE
fix(conflict): assign result of bail.Quo so non-voters are bailed at 1/5 stake

### DIFF
--- a/x/conflict/keeper/vote.go
+++ b/x/conflict/keeper/vote.go
@@ -112,8 +112,10 @@ func (k Keeper) HandleAndCloseVote(ctx sdk.Context, conflictVote types.ConflictV
 		default:
 			// punish providers that didnt vote
 			providersWithoutVote = append(providersWithoutVote, vote.Address)
-			bail := stake
-			bail.Quo(sdk.NewIntFromUint64(BailStakeDiv))
+			// sdk.Int.Quo is immutable - it returns a new Int and does not
+			// mutate the receiver. The result must be assigned, otherwise the
+			// bail equals the full stake instead of stake / BailStakeDiv.
+			bail := stake.Quo(sdk.NewIntFromUint64(BailStakeDiv))
 			err = k.pairingKeeper.JailEntry(ctx, vote.Address, conflictVote.ChainID, conflictVote.VoteStartBlock, blocksToSave, sdk.NewCoin(k.stakingKeeper.BondDenom(ctx), bail))
 			if err != nil {
 				utils.LavaFormatWarning("jailing failed at vote conflict", err)


### PR DESCRIPTION
# Description

Issue: #2292 

In `HandleAndCloseVote` (`x/conflict/keeper/vote.go`), the bail amount for providers that failed to vote was computed as:

```go
bail := stake
bail.Quo(sdk.NewIntFromUint64(BailStakeDiv))
```

sdk.Int (cosmossdk.io/math v1.3.0) is immutable: Quo has a value receiver and returns a freshly allocated Int (SafeQuo → div() does new(big.Int).Quo(...)). The receiver is never mutated, so the return value here was discarded and bail stayed equal to the full stake.

As a result JailEntry received the entire stake as bail instead of stake / BailStakeDiv (BailStakeDiv = 5, i.e. 20%). The call just below at line ~137 (halfTotalVotes := totalVotes.Quo(...)) uses the correct assigning form, confirming this was an oversight.

Current blast radius: pairingKeeper.JailEntry is still a // todo stub that does not consume the bail coin, so this bug has no on chain effect today and the change is not consensus-breaking. It is a latent correctness bug that would surface as a 5x over bail for non-voting providers the moment JailEntry is implemented. Fixing now so that implementation lands against correct input.

Fix: assign the division result.

bail := stake.Quo(sdk.NewIntFromUint64(BailStakeDiv))

Files to review

- x/conflict/keeper/vote.go — the only changed file (3-line diff: the fix plus an explanatory comment on sdk.Int immutability).