### PR TITLE
build(docker): harden geo-database downloads in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,11 +85,25 @@ ENV BUILD_COMMIT=${GIT_COMMIT}
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 
-# Download  IP geolocation database
-RUN curl https://iptoasn.com/data/ip2asn-v4.tsv.gz -o /tmp/ip2asn-v4.tsv.gz \
-    && gunzip /tmp/ip2asn-v4.tsv.gz
+# Download IP geolocation databases.
+# curl flags: -f fails (non-zero exit) on HTTP errors instead of silently
+# saving the error page as the "database"; -S surfaces the error; -L follows
+# redirects; -s hides the progress meter.
+# Optionally pin SHA-256 checksums via build args to detect tampering or
+# corruption in transit. They default to empty (verification skipped) because
+# the ip2asn dataset is refreshed upstream frequently; operators can pin a
+# known-good digest at build time, e.g. --build-arg COUNTRIES_SHA256=<hash>.
+ARG IP2ASN_SHA256=""
+ARG COUNTRIES_SHA256=""
 
-RUN curl https://storage.googleapis.com/lavanet-public-asssets/countries.csv -o /tmp/countries.csv
+RUN curl -fsSL https://iptoasn.com/data/ip2asn-v4.tsv.gz -o /tmp/ip2asn-v4.tsv.gz \
+    && if [ -n "$IP2ASN_SHA256" ]; then echo "$IP2ASN_SHA256  /tmp/ip2asn-v4.tsv.gz" | sha256sum -c -; fi \
+    && gunzip /tmp/ip2asn-v4.tsv.gz \
+    && test -s /tmp/ip2asn-v4.tsv
+
+RUN curl -fsSL https://storage.googleapis.com/lavanet-public-asssets/countries.csv -o /tmp/countries.csv \
+    && if [ -n "$COUNTRIES_SHA256" ]; then echo "$COUNTRIES_SHA256  /tmp/countries.csv" | sha256sum -c -; fi \
+    && test -s /tmp/countries.csv
 
 # Build lavad binary
 RUN --mount=type=cache,sharing=private,target=/root/.cache/go-build \


### PR DESCRIPTION
The two `curl` calls that fetch the IP geolocation databases (ip2asn-v4.tsv.gz, countries.csv) had no error or integrity checking:

1. RUN curl https://iptoasn.com/data/ip2asn-v4.tsv.gz -o /tmp/...
2. RUN curl https://storage.googleapis.com/.../countries.csv -o /tmp/...

Without `-f`, curl exits 0 on an HTTP 4xx/5xx and writes the error page body into the output file. The build then succeeds and the image silently ships a corrupt geo database. There was also no verification that the downloaded payload is what was expected.

Changes:
- Add `-fsSL` so curl fails loudly on HTTP errors and follows redirects.
- Add `test -s` after each download (and after gunzip) so an empty or
  truncated file fails the build instead of being baked into the image.
- Add optional `IP2ASN_SHA256` / `COUNTRIES_SHA256` build args; when set, the download is checksum-verified with `sha256sum -c`. They default to empty (skipped) because the ip2asn dataset is refreshed upstream frequently, so operators can pin a known-good digest at build time without breaking the default build.