### PR TITLE
fix(chainlib): tolerate non-scalar JSON-RPC request ids in id validation

### DIFF
--- a/protocol/chainlib/handle_and_classify_test.go
+++ b/protocol/chainlib/handle_and_classify_test.go
@@ -124,6 +124,38 @@ func TestExtractNodeErrorDetails_HTTPStatusFallback(t *testing.T) {
 	assert.Equal(t, 503, code, "HTTP status must be used when no JSON-RPC body is recoverable")
 }
 
+// TestValidateRequestAndResponseIds_NonScalarId is a regression test for the JSON-RPC
+// id-validation failure reported on Polygon (reproducible on every chain): a client sends a
+// non-scalar (object/array) request id — invalid per JSON-RPC 2.0. Captured against live
+// nodes: Polygon rejects it and replies id:null, while NEAR accepts it, returns a valid
+// result, and echoes the object id back. Previously lavap parsed the request id first and
+// hard-failed both ("failed parsing ID"), turning a clean node rejection / a valid response
+// into a relay failure + cross-provider retry storm.
+func TestValidateRequestAndResponseIds_NonScalarId(t *testing.T) {
+	geh := &genericErrorHandler{}
+	obj := []byte(`{"x":1}`)
+	// verbatim .NET CancellationToken id from the live Polygon log
+	cancellationToken := []byte(`{"IsCancellationRequested":false,"CanBeCanceled":false,"WaitHandle":{"Handle":{"value":6404},"SafeWaitHandle":{"IsInvalid":false,"IsClosed":false}}}`)
+
+	// Polygon: node rejects the object id -> response id null. Skip validation so the node's
+	// own "invalid request" passes through instead of a spurious ID mismatch + retry storm.
+	require.NoError(t, geh.ValidateRequestAndResponseIds(cancellationToken, []byte(`null`)))
+	require.NoError(t, geh.ValidateRequestAndResponseIds(obj, []byte(`null`)))
+
+	// NEAR: node accepts the object id and echoes it -> response id == request id. Must be OK
+	// so the valid result is not discarded.
+	require.NoError(t, geh.ValidateRequestAndResponseIds(obj, []byte(`{"x":1}`)))
+	// tolerant of insignificant whitespace / key formatting in the echoed id
+	require.NoError(t, geh.ValidateRequestAndResponseIds(obj, []byte(`{ "x": 1 }`)))
+
+	// A genuinely different object id is still a mismatch.
+	require.Error(t, geh.ValidateRequestAndResponseIds(obj, []byte(`{"x":2}`)))
+
+	// Scalar behavior unchanged: matching scalars OK, mismatched scalars error.
+	require.NoError(t, geh.ValidateRequestAndResponseIds([]byte(`1`), []byte(`1`)))
+	require.Error(t, geh.ValidateRequestAndResponseIds([]byte(`1`), []byte(`2`)))
+}
+
 func TestUnwrapLavaError_FromWrapped(t *testing.T) {
 	err := common.NewLavaError(common.LavaErrorChainNonceTooLow, "test")
 	le := unwrapLavaError(err)

--- a/protocol/chainlib/jsonRPC_nonscalar_id_test.go
+++ b/protocol/chainlib/jsonRPC_nonscalar_id_test.go
@@ -1,0 +1,100 @@
+package chainlib
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lavanet/lava/v5/protocol/chainlib/extensionslib"
+	spectypes "github.com/lavanet/lava/v5/x/spec/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendNodeMsg_NonScalarRequestId is an end-to-end regression test for the JSON-RPC
+// id-validation fix. It drives the real ParseMsg -> SendNodeMsg path against a mock node.
+//
+// A client may send a non-scalar (object/array) request id — invalid per JSON-RPC 2.0,
+// e.g. a .NET CancellationToken serialized into the id. Two node behaviours were observed
+// against live nodes, and both must be handled without failing the relay:
+//
+//   - NEAR-like: the node accepts the id, returns a valid result, and echoes the object id
+//     back. The valid result must be returned, not discarded.
+//   - Polygon-like: the node rejects the id per spec and replies id:null + "invalid request".
+//     That clean node error must pass through to the consumer (no spurious "ID mismatch" or
+//     cross-provider retry storm).
+//
+// Before the fix both cases hard-failed with "failed parsing ID ... not a string or float".
+func TestSendNodeMsg_NonScalarRequestId(t *testing.T) {
+	ctx := context.Background()
+	// The client sends a non-scalar (object) id — the malformed-client case.
+	objIDRequest := []byte(`{"jsonrpc":"2.0","id":{"x":1},"method":"eth_blockNumber","params":[]}`)
+	wsNoop := func(string) string { return `{"jsonrpc":"2.0","id":1,"result":"0x10a7a08"}` }
+
+	requestID := func(body []byte) string {
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+		return strings.TrimSpace(string(req.ID))
+	}
+
+	t.Run("node echoes object id and returns a result (NEAR-like)", func(t *testing.T) {
+		// GIVEN a node that echoes the request id verbatim and returns a valid result
+		node := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			id := requestID(body)
+			if id == "" {
+				id = "null"
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":"0x10a7a08"}`, id)
+		})
+		chainParser, chainRouter, _, closeServer, _, err := CreateChainLibMocks(ctx, "ETH1", spectypes.APIInterfaceJsonRPC, node, createWebSocketHandler(wsNoop), "../../", nil)
+		if closeServer != nil {
+			defer closeServer()
+		}
+		require.NoError(t, err)
+
+		// WHEN a request carrying a non-scalar id is relayed
+		chainMessage, err := chainParser.ParseMsg("", objIDRequest, "POST", nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+		reply, _, _, _, _, err := chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
+
+		// THEN the relay succeeds and the valid result is returned (not discarded on an id parse error)
+		require.NoError(t, err)
+		require.NotNil(t, reply)
+		require.Contains(t, string(reply.RelayReply.Data), "0x10a7a08")
+	})
+
+	t.Run("node rejects object id with id:null (Polygon-like)", func(t *testing.T) {
+		// GIVEN a node that rejects a non-scalar id per spec (id:null + invalid request)
+		node := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			if id := requestID(body); strings.HasPrefix(id, "{") || strings.HasPrefix(id, "[") {
+				fmt.Fprint(w, `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request"}}`)
+			} else {
+				fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":"0x10a7a08"}`)
+			}
+		})
+		chainParser, chainRouter, _, closeServer, _, err := CreateChainLibMocks(ctx, "ETH1", spectypes.APIInterfaceJsonRPC, node, createWebSocketHandler(wsNoop), "../../", nil)
+		if closeServer != nil {
+			defer closeServer()
+		}
+		require.NoError(t, err)
+
+		// WHEN a request carrying a non-scalar id is relayed
+		chainMessage, err := chainParser.ParseMsg("", objIDRequest, "POST", nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+		require.NoError(t, err)
+		reply, _, _, _, _, err := chainRouter.SendNodeMsg(ctx, nil, chainMessage, nil)
+
+		// THEN the relay does not hard-fail; the node's own error passes through to the consumer
+		require.NoError(t, err)
+		require.NotNil(t, reply)
+		require.Contains(t, string(reply.RelayReply.Data), "invalid request")
+	})
+}

