### PR TITLE
fix(provider): recover from panics in reward-claim gas estimation

### DIFF
--- a/protocol/rpcprovider/rewardserver/reward_server.go
+++ b/protocol/rpcprovider/rewardserver/reward_server.go
@@ -3,6 +3,7 @@ package rewardserver
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -293,6 +294,18 @@ func (rws *RewardServer) sendRewardsClaim(ctx context.Context, epoch uint64) err
 			}
 			go func(rewards []*pairingtypes.RelaySession, payment *PaymentConfiguration) { // send rewards asynchronously
 				defer paymentWaitGroup.Done()
+				// Backstop: this reward claim runs asynchronously, so an unrecovered panic here
+				// (e.g. the nil-GasInfo dereference inside CalculateGas during gas estimation)
+				// would crash the entire lavap process. Recover, log, and mark the claim for
+				// retry instead of taking the provider down.
+				defer func() {
+					if r := recover(); r != nil {
+						utils.LavaFormatError("recovered from panic in reward claim goroutine", nil,
+							utils.LogAttr("recovered", r),
+							utils.LogAttr("stack", string(debug.Stack())))
+						rws.updatePaymentRequestAttempt(rewards, false)
+					}
+				}()
 				specs := map[string]struct{}{}
 				if payment.shouldAddExpectedPayment {
 					for _, relay := range rewards {

--- a/protocol/rpcprovider/rewardserver/reward_server_test.go
+++ b/protocol/rpcprovider/rewardserver/reward_server_test.go
@@ -453,6 +453,36 @@ func TestFailedPaymentRequestAttemptsHappyFlow(t *testing.T) {
 	require.Equal(t, MaxPaymentRequestsRetiresForSession, rewardTxSent)
 }
 
+// TestSendRewardsClaim_RecoversFromTxPanic is a regression test for the provider crash where a
+// nil-pointer panic during reward-claim gas estimation (cosmos-sdk CalculateGas dereferencing a
+// nil GasInfo) took down the whole lavap process. The claim runs in a goroutine, so an
+// unrecovered panic there crashes the program. The goroutine must recover, log, and mark the
+// claim for retry. Reaching the assertions at all proves recovery worked — without it the test
+// binary would crash.
+func TestSendRewardsClaim_RecoversFromTxPanic(t *testing.T) {
+	rand.InitRandomSeed()
+	const providerAddr = "providerAddr"
+	spec := "spec1"
+
+	rewardDB, err := createInMemoryRewardDb([]string{spec})
+	require.NoError(t, err)
+
+	stubRewardsTxSender := rewardsTxSenderMock{
+		txRelayPaymentCallback: func(ctx context.Context, rs []*pairingtypes.RelaySession, s string, lbr []*pairingtypes.LatestBlockReport) error {
+			panic("runtime error: invalid memory address or nil pointer dereference")
+		},
+	}
+
+	ctx := sdk.WrapSDKContext(sdk.NewContext(nil, tmproto.Header{}, false, nil))
+	rws := NewRewardServer(&stubRewardsTxSender, nil, rewardDB, "badger_test", 1, 1, nil)
+
+	session := common.BuildRelayRequestWithSession(ctx, providerAddr, []byte{}, uint64(1), uint64(42), spec, nil)
+	rws.SendNewProof(ctx, session, 1, "consumerAddress", "apiInterface")
+
+	rws.sendRewardsClaim(ctx, 1)
+	require.Equal(t, 1, len(rws.failedRewardsPaymentRequests), "panicked claim must be recovered and marked for retry")
+}
+
 func TestFailedPaymentRequestAttemptsHappyMultipleSessions(t *testing.T) {
 	rand.InitRandomSeed()
 	const providerAddr = "providerAddr"

--- a/protocol/statetracker/tx_sender.go
+++ b/protocol/statetracker/tx_sender.go
@@ -165,10 +165,28 @@ func (ts *TxSender) parseTxErrorsAndTryGettingANewFactory(txResultString string,
 	return txfactory, fmt.Errorf("%s", txResultString)
 }
 
+// calculateGasWithRecover wraps cosmos-sdk's tx.CalculateGas and converts a panic into an
+// error. CalculateGas dereferences the Simulate response's GasInfo without a nil check
+// (cosmos-sdk client/tx/tx.go), so a node that returns a successful Simulate response with
+// no GasInfo triggers a nil-pointer panic. Left unrecovered, that panic crashes the whole
+// lavap process (observed from the async reward-claim goroutine). Recovering here turns it
+// into a normal error that the retry/fail handling below can deal with.
+func calculateGasWithRecover(clientCtx client.Context, txf tx.Factory, msg sdk.Msg) (gasUsed uint64, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			gasUsed = 0
+			err = utils.LavaFormatError("recovered from panic during gas estimation", nil,
+				utils.LogAttr("recovered", r))
+		}
+	}()
+	_, gasUsed, err = tx.CalculateGas(clientCtx, txf, msg)
+	return gasUsed, err
+}
+
 func (ts *TxSender) simulateTxWithRetry(clientCtx client.Context, txfactory tx.Factory, msg sdk.Msg) (tx.Factory, uint64, error) {
 	for retrySimulation := 0; retrySimulation < RETRY_INCORRECT_SEQUENCE; retrySimulation++ {
 		utils.LavaFormatDebug("Running Simulation", utils.LogAttr("idx", retrySimulation))
-		_, gasUsed, err := tx.CalculateGas(clientCtx, txfactory, msg)
+		gasUsed, err := calculateGasWithRecover(clientCtx, txfactory, msg)
 		if err != nil {
 			utils.LavaFormatInfo("Simulation failed", utils.LogAttr("reason:", err))
 			errString := err.Error()


### PR DESCRIPTION
## Problem

A provider can **crash (SIGSEGV)** while claiming rewards:

```
RewardServer.sendRewardsClaim (goroutine)
  └─ ProviderTxSender.TxRelayPayment
       └─ SimulateAndBroadCastTxWithRetryOnSeqMismatch
            └─ simulateTxWithRetry
                 └─ tx.CalculateGas   💥 nil pointer dereference
```

cosmos-sdk's `CalculateGas` does `simRes.GasInfo.GasUsed` with **no nil check** (`client/tx/tx.go`). A node can return a successful `Simulate` response with `GasInfo == nil` (the proto field is optional), so the dereference panics — `addr=0x8` in the signal is exactly the offset of `GasUsed` inside `GasInfo`. The reward claim runs in an **un-recovered goroutine**, so that panic crashes the **entire lavap provider process** (downtime, missed relays, lost claim).

## Fix (lavap-side, two layers)

1. `simulateTxWithRetry` now calls `calculateGasWithRecover`, which wraps `tx.CalculateGas` and converts a panic into a normal error handled by the existing retry/fail path. It lives in the shared simulation path, so it protects **every** gas-estimated tx (consumer + provider), not just reward claims.
2. A backstop `recover()` in the reward-claim goroutine logs the panic + stack and marks the claim for retry, so no panic in that async path can take the provider down.

Normal behavior is unchanged.

## Verification

- New regression test `TestSendRewardsClaim_RecoversFromTxPanic` (panicking `TxRelayPayment` mock): proven to **fail without** the change (the goroutine panic crashes the test binary) and **pass with** it; the recovered claim is marked for retry.
- Full `rewardserver` + `statetracker` packages, `go vet`, `gofmt` all clean.

## Related (not in this PR)

The **root** nil-deref is in the cosmos-sdk fork (`github.com/lavanet/cosmos-sdk`, `client/tx/tx.go`): `CalculateGas` should nil-check `simRes.GasInfo` and return an error instead of dereferencing. That's the complementary deeper fix in the fork; this PR is the lavap-side guard so a bad node response degrades gracefully regardless. Independent of #2301/#2302 (different subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)