### PR TITLE
fix(chainlib): classify NEAR cause/data errors (UNKNOWN_BLOCK) correctly

### DIFF
--- a/protocol/chainlib/handle_and_classify_test.go
+++ b/protocol/chainlib/handle_and_classify_test.go
@@ -156,6 +156,43 @@ func TestValidateRequestAndResponseIds_NonScalarId(t *testing.T) {
 	require.Error(t, geh.ValidateRequestAndResponseIds([]byte(`1`), []byte(`2`)))
 }
 
+// TestExtractNodeErrorDetails_NEARUnknownBlock_FoldsCauseIntoClassification is a
+// regression test for the NEART "UNKNOWN_BLOCK" misclassification (non-archive node
+// asked for a pruned block). The body below is the verbatim response captured from a
+// live NEAR testnet node for block_id 217272549, whose height is below the node's
+// earliest retained block.
+//
+// NEAR puts the canonical error name in error.cause.name ("UNKNOWN_BLOCK"), while
+// error.message is just "Server error". Extraction must fold cause/data into the
+// classification message so the chain-scoped Tier-2 matcher fires; otherwise the
+// error lands on the generic NODE_SERVER_ERROR rule (and, on builds predating the
+// error registry, on the unsupported-method path that suppressed archive failover).
+func TestExtractNodeErrorDetails_NEARUnknownBlock_FoldsCauseIntoClassification(t *testing.T) {
+	const nearUnknownBlockBody = `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Server error","data":"DB Not Found Error: BLOCK HEIGHT: 217272549 \n Cause: Unknown","name":"HANDLER_ERROR","cause":{"info":{},"name":"UNKNOWN_BLOCK"}}}`
+	httpErr := rpcclient.HTTPError{
+		StatusCode: 422,
+		Status:     "422 Unprocessable Entity",
+		Body:       []byte(nearUnknownBlockBody),
+	}
+
+	// Extraction keeps the structured JSON-RPC code and folds cause/data so the
+	// discriminating token reaches the matchers.
+	code, msg := ExtractNodeErrorDetails(httpErr)
+	assert.Equal(t, -32000, code)
+	assert.Contains(t, msg, "UNKNOWN_BLOCK", "cause.name must be folded into the classification message")
+
+	// PRIMARY assertion: the NEAR Tier-2 matcher fires (was NODE_SERVER_ERROR before the fix).
+	classified := ClassifyNodeError(httpErr, common.ChainFamilyNEAR, common.TransportJsonRPC)
+	require.NotNil(t, classified)
+	assert.Equal(t, common.LavaErrorChainNEARUnknownBlock, classified,
+		"NEAR UNKNOWN_BLOCK must classify as CHAIN_NEAR_UNKNOWN_BLOCK")
+
+	// Sanity: a pruned-block error stays retryable (so the consumer can fail over to an
+	// archive node) and is never treated as an unsupported method.
+	assert.True(t, classified.Retryable, "UNKNOWN_BLOCK must stay retryable for archive failover")
+	assert.False(t, IsUnsupportedMethodError(httpErr), "must not be classified as unsupported method")
+}
+
 func TestUnwrapLavaError_FromWrapped(t *testing.T) {
 	err := common.NewLavaError(common.LavaErrorChainNonceTooLow, "test")
 	le := unwrapLavaError(err)

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -38,9 +38,10 @@ func NewSolanaNonRetryableError(err error) error {
 	return common.NewLavaError(common.LavaErrorChainSolanaMissingLongTerm, err.Error())
 }
 
-// ExtractNodeErrorDetails extracts the numeric error code and canonical message from a node error.
-// It handles three error shapes in priority order:
-//  1. HTTP-wrapped JSON-RPC body  — extracts .error.code / .error.message
+// ExtractNodeErrorDetails extracts the numeric error code and a classification
+// message from a node error. It handles three error shapes in priority order:
+//  1. HTTP-wrapped JSON-RPC body  — extracts .error.code and a message folded
+//     from .error's message + name + cause + data (see classificationMessage)
 //  2. gRPC status                 — extracts status code and description
 //  3. Raw HTTP status code        — extracts the HTTP status integer
 //
@@ -49,14 +50,17 @@ func NewSolanaNonRetryableError(err error) error {
 // an rpcclient.HTTPError must NOT be overwritten by the HTTP status code —
 // downstream classification relies on the structured JSON-RPC code.
 //
+// The returned message is for CLASSIFICATION and telemetry only; the original
+// node error is always surfaced to the user unchanged (transparent hop).
+//
 // Falls back to (0, err.Error()) when none of the above apply.
 func ExtractNodeErrorDetails(nodeError error) (errorCode int, errorMessage string) {
 	errorMessage = nodeError.Error()
 
 	// 1. HTTP-wrapped JSON-RPC body — the richest source, check first.
 	if jsonMsg := TryRecoverNodeErrorFromClientError(nodeError); jsonMsg != nil && jsonMsg.Error != nil {
-		if jsonMsg.Error.Message != "" {
-			errorMessage = jsonMsg.Error.Message
+		if msg := classificationMessage(jsonMsg.Error); msg != "" {
+			errorMessage = msg
 		}
 		return jsonMsg.Error.Code, errorMessage
 	}
@@ -75,6 +79,58 @@ func ExtractNodeErrorDetails(nodeError error) (errorCode int, errorMessage strin
 	}
 
 	return 0, errorMessage
+}
+
+// classificationMessage builds the message string used for ERROR CLASSIFICATION
+// (and telemetry) from a recovered JSON-RPC error. It is never shown to the user;
+// the original node error always passes through unchanged.
+//
+// Beyond .message it folds in .name, .cause and .data, because several chains carry
+// the canonical, matcher-relevant error identity outside the message field. NEAR is
+// the motivating case: querying a pruned block on a non-archive node returns
+//
+//	{"code":-32000,"message":"Server error","name":"HANDLER_ERROR",
+//	 "cause":{"name":"UNKNOWN_BLOCK"},"data":"DB Not Found Error: BLOCK HEIGHT: ..."}
+//
+// The discriminating token "UNKNOWN_BLOCK" lives in cause.name (the same is true for
+// NEAR's UNKNOWN_CHUNK / INVALID_SHARD_ID / NOT_SYNCED_YET). Folding it in lets the
+// Tier-2 NEAR matchers fire; without it the error misclassifies as a generic
+// NODE_SERVER_ERROR (and, on builds predating the error registry, as an unsupported
+// method — non-retryable + zero-CU — which suppressed failover to an archive node).
+//
+// Chain-scoped Tier-2 matchers run before generic Tier-1 ones, so a chain that
+// declares its own matcher (NEAR here) is classified by it before any broadened
+// message can reach a Tier-1 rule.
+func classificationMessage(jsonErr *rpcclient.JsonError) string {
+	parts := make([]string, 0, 4)
+	if jsonErr.Message != "" {
+		parts = append(parts, jsonErr.Message)
+	}
+	for _, field := range []interface{}{jsonErr.Name, jsonErr.Cause, jsonErr.Data} {
+		if s := stringifyErrorField(field); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// stringifyErrorField renders an arbitrary JSON-RPC error sub-field (string, object,
+// number, ...) into a string suitable for substring/regex matching. Strings pass
+// through as-is; everything else is JSON-encoded so nested tokens (e.g. cause.name)
+// stay visible to the matchers. goccy/go-json sorts object keys, so the encoding is
+// deterministic for a given input.
+func stringifyErrorField(v interface{}) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // ClassifyNodeError classifies a node error into a LavaError using the error registry.


### PR DESCRIPTION
## Problem

`ExtractNodeErrorDetails` builds the message used for error classification from only `.error.message` (+ `.error.code`). NEAR carries its canonical error name in `.error.cause.name`. A request for a pruned block on a **non-archive** NEAR node returns:

```json
{"error":{"code":-32000,"message":"Server error",
 "name":"HANDLER_ERROR","cause":{"name":"UNKNOWN_BLOCK"},
 "data":"DB Not Found Error: BLOCK HEIGHT: ..."}}
```

The discriminating token (`UNKNOWN_BLOCK`) lives in `cause.name` while `.message` is just `"Server error"`, so the Tier-2 NEAR matcher never sees it and the error falls back to the generic `NODE_SERVER_ERROR`. On builds predating the error registry (#2261) the same error was tagged **"unsupported method"** (non-retryable + zero-CU), which suppressed consumer failover to an archive provider — the QoS/relay-failure symptom reported on NEART.

All four NEAR Tier-2 tokens are `cause.name` values: `UNKNOWN_BLOCK`, `UNKNOWN_CHUNK`, `INVALID_SHARD_ID`, `NOT_SYNCED_YET`.

## Fix

Fold `.name`, `.cause`, and `.data` into the message used for **classification + telemetry only**. The node error still passes through to the user unchanged (transparent hop). Tier-2 (chain-scoped) matchers run before Tier-1, so the broadened message cannot pull a chain with its own matcher into a generic rule.

## Verification

- Regression test (`TestExtractNodeErrorDetails_NEARUnknownBlock_FoldsCauseIntoClassification`) uses the **verbatim body captured from a live non-archive NEAR testnet node**. Proven to **fail without** the change (`NODE_SERVER_ERROR`) and **pass with** it (`CHAIN_NEAR_UNKNOWN_BLOCK`, Retryable=true).
- Full `chainlib`, `common`, `rpcsmartrouter` suites + `go vet` + `gofumpt` clean.

## Scope (NEAR only — Polygon tracked separately)

The original report also named Polygon. Investigation showed Polygon's failure is an **unrelated** JSON-RPC id-validation bug (a client sending a non-scalar `id`), **not** a classification issue — Polygon error identity lives in `.message` and already classifies correctly. That is addressed in a **separate PR**. This change is NEAR-only and verified against a live NEAR testnet node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)