--- a/protocol/chainlib/node_error_handler.go
+++ b/protocol/chainlib/node_error_handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -311,13 +312,14 @@ func (geh *genericErrorHandler) HandleJSONFormatError(replyData []byte) error {
 }
 
 func (geh *genericErrorHandler) ValidateRequestAndResponseIds(nodeMessageID json.RawMessage, replyMsgID json.RawMessage) error {
-	reqId, idErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessageID)
-	if idErr != nil {
-		return fmt.Errorf("failed parsing ID %s", idErr.Error())
-	}
-
 	// Allow empty/missing response ID for non-standard JSON-RPC implementations (e.g., XRPL/Ripple)
-	// Some chains don't follow JSON-RPC 2.0 spec strictly and omit the ID field in responses
+	// Some chains don't follow JSON-RPC 2.0 spec strictly and omit the ID field in responses.
+	// A spec-compliant node also replies id:null when it rejects an invalid request, so this
+	// also covers the case where a client sent a malformed (non-scalar) request id.
+	//
+	// This check MUST run before parsing the request id below: a client may send a non-scalar
+	// (object/array) id, and parsing the request id first would surface that as a spurious
+	// "failed parsing ID" — masking the node's actual response and turning it into a relay failure.
 	//
 	// TODO: In the future, add a spec-level parameter (e.g., in api_collection or as an add-on flag)
 	// to explicitly declare when a chain allows non-standard JSON-RPC responses. This validation
@@ -329,14 +331,37 @@ func (geh *genericErrorHandler) ValidateRequestAndResponseIds(nodeMessageID json
 		return nil // Skip ID validation when response has no ID
 	}
 
-	respId, idErr := rpcInterfaceMessages.IdFromRawMessage(replyMsgID)
-	if idErr != nil {
-		return fmt.Errorf("failed parsing ID %s", idErr.Error())
+	reqId, reqErr := rpcInterfaceMessages.IdFromRawMessage(nodeMessageID)
+	respId, respErr := rpcInterfaceMessages.IdFromRawMessage(replyMsgID)
+
+	// IdFromRawMessage only accepts scalar ids (string/number/null). A non-scalar id (object/
+	// array) is invalid per JSON-RPC 2.0, but a client may still send one and a lenient node
+	// may echo it back verbatim (observed on NEAR, which returns a valid result with the object
+	// id echoed). When either id is non-scalar, compare the ids semantically instead of
+	// erroring: equal ids mean the node answered this request, so the (valid) response must not
+	// be discarded; unequal ids are a genuine mismatch.
+	if reqErr != nil || respErr != nil {
+		if rawJSONEqual(nodeMessageID, replyMsgID) {
+			return nil
+		}
+		return fmt.Errorf("ID mismatch error")
 	}
+
 	if reqId != respId {
 		return fmt.Errorf("ID mismatch error")
 	}
 	return nil
+}
+
+// rawJSONEqual reports whether two raw JSON-RPC ids are semantically equal, tolerant of
+// insignificant whitespace and object key ordering. Used as a fallback when an id is a
+// non-scalar (object/array) that IdFromRawMessage cannot reduce to a comparable scalar.
+func rawJSONEqual(a, b json.RawMessage) bool {
+	var av, bv interface{}
+	if json.Unmarshal(a, &av) != nil || json.Unmarshal(b, &bv) != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
 }
 
 func TryRecoverNodeErrorFromClientError(nodeErr error) *rpcclient.JsonrpcMessage {


### PR DESCRIPTION
## Problem

`ValidateRequestAndResponseIds` parsed the **request** id (via `IdFromRawMessage`, which only accepts string/number/null) *before* reaching its existing "null/empty response id" carve-out. So when a client sends a **non-scalar** `id` (object/array) — invalid per JSON-RPC 2.0 — lavap hard-fails with `failed parsing ID …`, which surfaces to the consumer as `jsonRPC ID mismatch error → failed relay, insufficient results` and triggers a **cross-provider retry storm**, even when the relay itself was fine.

Observed in production on Polygon: a .NET client serialized a `CancellationToken` into the `id`:

```
{"IsCancellationRequested":false,"CanBeCanceled":false,"WaitHandle":{"Handle":{"value":6404},...}}
```

Captured against live nodes, the two react differently — and **both** were being failed:
- **Polygon** rejects the object id and replies `id:null` (correct per spec).
- **NEAR** accepts it, returns a **valid result**, and **echoes the object id back** — which lavap then discarded.

This is chain-agnostic: the same failure reproduces on any chain (confirmed by sending an object id to both gateways).

## Fix

- **Reorder**: evaluate the `null`/empty/`[]` response-id carve-out **first**, before parsing the request id (covers Polygon's `id:null` rejection — the node's own `invalid request` now passes through instead of a retry storm).
- **Semantic fallback**: when either id is non-scalar, compare the ids by value (tolerant of whitespace / object key order) instead of erroring (covers NEAR's verbatim echo, preserving the valid response). A genuinely different id is still reported as a mismatch.
- Scalar-id behaviour is unchanged.

The root cause is a non-compliant client (an object `id` violates JSON-RPC 2.0); this change makes lavap surface the node's real response instead of masking it behind an internal "ID mismatch".

## Verification

- New regression test `TestValidateRequestAndResponseIds_NonScalarId`: proven to **fail without** the change with the exact production error (`failed parsing ID … not a string or float (id: {…CancellationToken…})`) and **pass with** it. Covers Polygon (object→null), NEAR (object echo), whitespace tolerance, genuine object mismatch, and unchanged scalar cases.
- Full `chainlib` suite + `go build` / `go vet` / `gofmt` clean.

## Relationship to #2301

Separate root cause from #2301 (NEAR `UNKNOWN_BLOCK` classification). This PR addresses the Polygon-reported failure; the two are independent and touch different code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)