### PR TITLE
feat: Added host.name to OTel traces

### DIFF
--- a/protocol/tracing/trace_manager.go
+++ b/protocol/tracing/trace_manager.go
@@ -135,10 +135,7 @@ func New(ctx context.Context, cfg TraceConfig) (*TraceManager, error) {
 	// limit on the same spans, so we cannot disagree with the SDK.
 	bodyAttrLimit = sdktrace.NewSpanLimits().AttributeValueLengthLimit
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(cfg.DefaultServiceName)),
-		resource.WithFromEnv(), // OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES
-	)
+	res, err := newResource(ctx, cfg)
 	if err != nil {
 		return nil, utils.LavaFormatError("failed to create OTel resource", err)
 	}
@@ -178,6 +175,21 @@ func New(ctx context.Context, cfg TraceConfig) (*TraceManager, error) {
 		provider: tp,
 		shutdown: tp.Shutdown,
 	}, nil
+}
+
+// newResource builds the OTel resource describing this service. WithHost() adds
+// the standard `host.name` attribute (the OS hostname) so traces can be mapped
+// to the host's region. WithFromEnv() is applied LAST so operator-supplied env
+// config wins on conflicts: OTEL_SERVICE_NAME overrides DefaultServiceName, and
+// OTEL_RESOURCE_ATTRIBUTES (e.g. host.name=eu-west-1) overrides the detected
+// hostname. resource.New merges detectors in order, with later ones taking
+// precedence on key collisions.
+func newResource(ctx context.Context, cfg TraceConfig) (*resource.Resource, error) {
+	return resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceName(cfg.DefaultServiceName)),
+		resource.WithHost(),    // host.name from os.Hostname()
+		resource.WithFromEnv(), // OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES (override)
+	)
 }
 
 // newNoop installs a noop TracerProvider as the global and returns a TraceManager

--- a/protocol/tracing/trace_manager_test.go
+++ b/protocol/tracing/trace_manager_test.go
@@ -217,6 +217,7 @@ func clearTracingEnv(t *testing.T) {
 		"OTEL_EXPORTER_OTLP_ENDPOINT",
 		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 		"OTEL_SERVICE_NAME",
+		"OTEL_RESOURCE_ATTRIBUTES",
 		"OTEL_TRACES_SAMPLER",
 		"OTEL_TRACES_SAMPLER_ARG",
 		"OTEL_TRACES_EXPORTER",
@@ -246,6 +247,44 @@ func TestNew_DefaultServiceNameRequired(t *testing.T) {
 	_, err := New(context.Background(), TraceConfig{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "DefaultServiceName")
+}
+
+func TestNewResource_HostName(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
+	clearTracingEnv(t)
+
+	res, err := newResource(context.Background(), TraceConfig{DefaultServiceName: "lava-test-binary"})
+	require.NoError(t, err)
+
+	var gotHost string
+	var hasHost bool
+	for _, attr := range res.Attributes() {
+		if string(attr.Key) == "host.name" {
+			hasHost = true
+			gotHost = attr.Value.AsString()
+		}
+	}
+	require.True(t, hasHost, "resource should always carry host.name")
+	require.Equal(t, hostname, gotHost)
+}
+
+func TestNewResource_HostNameOverridableViaEnv(t *testing.T) {
+	clearTracingEnv(t)
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "host.name=eu-west-1-consumer")
+
+	res, err := newResource(context.Background(), TraceConfig{DefaultServiceName: "lava-test-binary"})
+	require.NoError(t, err)
+
+	var gotHost string
+	for _, attr := range res.Attributes() {
+		if string(attr.Key) == "host.name" {
+			gotHost = attr.Value.AsString()
+		}
+	}
+	require.Equal(t, "eu-west-1-consumer", gotHost,
+		"OTEL_RESOURCE_ATTRIBUTES should override the detected hostname")
 }
 
 func TestBuildPropagatorFromEnv(t *testing.T) {


### PR DESCRIPTION
### What
Attach the host's name as a resource attribute (`host.name`) to every OTel span emitted by `lavap` (consumer, provider, and smart router). This lets us map collected traces back to
the region a consumer/provider runs in.

### How
- `protocol/tracing/trace_manager.go`: factored resource construction into `newResource()` and added OTel's built-in host detector (`resource.WithHost()`), which sets the standard
`host.name` attribute from `os.Hostname()`. Enabled unconditionally — no flag, no opt-in.
- Ordered `WithFromEnv()` **last** so operator config wins on conflicts: `OTEL_SERVICE_NAME` overrides the in-code service name, and `OTEL_RESOURCE_ATTRIBUTES=host.name=...`
overrides the detected hostname (e.g. to label a clean region instead of a pod hostname).

### Override example
OTEL_SERVICE_NAME=lava-consumer
OTEL_RESOURCE_ATTRIBUTES=host.name=eu-west-1-consumer-3,deployment.environment=production

### Tests
- `TestNewResource_HostName` — default resource carries `os.Hostname()`.
- `TestNewResource_HostNameOverridableViaEnv` — `OTEL_RESOURCE_ATTRIBUTES` overrides the detected hostname.
- Added `OTEL_RESOURCE_ATTRIBUTES` to `clearTracingEnv` so the suite stays hermetic.

No protocol-surface or config changes; standard OTel SDK behavior only.

### Example
<img width="858" height="431" alt="image" src="https://github.com/user-attachments/assets/3a659f4e-98fb-43df-bce4-fb9ce985d39a" />
