### PR TITLE
fix(chainlib): reply to eth_unsubscribe instead of hanging the client

### DIFF
--- a/protocol/chainlib/consumer_websocket_manager.go
+++ b/protocol/chainlib/consumer_websocket_manager.go
@@ -274,7 +274,20 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages() {
 							websocketConnWriteChan <- webSocketMsgWithType{messageType: messageType, msg: formatterMsg}
 						}
 					}
-				} else if responseData != nil {
+				} else {
+					if responseData == nil {
+						// Legacy provider-relay path: Unsubscribe returns (nil, nil) on success
+						// because the provider's relay stream has no synchronous ack frame to
+						// forward. Synthesize a §4.2-compliant reply so clients don't hang on
+						// recv() until they time out. The JSON-RPC envelope is safe here:
+						// ConsumerWebsocketManager is only constructed by jsonRPC.go and
+						// tendermintRPC.go, both JSON-RPC-shaped.
+						responseData = buildUnsubscribeSuccessReply(msg)
+						utils.LavaFormatTrace("synthesized unsubscribe ack",
+							utils.LogAttr("GUID", webSocketCtx),
+							utils.LogAttr("dappID", dappID),
+						)
+					}
 					// Forward the node's response directly to the end user - no transformation or wrapping.
 					websocketConnWriteChan <- webSocketMsgWithType{messageType: messageType, msg: responseData}
 				}
@@ -372,4 +385,21 @@ func (cwm *ConsumerWebsocketManager) ListenToMessages() {
 			logger.LogRequestAndResponse("jsonrpc ws msg", false, "ws", websocketConn.LocalAddr().String(), string(msg), string(reply.Data), msgSeed, time.Since(startTime), nil)
 		}
 	}
+}
+
+// buildUnsubscribeSuccessReply synthesizes a JSON-RPC 2.0 success response for an
+// eth_unsubscribe / unsubscribe that the consumer satisfied locally — provider
+// relays do not surface an unsubscribe acknowledgement frame, so we fabricate
+// one here rather than letting clients hang. id is substituted as raw JSON to
+// preserve the caller's exact type (§4.2).
+//
+// result is hard-coded to `true`, matching EVM upstream conventions. Tendermint
+// upstreams typically return `{}` here; we optimize for "client unblocks"
+// rather than exact upstream parity.
+func buildUnsubscribeSuccessReply(requestBytes []byte) []byte {
+	idRaw := "null"
+	if r := gjson.GetBytes(requestBytes, "id"); r.Exists() {
+		idRaw = r.Raw
+	}
+	return []byte(`{"jsonrpc":"2.0","id":` + idRaw + `,"result":true}`)
 }

--- a/protocol/chainlib/consumer_websocket_manager_test.go
+++ b/protocol/chainlib/consumer_websocket_manager_test.go
@@ -7,7 +7,61 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestBuildUnsubscribeSuccessReply verifies that the synthesized reply for a
+// successful eth_unsubscribe / unsubscribe echoes the caller's JSON-RPC id
+// verbatim (per spec §4.2) and returns result:true. The legacy consumer
+// previously sent no frame at all on this path, hanging clients until they
+// timed out.
+func TestBuildUnsubscribeSuccessReply(t *testing.T) {
+	cases := []struct {
+		name string
+		req  string
+		want string
+	}{
+		{
+			name: "string id",
+			req:  `{"jsonrpc":"2.0","id":"sub-1","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":"sub-1","result":true}`,
+		},
+		{
+			name: "numeric id",
+			req:  `{"jsonrpc":"2.0","id":42,"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":42,"result":true}`,
+		},
+		{
+			name: "null id",
+			req:  `{"jsonrpc":"2.0","id":null,"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":null,"result":true}`,
+		},
+		{
+			name: "missing id falls back to null",
+			req:  `{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":null,"result":true}`,
+		},
+		{
+			name: "string id containing escaped quote round-trips",
+			req:  `{"jsonrpc":"2.0","id":"a\"b","method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":"a\"b","result":true}`,
+		},
+		{
+			// JSON-RPC 2.0 §4.2 recommends scalar ids but does not forbid structured
+			// ones. Lock in that we pass an object id through verbatim rather than
+			// silently corrupting it.
+			name: "object id passes through verbatim",
+			req:  `{"jsonrpc":"2.0","id":{"foo":1},"method":"eth_unsubscribe","params":["0xabc"]}`,
+			want: `{"jsonrpc":"2.0","id":{"foo":1},"result":true}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUnsubscribeSuccessReply([]byte(tc.req))
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
 
 func TestWebsocketConnectionLimiter(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
ConsumerWSSubscriptionManager.Unsubscribe returns (nil, nil) on success because the provider-relay stream has no synchronous ack frame to forward, which left consumer_websocket_manager writing nothing to the wire and clients waiting until their own timeout fired (~15s). Synthesize a JSON-RPC 2.0 §4.2-compliant {"jsonrpc":"2.0","id":<caller-id>,"result":true} frame at the websocket layer for the (nil, nil) case, echoing the caller's id verbatim via gjson.Raw to preserve string/number/null/object types.

Also cures the equivalent silent-hang on DirectWSSubscriptionManager's not-last-client and upstream-no-ack branches, which share the same (nil, nil) shape.

Verified locally: unsubscribe reply now arrives in ~2ms instead of timing out at 15s.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage