### PR TITLE
feat(rpcconsumer): provider whitelist restricting relays per chain and geolocation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -645,7 +645,7 @@ func New(
 	// If evidence needs to be handled for the app, set routes in router here and seal
 	app.EvidenceKeeper = *evidenceKeeper
 
-	govConfig := govtypes.Config{MaxMetadataLen: 4000} // 1640 TODO fix it from spec test proposal
+	govConfig := govtypes.Config{MaxMetadataLen: 8000} // 1640 TODO fix it from spec test proposal
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.AccountKeeper, app.BankKeeper,
 		app.StakingKeeper, app.MsgServiceRouter(), govConfig,

--- a/docs/provider-whitelist.md
+++ b/docs/provider-whitelist.md
@@ -1,0 +1,133 @@
+# Consumer Provider Whitelist
+
+## Goal
+
+Give an `rpcconsumer` operator a way to **restrict which providers the consumer relays to**,
+on top of the on-chain pairing, using an externally-managed list of `(provider, chain)` pairs.
+The list is refreshed periodically (hourly by default) from **GitHub/GitLab or a local file**,
+so it can be updated without restarting the consumer.
+
+> "Build a list of providers and the chains they support, fetched every hour from GitHub or a
+> local file, and only relay to providers in that list. If the list does not exist, keep the
+> current relay behavior."
+
+This is a **client-side** filter. It is unrelated to the on-chain
+`x/pairing/keeper/filters/selected_providers_filter.go` (EXCLUSIVE/MIXED policy filter), which
+is a consensus-level mechanism.
+
+## TL;DR
+
+- Set `--providers-whitelist-config` to a JSON file path or a GitHub/GitLab directory URL.
+- When the list is configured **and successfully loaded**, the consumer relays **only** to
+  whitelisted `(provider address, chain)` pairs.
+- When the flag is **empty** (default) **or no list has loaded yet**, the consumer keeps its
+  **current behavior** (relay to any paired provider) and **no refresh loop runs**.
+- The list is re-fetched every `--providers-whitelist-refresh-interval` (default `1h`).
+
+## Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--providers-whitelist-config` | `""` (disabled) | JSON file path **or** a GitHub/GitLab directory URL. Empty keeps current relay behavior. |
+| `--providers-whitelist-refresh-interval` | `1h` | How often the list is re-fetched. Only used when a source is configured. |
+| `--providers-whitelist-token` | `""` | Dedicated access token for a **remote** source in a different repo than the specs. Falls back to `--github-token` / `--gitlab-token` (by provider) when empty. |
+
+The flags are defined in `protocol/common/cobra_common.go` and registered for `rpcconsumer` in
+`protocol/rpcconsumer/rpcconsumer.go`.
+
+### Example: local file
+
+```bash
+rpcconsumer rpcconsumer.yml \
+  --providers-whitelist-config ./provider-whitelist.json \
+  --providers-whitelist-refresh-interval 1h
+```
+
+### Example: GitHub (fetched exactly like specs)
+
+```bash
+rpcconsumer rpcconsumer.yml \
+  --providers-whitelist-config https://github.com/{owner}/{repo}/tree/{branch}/{path} \
+  --providers-whitelist-token ghp_xxxxxxxx        # optional; else falls back to --github-token
+```
+
+The GitHub/GitLab URL format is identical in shape to the spec source
+(`--use-static-spec`): a `/tree/{branch}/{path}` **directory** URL.
+
+## List format
+
+The list is a JSON document describing providers and the chains each is allowed to serve:
+
+```json
+{
+  "providers": [
+    { "address": "lava@1abc...", "chains": ["ETH1", "LAV1"] },
+    { "address": "lava@1def...", "chains": ["NEAR"] }
+  ]
+}
+```
+
+- `address` — the provider's **on-chain bech32 address** (`lava@1...`). It is matched **exactly**
+  (case- and whitespace-sensitive); it must match the address as staked on-chain.
+- `chains` — the spec chain IDs (e.g. `ETH1`, `LAV1`) this provider is allowed to serve.
+
+A GitHub/GitLab directory may contain **one or more** `.json` files; their `providers` arrays are
+**unioned** (the same way specs are split across files). Files that don't conform to this schema
+(for example a spec file in a shared directory) are skipped with a warning. A local source is a
+single JSON file.
+
+The schema and parsing live in `protocol/lavasession/provider_whitelist.go`.
+
+## How fetching works
+
+Remote fetching reuses the **exact same machinery as specs** — URL parsing, GitHub/GitLab
+directory listing, authenticated raw-file download, HTTP client, and timeouts — via
+`specfetcher.FetchAllFilesFromRemote` (`utils/specfetcher/api.go`). The only thing that differs
+from specs is the terminal JSON parse (whitelist schema, not `types.Spec`).
+
+The background refresher is `ProviderWhitelistFetcher`
+(`protocol/rpcconsumer/provider_whitelist_fetcher.go`):
+
+1. On startup it attempts an initial load, **retrying on a short interval (30s) until the first
+   success** — this avoids a long "fail-open" window if the source is briefly unreachable.
+2. After the first successful load, it re-fetches every refresh interval (default `1h`).
+3. The active list is held in an `atomic.Pointer`, so the read path (`IsAllowed`, called per
+   candidate provider per relay) is lock-free and the refresh swaps the list atomically.
+
+## How filtering works
+
+Each per-chain `ConsumerSessionManager` (CSM) is injected with the shared whitelist and queries it
+with **its own** `ChainID` (`SetProviderWhitelist`, `consumer_session_manager.go`). A non-whitelisted
+provider is filtered out of **every** provider-selection path:
+
+| Selection path | Where it is guarded |
+|----------------|---------------------|
+| Optimizer (normal selection) | `validAddresses` is filtered in `getValidProviderAddresses` before the optimizer reads it |
+| Header-selected provider | same `validAddresses` filter (the header shortcut gates on membership) |
+| Sticky session | same `validAddresses` filter (the sticky shortcut gates on membership) |
+| Emergency backup providers | per-candidate guard in `getValidConsumerSessionsWithProviderFromBackupProviderList` |
+| Blocked-provider recovery | per-candidate guard in `tryGetConsumerSessionWithProviderFromBlockedProviderList` |
+
+The blocked-recovery guard matters specifically because the list refreshes on its own clock: a
+provider that was whitelisted when it got blocked can be **de-listed** before it is recovered, and
+must not be relayed to.
+
+Filtering is applied at the **selection call site**, not inside the addon-address calculation that
+`validatePairingListNotEmpty` drives. This way, when the whitelist intersection is empty, the
+consumer returns a clean "no available providers" error (`PairingListEmptyError`) instead of
+triggering repeated `validAddresses` resets.
+
+## Behavior and failure modes
+
+| Situation | Behavior |
+|-----------|----------|
+| Flag empty (not configured) | Passthrough — relay to any paired provider (current behavior). No refresh loop runs. |
+| Configured, first fetch fails at startup | Passthrough, with **short-interval retry** until the first success. Logged loudly. |
+| Configured, loads as empty `{"providers":[]}` | Loaded and **enabled** → relay to **nobody** for every chain. Logged loudly (a footgun, but correct whitelist semantics). |
+| Configured, a later refresh fails or returns malformed JSON | Keep the **last-known-good** list; log the error. |
+| Whitelist excludes every paired provider for a chain | Relays for that chain fail cleanly with `PairingListEmptyError`. |
+
+## Scope
+
+The feature is wired into **`rpcconsumer` only**. The `rpcsmartrouter` shares the same selection
+code but is injected no whitelist, so its `ConsumerSessionManager` stays in passthrough behavior.

--- a/docs/provider-whitelist.md
+++ b/docs/provider-whitelist.md
@@ -105,7 +105,6 @@ provider is filtered out of **every** provider-selection path:
 | Optimizer (normal selection) | `validAddresses` is filtered in `getValidProviderAddresses` before the optimizer reads it |
 | Header-selected provider | same `validAddresses` filter (the header shortcut gates on membership) |
 | Sticky session | same `validAddresses` filter (the sticky shortcut gates on membership) |
-| Emergency backup providers | per-candidate guard in `getValidConsumerSessionsWithProviderFromBackupProviderList` |
 | Blocked-provider recovery | per-candidate guard in `tryGetConsumerSessionWithProviderFromBlockedProviderList` |
 
 The blocked-recovery guard matters specifically because the list refreshes on its own clock: a
@@ -129,5 +128,7 @@ triggering repeated `validAddresses` resets.
 
 ## Scope
 
-The feature is wired into **`rpcconsumer` only**. The `rpcsmartrouter` shares the same selection
-code but is injected no whitelist, so its `ConsumerSessionManager` stays in passthrough behavior.
+The feature is wired into **`rpcconsumer` only**: the whitelist is injected into each per-chain
+`ConsumerSessionManager` at consumer startup (`SetProviderWhitelist`). A `ConsumerSessionManager`
+that is never handed a whitelist keeps its current behavior (the nil-instance passthrough case
+above).

--- a/docs/provider-whitelist.md
+++ b/docs/provider-whitelist.md
@@ -3,13 +3,13 @@
 ## Goal
 
 Give an `rpcconsumer` operator a way to **restrict which providers the consumer relays to**,
-on top of the on-chain pairing, using an externally-managed list of `(provider, chain)` pairs.
-The list is refreshed periodically (hourly by default) from **GitHub/GitLab or a local file**,
-so it can be updated without restarting the consumer.
+on top of the on-chain pairing, using an externally-managed list of `(provider, chain, geolocation)`
+tuples. The list is refreshed periodically (hourly by default) from **GitHub/GitLab or a local
+file**, so it can be updated without restarting the consumer.
 
-> "Build a list of providers and the chains they support, fetched every hour from GitHub or a
-> local file, and only relay to providers in that list. If the list does not exist, keep the
-> current relay behavior."
+> "Build a list of providers and the chains they support **per geolocation**, fetched every hour
+> from GitHub or a local file, and only relay to providers in that list for the consumer's own
+> region. If the list does not exist, keep the current relay behavior."
 
 This is a **client-side** filter. It is unrelated to the on-chain
 `x/pairing/keeper/filters/selected_providers_filter.go` (EXCLUSIVE/MIXED policy filter), which
@@ -19,7 +19,8 @@ is a consensus-level mechanism.
 
 - Set `--providers-whitelist-config` to a JSON file path or a GitHub/GitLab directory URL.
 - When the list is configured **and successfully loaded**, the consumer relays **only** to
-  whitelisted `(provider address, chain)` pairs.
+  whitelisted `(provider address, chain, geolocation)` tuples — matching the chain it serves and
+  its own configured `--geolocation`.
 - When the flag is **empty** (default) **or no list has loaded yet**, the consumer keeps its
   **current behavior** (relay to any paired provider) and **no refresh loop runs**.
 - The list is re-fetched every `--providers-whitelist-refresh-interval` (default `1h`).
@@ -56,25 +57,45 @@ The GitHub/GitLab URL format is identical in shape to the spec source
 
 ## List format
 
-The list is a JSON document describing providers and the chains each is allowed to serve:
+The list is a JSON document keyed **chain → geolocation → the providers** allowed to serve that
+chain from that region:
 
 ```json
 {
-  "providers": [
-    { "address": "lava@1abc...", "chains": ["ETH1", "LAV1"] },
-    { "address": "lava@1def...", "chains": ["NEAR"] }
-  ]
+  "chains": {
+    "ETH1": {
+      "EU": ["lava@1abc...", "lava@1def..."],
+      "AS": ["lava@1ghi...", "lava@1abc..."]
+    },
+    "LAV1": {
+      "EU": ["lava@1abc..."]
+    }
+  }
 }
 ```
 
-- `address` — the provider's **on-chain bech32 address** (`lava@1...`). It is matched **exactly**
-  (case- and whitespace-sensitive); it must match the address as staked on-chain.
-- `chains` — the spec chain IDs (e.g. `ETH1`, `LAV1`) this provider is allowed to serve.
+- **chain id** — the spec chain ID (e.g. `ETH1`, `LAV1`).
+- **geolocation** — an on-chain region code: a name (`EU`, `AS`, `AF`, `AU`, `USC`/`USE`/`USW`), a
+  raw bitmask (`2`), a comma-combined set (`EU,AS`), or `GL` meaning **any region**. Note `US` is
+  *not* a code — use the specific `USC`/`USE`/`USW`. A consumer only consults the bucket matching its
+  own `--geolocation`, so an EU gateway (`--geolocation 2`) reads the `EU` lists.
+- **provider address** — the provider's **on-chain bech32 address** (`lava@1...`), matched
+  **exactly** (case- and whitespace-sensitive); it must match the address as staked on-chain.
 
-A GitHub/GitLab directory may contain **one or more** `.json` files; their `providers` arrays are
-**unioned** (the same way specs are split across files). Files that don't conform to this schema
-(for example a spec file in a shared directory) are skipped with a warning. A local source is a
-single JSON file.
+The same provider may appear under multiple regions (e.g. `lava@1abc...` in both `ETH1/EU` and
+`ETH1/AS` above).
+
+A GitHub/GitLab directory may contain **one or more** `.json` files; their `chains` maps are
+**unioned** per (chain, region) (the same way specs are split across files). Files that don't
+conform to this schema (for example a spec file in a shared directory, with no `chains` key) are
+skipped with a warning. A malformed file **or an invalid geolocation code** fails the whole refresh
+(the last-known-good list is kept). A local source is a single JSON file.
+
+> **Migration from the old schema.** An earlier version keyed the list by `(provider, chain)` only
+> (a top-level `"providers"` array). That shape is now **rejected with a hard error** — an
+> un-migrated file fails to load (logged loudly; the consumer stays in passthrough, i.e. relays to
+> everyone). Convert existing files to the `chains → geolocation → providers` shape above and roll
+> the file out **together** with this build.
 
 The schema and parsing live in `protocol/lavasession/provider_whitelist.go`.
 
@@ -94,11 +115,27 @@ The background refresher is `ProviderWhitelistFetcher`
 3. The active list is held in an `atomic.Pointer`, so the read path (`IsAllowed`, called per
    candidate provider per relay) is lock-free and the refresh swaps the list atomically.
 
+### Repo layout (remote sources)
+
+A remote source lists **one directory** — the `{path}` in the URL — and loads only the **top-level
+`.json` files** in it:
+
+- Subdirectories are **not** descended into, and non-`.json` files are ignored.
+- All `.json` files in that directory are downloaded (all-or-nothing) and their `chains` maps are
+  **unioned** into a single whitelist, so the list may be split across several files in that one
+  directory.
+- A file with no `chains` key (e.g. a stray spec or notes file) is skipped with a warning; a
+  malformed, old-schema, or invalid-geolocation file fails the whole refresh.
+
+Example: `…/tree/main/whitelist` reads every `*.json` directly under `whitelist/`, but not
+`whitelist/eu/…`. Point the URL at the single directory that holds the whitelist file(s).
+
 ## How filtering works
 
 Each per-chain `ConsumerSessionManager` (CSM) is injected with the shared whitelist and queries it
-with **its own** `ChainID` (`SetProviderWhitelist`, `consumer_session_manager.go`). A non-whitelisted
-provider is filtered out of **every** provider-selection path:
+with **its own** `ChainID` **and the consumer's configured `Geolocation`** (`SetProviderWhitelist`,
+`consumer_session_manager.go`). A provider not whitelisted for that `(chain, region)` is filtered out
+of **every** provider-selection path:
 
 | Selection path | Where it is guarded |
 |----------------|---------------------|
@@ -111,6 +148,12 @@ The blocked-recovery guard matters specifically because the list refreshes on it
 provider that was whitelisted when it got blocked can be **de-listed** before it is recovered, and
 must not be relayed to.
 
+**Geolocation matching.** The consumer compares its own `--geolocation` against the region keys for
+the chain: a `GL` bucket matches any region; otherwise the consumer's geolocation must share a bit
+with the region (so a single-region gateway like `--geolocation 2` matches the `EU` bucket exactly).
+This is a **per-region-gateway** model — production runs one consumer per region, each pinned with
+`--geolocation`, and each relays only to the providers listed for its region.
+
 Filtering is applied at the **selection call site**, not inside the addon-address calculation that
 `validatePairingListNotEmpty` drives. This way, when the whitelist intersection is empty, the
 consumer returns a clean "no available providers" error (`PairingListEmptyError`) instead of
@@ -122,9 +165,10 @@ triggering repeated `validAddresses` resets.
 |-----------|----------|
 | Flag empty (not configured) | Passthrough — relay to any paired provider (current behavior). No refresh loop runs. |
 | Configured, first fetch fails at startup | Passthrough, with **short-interval retry** until the first success. Logged loudly. |
-| Configured, loads as empty `{"providers":[]}` | Loaded and **enabled** → relay to **nobody** for every chain. Logged loudly (a footgun, but correct whitelist semantics). |
-| Configured, a later refresh fails or returns malformed JSON | Keep the **last-known-good** list; log the error. |
-| Whitelist excludes every paired provider for a chain | Relays for that chain fail cleanly with `PairingListEmptyError`. |
+| Configured, loads as empty `{"chains":{}}` | Loaded and **enabled** → relay to **nobody** for every chain. Logged loudly (a footgun, but correct whitelist semantics). |
+| Configured, a later refresh fails, is malformed, or has an invalid geolocation | Keep the **last-known-good** list; log the error. |
+| Configured, file uses the old `{"providers":[...]}` schema | **Hard error** — load fails loudly; migrate to the `chains → geolocation → providers` schema. |
+| No providers listed for the consumer's `(chain, region)` | Relays for that chain fail cleanly with `PairingListEmptyError` (no fallback to another region). |
 
 ## Scope
 

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -72,6 +72,18 @@ const (
 	// Example: --gitlab-token glpat-xxxxxxxxxxxx
 	GitLabTokenFlag = "gitlab-token"
 
+	// ProvidersWhitelistConfigFlag points the consumer at a provider whitelist. When set and
+	// successfully loaded, the consumer relays only to whitelisted (provider, chain) pairs; when
+	// empty (the default) the consumer keeps its current relay behavior and no refresh loop runs.
+	// The source is either a local JSON file path, or a GitHub/GitLab directory URL fetched the
+	// exact same way as specs (authenticated with --github-token / --gitlab-token).
+	// Example: --providers-whitelist-config https://github.com/{owner}/{repo}/tree/{branch}/{path}
+	ProvidersWhitelistConfigFlag = "providers-whitelist-config"
+
+	// ProvidersWhitelistRefreshIntervalFlag is how often the provider whitelist is re-fetched.
+	ProvidersWhitelistRefreshIntervalFlag    = "providers-whitelist-refresh-interval"
+	DefaultProvidersWhitelistRefreshInterval = time.Hour
+
 	EpochDurationFlag              = "epoch-duration"         // duration of each epoch for time-based epoch system (standalone mode)
 	DefaultEpochDuration           = 30 * time.Minute         // default epoch duration for regular mode (if using time-based epochs)
 	StandaloneEpochDuration        = 15 * time.Minute         // default epoch duration for standalone/static provider mode
@@ -153,6 +165,10 @@ type ConsumerCmdFlags struct {
 	EnableSelectionStats     bool          // enables selection stats header for debugging provider selection
 	DebugAddress             string        // address for the debug HTTP server, e.g. ":9999". Empty = disabled.
 	ResponseCompression      string        // "gzip" (default), "brotli", or "off" — controls client-facing response compression
+	// ProvidersWhitelistConfig is the provider whitelist source (local JSON file path or a
+	// GitHub/GitLab directory URL). Empty disables the feature (current relay behavior).
+	ProvidersWhitelistConfig          string
+	ProvidersWhitelistRefreshInterval time.Duration // how often to re-fetch the provider whitelist
 }
 
 // default rolling logs behavior (if enabled) will store 3 files each 100MB for up to 1 day every time.

--- a/protocol/common/cobra_common.go
+++ b/protocol/common/cobra_common.go
@@ -76,9 +76,15 @@ const (
 	// successfully loaded, the consumer relays only to whitelisted (provider, chain) pairs; when
 	// empty (the default) the consumer keeps its current relay behavior and no refresh loop runs.
 	// The source is either a local JSON file path, or a GitHub/GitLab directory URL fetched the
-	// exact same way as specs (authenticated with --github-token / --gitlab-token).
+	// exact same way as specs.
 	// Example: --providers-whitelist-config https://github.com/{owner}/{repo}/tree/{branch}/{path}
 	ProvidersWhitelistConfigFlag = "providers-whitelist-config"
+
+	// ProvidersWhitelistTokenFlag is a dedicated access token for the (remote) provider whitelist
+	// source. It is used when the whitelist lives in a different repo than the specs, requiring a
+	// different credential. When empty, the whitelist fetch falls back to --github-token /
+	// --gitlab-token (selected by the source's provider).
+	ProvidersWhitelistTokenFlag = "providers-whitelist-token"
 
 	// ProvidersWhitelistRefreshIntervalFlag is how often the provider whitelist is re-fetched.
 	ProvidersWhitelistRefreshIntervalFlag    = "providers-whitelist-refresh-interval"
@@ -168,6 +174,7 @@ type ConsumerCmdFlags struct {
 	// ProvidersWhitelistConfig is the provider whitelist source (local JSON file path or a
 	// GitHub/GitLab directory URL). Empty disables the feature (current relay behavior).
 	ProvidersWhitelistConfig          string
+	ProvidersWhitelistToken           string        // dedicated token for the whitelist source; falls back to GitHub/GitLab token when empty
 	ProvidersWhitelistRefreshInterval time.Duration // how often to re-fetch the provider whitelist
 }
 

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -113,7 +113,8 @@ func (csm *ConsumerSessionManager) SetProviderWhitelist(whitelist *ProviderWhite
 
 // isProviderAllowed reports whether this manager may relay to providerAddr, per the provider
 // whitelist for this manager's chain. Returns true (allowed) when no whitelist is configured or
-// it has not loaded yet. Used to guard single-provider selection paths (backup, blocked-recovery).
+// it has not loaded yet. Used to guard the blocked-provider recovery path, whose candidates are
+// not re-filtered through the central validAddresses filter.
 func (csm *ConsumerSessionManager) isProviderAllowed(providerAddr string) bool {
 	if csm.providerWhitelist == nil {
 		return true
@@ -130,7 +131,7 @@ func (csm *ConsumerSessionManager) filterAllowedProviders(addresses []string) []
 	}
 	data := csm.providerWhitelist.snapshot()
 	if data == nil {
-		return addresses // not loaded yet -> passthrough
+		return addresses // not loaded yet -> passthrough (allow all until the first successful load)
 	}
 	chainID := csm.rpcEndpoint.ChainID
 	filtered := make([]string, 0, len(addresses))
@@ -1400,11 +1401,6 @@ func (csm *ConsumerSessionManager) getValidConsumerSessionsWithProviderFromBacku
 	// Get valid backup provider addresses that support the required addon and extensions
 	backupProviderAddresses := []string{}
 	for providerAddress, consumerSessionsWithProvider := range csm.backupProviders {
-		// Skip providers not permitted by the provider whitelist for this chain.
-		if !csm.isProviderAllowed(providerAddress) {
-			continue
-		}
-
 		// Skip if provider is in ignored list (already tried or failed this request)
 		if _, exists := ignoredProviders.providers[providerAddress]; exists {
 			continue

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -88,6 +88,11 @@ type ConsumerSessionManager struct {
 	// getLavaBlockHeight returns the current Lava blockchain block height
 	// This is NOT used for RelaySession.Epoch (which must be the pairing epoch start block)
 	getLavaBlockHeight func() int64
+
+	// providerWhitelist, when set and loaded, restricts relays to whitelisted (provider, chain)
+	// pairs. nil (not configured) or not-yet-loaded means passthrough (current behavior).
+	// Shared across all per-chain managers; this manager queries it with its own ChainID.
+	providerWhitelist *ProviderWhitelist
 }
 
 func (csm *ConsumerSessionManager) GetQoSManager() *qos.QoSManager {
@@ -98,6 +103,43 @@ func (csm *ConsumerSessionManager) GetNumberOfValidProviders() int {
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()
 	return len(csm.validAddresses)
+}
+
+// SetProviderWhitelist injects the shared provider whitelist into this per-chain manager. It is
+// safe to pass nil (no whitelist configured), which leaves the manager in passthrough behavior.
+func (csm *ConsumerSessionManager) SetProviderWhitelist(whitelist *ProviderWhitelist) {
+	csm.providerWhitelist = whitelist
+}
+
+// isProviderAllowed reports whether this manager may relay to providerAddr, per the provider
+// whitelist for this manager's chain. Returns true (allowed) when no whitelist is configured or
+// it has not loaded yet. Used to guard single-provider selection paths (backup, blocked-recovery).
+func (csm *ConsumerSessionManager) isProviderAllowed(providerAddr string) bool {
+	if csm.providerWhitelist == nil {
+		return true
+	}
+	return csm.providerWhitelist.IsAllowed(csm.rpcEndpoint.ChainID, providerAddr)
+}
+
+// filterAllowedProviders returns the subset of addresses permitted by the provider whitelist for
+// this manager's chain. When no whitelist is configured or loaded it returns the input unchanged.
+// The whitelist snapshot is loaded once and reused across all addresses (lock-free hot path).
+func (csm *ConsumerSessionManager) filterAllowedProviders(addresses []string) []string {
+	if csm.providerWhitelist == nil {
+		return addresses
+	}
+	data := csm.providerWhitelist.snapshot()
+	if data == nil {
+		return addresses // not loaded yet -> passthrough
+	}
+	chainID := csm.rpcEndpoint.ChainID
+	filtered := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		if data.isAllowed(chainID, addr) {
+			filtered = append(filtered, addr)
+		}
+	}
+	return filtered
 }
 
 // IsStaticProvider returns true when the given provider address belongs to a
@@ -1084,6 +1126,11 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 	// cs.Lock must be Rlocked here.
 	ignoredProvidersListLength := len(ignoredProvidersList)
 	validAddresses := csm.getValidAddresses(addon, extensions, ctx)
+	// Restrict candidates to whitelisted providers for this chain (no-op when no whitelist is
+	// configured/loaded). This single filter also covers the header-selected and sticky-session
+	// shortcuts below, since both gate on membership in validAddresses, and the optimizer paths
+	// which all select from validAddresses.
+	validAddresses = csm.filterAllowedProviders(validAddresses)
 	validAddressesLength := len(validAddresses)
 	totalValidLength := validAddressesLength - ignoredProvidersListLength
 
@@ -1282,6 +1329,12 @@ func (csm *ConsumerSessionManager) tryGetConsumerSessionWithProviderFromBlockedP
 	// csm.currentlyBlockedProviderAddresses is sorted by the provider with the highest cu used this epoch to the lowest
 	// meaning if we fetch the first successful index this is probably the highest success ratio to get a response.
 	for _, providerAddress := range csm.currentlyBlockedProviderAddresses {
+		// Skip providers not permitted by the provider whitelist for this chain. The whitelist can
+		// change (hourly refresh) after a provider was blocked, so a now-delisted provider must not
+		// be recovered into service through this fallback.
+		if !csm.isProviderAllowed(providerAddress) {
+			continue
+		}
 		// check if we have this provider already.
 		if _, providerExistInIgnoredProviders := ignoredProviders.providers[providerAddress]; providerExistInIgnoredProviders {
 			utils.LavaFormatTrace("[continue] provider already in ignored providers", utils.LogAttr("providerAddress", providerAddress), utils.LogAttr("GUID", ctx))
@@ -1347,6 +1400,11 @@ func (csm *ConsumerSessionManager) getValidConsumerSessionsWithProviderFromBacku
 	// Get valid backup provider addresses that support the required addon and extensions
 	backupProviderAddresses := []string{}
 	for providerAddress, consumerSessionsWithProvider := range csm.backupProviders {
+		// Skip providers not permitted by the provider whitelist for this chain.
+		if !csm.isProviderAllowed(providerAddress) {
+			continue
+		}
+
 		// Skip if provider is in ignored list (already tried or failed this request)
 		if _, exists := ignoredProviders.providers[providerAddress]; exists {
 			continue

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -89,9 +89,10 @@ type ConsumerSessionManager struct {
 	// This is NOT used for RelaySession.Epoch (which must be the pairing epoch start block)
 	getLavaBlockHeight func() int64
 
-	// providerWhitelist, when set and loaded, restricts relays to whitelisted (provider, chain)
-	// pairs. nil (not configured) or not-yet-loaded means passthrough (current behavior).
-	// Shared across all per-chain managers; this manager queries it with its own ChainID.
+	// providerWhitelist, when set and loaded, restricts relays to whitelisted (provider, chain,
+	// geolocation) tuples. nil (not configured) or not-yet-loaded means passthrough (current
+	// behavior). Shared across all per-chain managers; this manager queries it with its own ChainID
+	// and the consumer's configured geolocation.
 	providerWhitelist *ProviderWhitelist
 }
 
@@ -112,19 +113,20 @@ func (csm *ConsumerSessionManager) SetProviderWhitelist(whitelist *ProviderWhite
 }
 
 // isProviderAllowed reports whether this manager may relay to providerAddr, per the provider
-// whitelist for this manager's chain. Returns true (allowed) when no whitelist is configured or
-// it has not loaded yet. Used to guard the blocked-provider recovery path, whose candidates are
-// not re-filtered through the central validAddresses filter.
+// whitelist for this manager's chain and the consumer's geolocation. Returns true (allowed) when no
+// whitelist is configured or it has not loaded yet. Used to guard the blocked-provider recovery
+// path, whose candidates are not re-filtered through the central validAddresses filter.
 func (csm *ConsumerSessionManager) isProviderAllowed(providerAddr string) bool {
 	if csm.providerWhitelist == nil {
 		return true
 	}
-	return csm.providerWhitelist.IsAllowed(csm.rpcEndpoint.ChainID, providerAddr)
+	return csm.providerWhitelist.IsAllowed(csm.rpcEndpoint.ChainID, csm.rpcEndpoint.Geolocation, providerAddr)
 }
 
 // filterAllowedProviders returns the subset of addresses permitted by the provider whitelist for
-// this manager's chain. When no whitelist is configured or loaded it returns the input unchanged.
-// The whitelist snapshot is loaded once and reused across all addresses (lock-free hot path).
+// this manager's chain and the consumer's geolocation. When no whitelist is configured or loaded it
+// returns the input unchanged. The whitelist snapshot is loaded once and reused across all addresses
+// (lock-free hot path).
 func (csm *ConsumerSessionManager) filterAllowedProviders(addresses []string) []string {
 	if csm.providerWhitelist == nil {
 		return addresses
@@ -134,9 +136,10 @@ func (csm *ConsumerSessionManager) filterAllowedProviders(addresses []string) []
 		return addresses // not loaded yet -> passthrough (allow all until the first successful load)
 	}
 	chainID := csm.rpcEndpoint.ChainID
+	geo := csm.rpcEndpoint.Geolocation
 	filtered := make([]string, 0, len(addresses))
 	for _, addr := range addresses {
-		if data.isAllowed(chainID, addr) {
+		if data.isAllowed(chainID, geo, addr) {
 			filtered = append(filtered, addr)
 		}
 	}

--- a/protocol/lavasession/provider_whitelist.go
+++ b/protocol/lavasession/provider_whitelist.go
@@ -1,0 +1,185 @@
+package lavasession
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/lavanet/lava/v5/utils"
+)
+
+// providerWhitelistJSON is the JSON schema of the consumer provider whitelist, as fetched from
+// GitHub or a local file. It is intentionally unrelated to the spec schema
+// (specutils.SpecAddProposalJSON): the whitelist is a flat list of providers and the chains
+// each provider is allowed to serve.
+//
+//	{
+//	  "providers": [
+//	    { "address": "lava@1abc...", "chains": ["ETH1", "LAV1"] },
+//	    { "address": "lava@1def...", "chains": ["NEAR"] }
+//	  ]
+//	}
+//
+// Providers is a pointer so we can distinguish a document that omits the "providers" key (not a
+// whitelist file at all -> rejected) from one that sets it to an empty array (an intentional
+// "allow nobody" whitelist -> accepted).
+type providerWhitelistJSON struct {
+	Providers *[]providerWhitelistEntry `json:"providers"`
+}
+
+type providerWhitelistEntry struct {
+	Address string   `json:"address"`
+	Chains  []string `json:"chains"`
+}
+
+// whitelistData is the immutable, lookup-optimized index built from the parsed JSON:
+// chainID -> set of allowed provider addresses.
+type whitelistData struct {
+	byChain map[string]map[string]struct{}
+}
+
+func (wd *whitelistData) isAllowed(chainID, providerAddr string) bool {
+	addrs, ok := wd.byChain[chainID]
+	if !ok {
+		return false
+	}
+	_, ok = addrs[providerAddr]
+	return ok
+}
+
+// pairCount returns the number of distinct (chain, provider) pairs, used for logging.
+func (wd *whitelistData) pairCount() int {
+	count := 0
+	for _, addrs := range wd.byChain {
+		count += len(addrs)
+	}
+	return count
+}
+
+// ProviderWhitelist is a thread-safe, hourly-refreshed allowlist that restricts which providers
+// the consumer is willing to relay to, per chain. A single instance is shared across all
+// per-chain ConsumerSessionManagers; each manager queries it with its own chainID.
+//
+// Semantics:
+//   - Until the first successful load it is "not loaded": IsAllowed returns true (passthrough),
+//     preserving the consumer's current behavior when no whitelist exists.
+//   - Once loaded, IsAllowed returns true only for (chainID, providerAddr) pairs present in the
+//     list. A loaded-but-empty list therefore allows nobody (intentional whitelist semantics).
+//
+// The active snapshot is held in an atomic.Pointer so the read hot path (IsAllowed, called
+// per-candidate-provider per-relay) takes no locks, and the hourly refresh swaps it atomically.
+type ProviderWhitelist struct {
+	data atomic.Pointer[whitelistData]
+}
+
+// NewProviderWhitelist returns a whitelist in the "not loaded" (passthrough) state.
+func NewProviderWhitelist() *ProviderWhitelist {
+	return &ProviderWhitelist{}
+}
+
+// Enabled reports whether a whitelist has been successfully loaded at least once.
+func (pw *ProviderWhitelist) Enabled() bool {
+	return pw.data.Load() != nil
+}
+
+// snapshot returns the current whitelist index, or nil if no whitelist has loaded yet. Callers
+// filtering a list should snapshot once and reuse it across elements rather than calling
+// IsAllowed per element.
+func (pw *ProviderWhitelist) snapshot() *whitelistData {
+	return pw.data.Load()
+}
+
+// IsAllowed reports whether the consumer may relay to providerAddr for chainID. It returns true
+// (passthrough) when no whitelist has been loaded yet.
+func (pw *ProviderWhitelist) IsAllowed(chainID, providerAddr string) bool {
+	data := pw.data.Load()
+	if data == nil {
+		return true // not loaded -> passthrough (current relay behavior)
+	}
+	return data.isAllowed(chainID, providerAddr)
+}
+
+// UpdateFromBytes parses a single whitelist JSON document and atomically replaces the active
+// snapshot. On error the previous snapshot is left intact.
+func (pw *ProviderWhitelist) UpdateFromBytes(content []byte) error {
+	index, err := parseWhitelist(content)
+	if err != nil {
+		return err
+	}
+	pw.store(index)
+	return nil
+}
+
+// UpdateFromFiles parses each provided file as a whitelist document and atomically replaces the
+// active snapshot with the union of their entries. Files that do not conform to the whitelist
+// schema are skipped with a warning (so a shared/mixed repo does not break the load). If no file
+// yields a valid whitelist, the previous snapshot is left intact and an error is returned.
+func (pw *ProviderWhitelist) UpdateFromFiles(files map[string][]byte) error {
+	merged := map[string]map[string]struct{}{}
+	parsedAny := false
+	for fileURL, content := range files {
+		index, err := parseWhitelist(content)
+		if err != nil {
+			utils.LavaFormatWarning("skipping non-conforming provider whitelist file", err, utils.LogAttr("file", fileURL))
+			continue
+		}
+		parsedAny = true
+		for chainID, addrs := range index.byChain {
+			if merged[chainID] == nil {
+				merged[chainID] = map[string]struct{}{}
+			}
+			for addr := range addrs {
+				merged[chainID][addr] = struct{}{}
+			}
+		}
+	}
+	if !parsedAny {
+		return fmt.Errorf("no valid provider whitelist files found (out of %d fetched)", len(files))
+	}
+	pw.store(&whitelistData{byChain: merged})
+	return nil
+}
+
+// store atomically swaps in a new snapshot and logs the result. An empty (but loaded) whitelist
+// is logged loudly because it causes the consumer to relay to no providers.
+func (pw *ProviderWhitelist) store(data *whitelistData) {
+	pw.data.Store(data)
+	pairs := data.pairCount()
+	if pairs == 0 {
+		utils.LavaFormatWarning("provider whitelist loaded but EMPTY - the consumer will relay to NO providers", nil)
+		return
+	}
+	utils.LavaFormatInfo("provider whitelist loaded",
+		utils.LogAttr("chains", len(data.byChain)),
+		utils.LogAttr("allowed_provider_chain_pairs", pairs),
+	)
+}
+
+// parseWhitelist parses a single whitelist JSON document into a lookup index. It returns an error
+// for malformed JSON or for a document that omits the "providers" key (i.e. is not a whitelist).
+func parseWhitelist(content []byte) (*whitelistData, error) {
+	var doc providerWhitelistJSON
+	if err := json.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse provider whitelist JSON: %w", err)
+	}
+	if doc.Providers == nil {
+		return nil, fmt.Errorf("not a provider whitelist document (missing \"providers\" field)")
+	}
+
+	byChain := map[string]map[string]struct{}{}
+	for _, entry := range *doc.Providers {
+		if entry.Address == "" {
+			continue
+		}
+		for _, chainID := range entry.Chains {
+			if chainID == "" {
+				continue
+			}
+			if byChain[chainID] == nil {
+				byChain[chainID] = map[string]struct{}{}
+			}
+			byChain[chainID][entry.Address] = struct{}{}
+		}
+	}
+	return &whitelistData{byChain: byChain}, nil
+}

--- a/protocol/lavasession/provider_whitelist.go
+++ b/protocol/lavasession/provider_whitelist.go
@@ -2,11 +2,18 @@ package lavasession
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
 	"github.com/lavanet/lava/v5/utils"
 )
+
+// errNotWhitelistDocument marks a file that is valid JSON but is not a whitelist (it omits the
+// "providers" key). During a multi-file load these are skipped so a shared/mixed repo of unrelated
+// configs doesn't break the load. It is deliberately distinct from a malformed-JSON error, which
+// is treated as a hard failure (a corrupt file must not silently drop its chains from the snapshot).
+var errNotWhitelistDocument = errors.New(`not a provider whitelist document (missing "providers" field)`)
 
 // providerWhitelistJSON is the JSON schema of the consumer provider whitelist, as fetched from
 // GitHub or a local file. It is intentionally unrelated to the spec schema
@@ -61,10 +68,11 @@ func (wd *whitelistData) pairCount() int {
 // per-chain ConsumerSessionManagers; each manager queries it with its own chainID.
 //
 // Semantics:
-//   - Until the first successful load it is "not loaded": IsAllowed returns true (passthrough),
-//     preserving the consumer's current behavior when no whitelist exists.
+//   - Until the first successful load it is "not loaded": IsAllowed returns true (passthrough), so
+//     a startup fetch failure keeps the consumer relaying to everyone rather than going dark.
 //   - Once loaded, IsAllowed returns true only for (chainID, providerAddr) pairs present in the
-//     list. A loaded-but-empty list therefore allows nobody (intentional whitelist semantics).
+//     list. A loaded-but-empty list therefore allows nobody (intentional whitelist semantics). A
+//     later refresh failure does NOT clear the snapshot, so the last-known-good list stays in place.
 //
 // The active snapshot is held in an atomic.Pointer so the read hot path (IsAllowed, called
 // per-candidate-provider per-relay) takes no locks, and the hourly refresh swaps it atomically.
@@ -72,7 +80,9 @@ type ProviderWhitelist struct {
 	data atomic.Pointer[whitelistData]
 }
 
-// NewProviderWhitelist returns a whitelist in the "not loaded" (passthrough) state.
+// NewProviderWhitelist returns a whitelist in the "not loaded" (passthrough) state. Until the first
+// successful load the consumer relays to everyone; once loaded a refresh failure keeps the
+// last-known-good snapshot.
 func NewProviderWhitelist() *ProviderWhitelist {
 	return &ProviderWhitelist{}
 }
@@ -90,11 +100,12 @@ func (pw *ProviderWhitelist) snapshot() *whitelistData {
 }
 
 // IsAllowed reports whether the consumer may relay to providerAddr for chainID. It returns true
-// (passthrough) when no whitelist has been loaded yet.
+// (passthrough) when no whitelist has been loaded yet, so a startup fetch failure keeps the
+// consumer relaying to everyone rather than going dark.
 func (pw *ProviderWhitelist) IsAllowed(chainID, providerAddr string) bool {
 	data := pw.data.Load()
 	if data == nil {
-		return true // not loaded -> passthrough (current relay behavior)
+		return true // not loaded yet -> passthrough (allow all until the first successful load)
 	}
 	return data.isAllowed(chainID, providerAddr)
 }
@@ -111,17 +122,25 @@ func (pw *ProviderWhitelist) UpdateFromBytes(content []byte) error {
 }
 
 // UpdateFromFiles parses each provided file as a whitelist document and atomically replaces the
-// active snapshot with the union of their entries. Files that do not conform to the whitelist
-// schema are skipped with a warning (so a shared/mixed repo does not break the load). If no file
-// yields a valid whitelist, the previous snapshot is left intact and an error is returned.
+// active snapshot with the union of their entries. Files that are valid JSON but are not whitelist
+// documents (no "providers" key) are skipped with a warning, so a shared/mixed repo does not break
+// the load. Any other parse failure (malformed JSON) is treated as a hard error: the previous
+// snapshot is left intact and an error is returned, so a corrupt file can't silently drop its
+// chains from the snapshot. If no file yields a valid whitelist, the previous snapshot is likewise
+// left intact and an error is returned.
 func (pw *ProviderWhitelist) UpdateFromFiles(files map[string][]byte) error {
 	merged := map[string]map[string]struct{}{}
 	parsedAny := false
 	for fileURL, content := range files {
 		index, err := parseWhitelist(content)
 		if err != nil {
-			utils.LavaFormatWarning("skipping non-conforming provider whitelist file", err, utils.LogAttr("file", fileURL))
-			continue
+			if errors.Is(err, errNotWhitelistDocument) {
+				utils.LavaFormatWarning("skipping non-whitelist file in provider whitelist source", err, utils.LogAttr("file", fileURL))
+				continue
+			}
+			// Malformed whitelist file: fail the whole refresh and keep the last-known-good snapshot
+			// rather than swapping in a partial union that silently omits this file's chains.
+			return fmt.Errorf("malformed provider whitelist file %q: %w", fileURL, err)
 		}
 		parsedAny = true
 		for chainID, addrs := range index.byChain {
@@ -163,7 +182,7 @@ func parseWhitelist(content []byte) (*whitelistData, error) {
 		return nil, fmt.Errorf("failed to parse provider whitelist JSON: %w", err)
 	}
 	if doc.Providers == nil {
-		return nil, fmt.Errorf("not a provider whitelist document (missing \"providers\" field)")
+		return nil, errNotWhitelistDocument
 	}
 
 	byChain := map[string]map[string]struct{}{}

--- a/protocol/lavasession/provider_whitelist.go
+++ b/protocol/lavasession/provider_whitelist.go
@@ -7,72 +7,102 @@ import (
 	"sync/atomic"
 
 	"github.com/lavanet/lava/v5/utils"
+	planstypes "github.com/lavanet/lava/v5/x/plans/types"
 )
 
 // errNotWhitelistDocument marks a file that is valid JSON but is not a whitelist (it omits the
-// "providers" key). During a multi-file load these are skipped so a shared/mixed repo of unrelated
-// configs doesn't break the load. It is deliberately distinct from a malformed-JSON error, which
-// is treated as a hard failure (a corrupt file must not silently drop its chains from the snapshot).
-var errNotWhitelistDocument = errors.New(`not a provider whitelist document (missing "providers" field)`)
+// "chains" key). During a multi-file load these are skipped so a shared/mixed repo of unrelated
+// configs doesn't break the load. It is deliberately distinct from a malformed-JSON error (or an
+// invalid geolocation), which is treated as a hard failure: a corrupt file must not silently drop
+// its chains from the snapshot.
+var errNotWhitelistDocument = errors.New(`not a provider whitelist document (missing "chains" field)`)
 
 // providerWhitelistJSON is the JSON schema of the consumer provider whitelist, as fetched from
-// GitHub or a local file. It is intentionally unrelated to the spec schema
-// (specutils.SpecAddProposalJSON): the whitelist is a flat list of providers and the chains
-// each provider is allowed to serve.
+// GitHub or a local file. It is keyed chain -> geolocation -> the providers allowed to serve that
+// chain from that region:
 //
 //	{
-//	  "providers": [
-//	    { "address": "lava@1abc...", "chains": ["ETH1", "LAV1"] },
-//	    { "address": "lava@1def...", "chains": ["NEAR"] }
-//	  ]
+//	  "chains": {
+//	    "ETH1": { "EU": ["lava@1abc...", "lava@1def..."], "AS": ["lava@1ghi..."] },
+//	    "LAV1": { "EU": ["lava@1abc..."] }
+//	  }
 //	}
 //
-// Providers is a pointer so we can distinguish a document that omits the "providers" key (not a
-// whitelist file at all -> rejected) from one that sets it to an empty array (an intentional
-// "allow nobody" whitelist -> accepted).
+// The geolocation keys are the on-chain region codes parsed by planstypes.ParseGeoEnum: a name
+// ("EU", "AS", "USC"/"USE"/"USW", "AF", "AU"), a raw bitmask ("2"), a comma-combined set ("EU,AS"),
+// or "GL" meaning "any region". Reusing that parser makes the list speak the same geolocation
+// vocabulary as the consumer's own --geolocation flag and every on-chain policy.
+//
+// Chains is a pointer so we can distinguish a document that omits the "chains" key (not a whitelist
+// file at all -> rejected) from one that sets it to an empty object (an intentional "allow nobody"
+// whitelist -> accepted).
 type providerWhitelistJSON struct {
-	Providers *[]providerWhitelistEntry `json:"providers"`
-}
-
-type providerWhitelistEntry struct {
-	Address string   `json:"address"`
-	Chains  []string `json:"chains"`
+	Chains *map[string]map[string][]string `json:"chains"`
+	// Providers detects the OLD pre-geolocation schema (a top-level "providers" array). It is never
+	// parsed; its only purpose is to fail an un-migrated file loudly instead of silently treating it
+	// as "not a whitelist" and falling through to passthrough (relay to everyone).
+	Providers *json.RawMessage `json:"providers"`
 }
 
 // whitelistData is the immutable, lookup-optimized index built from the parsed JSON:
-// chainID -> set of allowed provider addresses.
+// chainID -> geolocation code -> set of allowed provider addresses.
 type whitelistData struct {
-	byChain map[string]map[string]struct{}
+	byChainGeo map[string]map[int32]map[string]struct{}
 }
 
-func (wd *whitelistData) isAllowed(chainID, providerAddr string) bool {
-	addrs, ok := wd.byChain[chainID]
+// geoMatch reports whether a consumer in consumerGeo should be served by an entry whitelisted for
+// regionCode. A "GL" entry matches every region; otherwise the consumer's geolocation must share a
+// bit with the region (bitwise overlap), which reduces to plain equality for a single discrete
+// region (the common per-region-gateway case).
+func geoMatch(consumerGeo uint64, regionCode int32) bool {
+	if regionCode == int32(planstypes.Geolocation_GL) {
+		return true
+	}
+	return consumerGeo&uint64(regionCode) != 0
+}
+
+// isAllowed reports whether providerAddr may serve chainID for a consumer in consumerGeo. A chain
+// has at most one bucket per geolocation, so this per-relay scan is over a handful of regions and
+// is effectively constant time.
+func (wd *whitelistData) isAllowed(chainID string, consumerGeo uint64, providerAddr string) bool {
+	geoSets, ok := wd.byChainGeo[chainID]
 	if !ok {
 		return false
 	}
-	_, ok = addrs[providerAddr]
-	return ok
+	for regionCode, addrs := range geoSets {
+		if !geoMatch(consumerGeo, regionCode) {
+			continue
+		}
+		if _, ok := addrs[providerAddr]; ok {
+			return true
+		}
+	}
+	return false
 }
 
-// pairCount returns the number of distinct (chain, provider) pairs, used for logging.
-func (wd *whitelistData) pairCount() int {
+// entryCount returns the number of distinct (chain, geolocation, provider) entries, used for logging.
+func (wd *whitelistData) entryCount() int {
 	count := 0
-	for _, addrs := range wd.byChain {
-		count += len(addrs)
+	for _, geoSets := range wd.byChainGeo {
+		for _, addrs := range geoSets {
+			count += len(addrs)
+		}
 	}
 	return count
 }
 
-// ProviderWhitelist is a thread-safe, hourly-refreshed allowlist that restricts which providers
-// the consumer is willing to relay to, per chain. A single instance is shared across all
-// per-chain ConsumerSessionManagers; each manager queries it with its own chainID.
+// ProviderWhitelist is a thread-safe, hourly-refreshed allowlist that restricts which providers the
+// consumer is willing to relay to, per chain AND per geolocation. A single instance is shared across
+// all per-chain ConsumerSessionManagers; each manager queries it with its own ChainID and the
+// consumer's configured geolocation.
 //
 // Semantics:
 //   - Until the first successful load it is "not loaded": IsAllowed returns true (passthrough), so
 //     a startup fetch failure keeps the consumer relaying to everyone rather than going dark.
-//   - Once loaded, IsAllowed returns true only for (chainID, providerAddr) pairs present in the
-//     list. A loaded-but-empty list therefore allows nobody (intentional whitelist semantics). A
-//     later refresh failure does NOT clear the snapshot, so the last-known-good list stays in place.
+//   - Once loaded, IsAllowed returns true only for (chainID, geolocation, providerAddr) tuples
+//     present in the list. A loaded-but-empty list therefore allows nobody (intentional whitelist
+//     semantics). A later refresh failure does NOT clear the snapshot, so the last-known-good list
+//     stays in place.
 //
 // The active snapshot is held in an atomic.Pointer so the read hot path (IsAllowed, called
 // per-candidate-provider per-relay) takes no locks, and the hourly refresh swaps it atomically.
@@ -99,15 +129,15 @@ func (pw *ProviderWhitelist) snapshot() *whitelistData {
 	return pw.data.Load()
 }
 
-// IsAllowed reports whether the consumer may relay to providerAddr for chainID. It returns true
-// (passthrough) when no whitelist has been loaded yet, so a startup fetch failure keeps the
-// consumer relaying to everyone rather than going dark.
-func (pw *ProviderWhitelist) IsAllowed(chainID, providerAddr string) bool {
+// IsAllowed reports whether the consumer (in consumerGeo) may relay to providerAddr for chainID. It
+// returns true (passthrough) when no whitelist has been loaded yet, so a startup fetch failure keeps
+// the consumer relaying to everyone rather than going dark.
+func (pw *ProviderWhitelist) IsAllowed(chainID string, consumerGeo uint64, providerAddr string) bool {
 	data := pw.data.Load()
 	if data == nil {
 		return true // not loaded yet -> passthrough (allow all until the first successful load)
 	}
-	return data.isAllowed(chainID, providerAddr)
+	return data.isAllowed(chainID, consumerGeo, providerAddr)
 }
 
 // UpdateFromBytes parses a single whitelist JSON document and atomically replaces the active
@@ -123,13 +153,13 @@ func (pw *ProviderWhitelist) UpdateFromBytes(content []byte) error {
 
 // UpdateFromFiles parses each provided file as a whitelist document and atomically replaces the
 // active snapshot with the union of their entries. Files that are valid JSON but are not whitelist
-// documents (no "providers" key) are skipped with a warning, so a shared/mixed repo does not break
-// the load. Any other parse failure (malformed JSON) is treated as a hard error: the previous
-// snapshot is left intact and an error is returned, so a corrupt file can't silently drop its
-// chains from the snapshot. If no file yields a valid whitelist, the previous snapshot is likewise
-// left intact and an error is returned.
+// documents (no "chains" key) are skipped with a warning, so a shared/mixed repo does not break the
+// load. Any other parse failure (malformed JSON or an invalid geolocation) is treated as a hard
+// error: the previous snapshot is left intact and an error is returned, so a corrupt file can't
+// silently drop its chains from the snapshot. If no file yields a valid whitelist, the previous
+// snapshot is likewise left intact and an error is returned.
 func (pw *ProviderWhitelist) UpdateFromFiles(files map[string][]byte) error {
-	merged := map[string]map[string]struct{}{}
+	merged := map[string]map[int32]map[string]struct{}{}
 	parsedAny := false
 	for fileURL, content := range files {
 		index, err := parseWhitelist(content)
@@ -138,67 +168,94 @@ func (pw *ProviderWhitelist) UpdateFromFiles(files map[string][]byte) error {
 				utils.LavaFormatWarning("skipping non-whitelist file in provider whitelist source", err, utils.LogAttr("file", fileURL))
 				continue
 			}
-			// Malformed whitelist file: fail the whole refresh and keep the last-known-good snapshot
-			// rather than swapping in a partial union that silently omits this file's chains.
+			// Malformed/invalid whitelist file: fail the whole refresh and keep the last-known-good
+			// snapshot rather than swapping in a partial union that silently omits this file's chains.
 			return fmt.Errorf("malformed provider whitelist file %q: %w", fileURL, err)
 		}
 		parsedAny = true
-		for chainID, addrs := range index.byChain {
+		for chainID, geoSets := range index.byChainGeo {
 			if merged[chainID] == nil {
-				merged[chainID] = map[string]struct{}{}
+				merged[chainID] = map[int32]map[string]struct{}{}
 			}
-			for addr := range addrs {
-				merged[chainID][addr] = struct{}{}
+			for geo, addrs := range geoSets {
+				if merged[chainID][geo] == nil {
+					merged[chainID][geo] = map[string]struct{}{}
+				}
+				for addr := range addrs {
+					merged[chainID][geo][addr] = struct{}{}
+				}
 			}
 		}
 	}
 	if !parsedAny {
 		return fmt.Errorf("no valid provider whitelist files found (out of %d fetched)", len(files))
 	}
-	pw.store(&whitelistData{byChain: merged})
+	pw.store(&whitelistData{byChainGeo: merged})
 	return nil
 }
 
-// store atomically swaps in a new snapshot and logs the result. An empty (but loaded) whitelist
-// is logged loudly because it causes the consumer to relay to no providers.
+// store atomically swaps in a new snapshot and logs the result. An empty (but loaded) whitelist is
+// logged loudly because it causes the consumer to relay to no providers.
 func (pw *ProviderWhitelist) store(data *whitelistData) {
 	pw.data.Store(data)
-	pairs := data.pairCount()
-	if pairs == 0 {
+	entries := data.entryCount()
+	if entries == 0 {
 		utils.LavaFormatWarning("provider whitelist loaded but EMPTY - the consumer will relay to NO providers", nil)
 		return
 	}
 	utils.LavaFormatInfo("provider whitelist loaded",
-		utils.LogAttr("chains", len(data.byChain)),
-		utils.LogAttr("allowed_provider_chain_pairs", pairs),
+		utils.LogAttr("chains", len(data.byChainGeo)),
+		utils.LogAttr("allowed_provider_chain_geo_entries", entries),
 	)
 }
 
 // parseWhitelist parses a single whitelist JSON document into a lookup index. It returns an error
-// for malformed JSON or for a document that omits the "providers" key (i.e. is not a whitelist).
+// for malformed JSON, for a document that omits the "chains" key (i.e. is not a whitelist), or for
+// an unparseable geolocation code.
 func parseWhitelist(content []byte) (*whitelistData, error) {
 	var doc providerWhitelistJSON
 	if err := json.Unmarshal(content, &doc); err != nil {
 		return nil, fmt.Errorf("failed to parse provider whitelist JSON: %w", err)
 	}
-	if doc.Providers == nil {
+	if doc.Chains == nil {
+		// An old-schema whitelist (top-level "providers", no "chains") is a stale file that must be
+		// migrated, not an unrelated file to skip. Fail it loudly: errNotWhitelistDocument would be
+		// skipped in a multi-file load, leaving the consumer in passthrough (relaying to everyone).
+		if doc.Providers != nil {
+			return nil, fmt.Errorf(`provider whitelist uses the old pre-geolocation schema (top-level "providers"); migrate it to the chain -> geolocation -> providers schema (see docs/provider-whitelist.md)`)
+		}
 		return nil, errNotWhitelistDocument
 	}
 
-	byChain := map[string]map[string]struct{}{}
-	for _, entry := range *doc.Providers {
-		if entry.Address == "" {
+	byChainGeo := map[string]map[int32]map[string]struct{}{}
+	for chainID, regions := range *doc.Chains {
+		if chainID == "" {
 			continue
 		}
-		for _, chainID := range entry.Chains {
-			if chainID == "" {
+		for region, addrs := range regions {
+			if region == "" {
 				continue
 			}
-			if byChain[chainID] == nil {
-				byChain[chainID] = map[string]struct{}{}
+			// A typo'd region (e.g. "Asia" instead of "AS", or "US" which is not a region code) is a
+			// hard error rather than a silent skip: quietly dropping it would stop relaying for that
+			// region, which is exactly the misconfiguration this whitelist exists to prevent.
+			geoCode, err := planstypes.ParseGeoEnum(region)
+			if err != nil {
+				return nil, fmt.Errorf("invalid geolocation %q for chain %q in provider whitelist: %w", region, chainID, err)
 			}
-			byChain[chainID][entry.Address] = struct{}{}
+			for _, addr := range addrs {
+				if addr == "" {
+					continue
+				}
+				if byChainGeo[chainID] == nil {
+					byChainGeo[chainID] = map[int32]map[string]struct{}{}
+				}
+				if byChainGeo[chainID][geoCode] == nil {
+					byChainGeo[chainID][geoCode] = map[string]struct{}{}
+				}
+				byChainGeo[chainID][geoCode][addr] = struct{}{}
+			}
 		}
 	}
-	return &whitelistData{byChain: byChain}, nil
+	return &whitelistData{byChainGeo: byChainGeo}, nil
 }

--- a/protocol/lavasession/provider_whitelist_filter_test.go
+++ b/protocol/lavasession/provider_whitelist_filter_test.go
@@ -107,28 +107,6 @@ func TestProviderWhitelist_FilterStickySession(t *testing.T) {
 	require.NotContains(t, addrs, excluded)
 }
 
-// TestProviderWhitelist_FilterBackupProviders asserts the emergency backup fallback never selects
-// a non-whitelisted provider (separate store, line ~1361).
-func TestProviderWhitelist_FilterBackupProviders(t *testing.T) {
-	ctx := context.Background()
-	csm := CreateConsumerSessionManager()
-	// Same addresses serve as both main pairing and backups; we only exercise the backup path.
-	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), createPairingList("", true)))
-	excluded := providerStr + "0"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
-
-	ignored := &ignoredProviders{providers: map[string]struct{}{}, currentEpoch: csm.atomicReadCurrentEpoch()}
-	// Drain the backup pool; the excluded provider must never be returned.
-	for i := 0; i < numberOfProviders*2; i++ {
-		m, err := csm.getValidConsumerSessionsWithProviderFromBackupProviderList(ctx, ignored, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, 0, NewUsedProviders(nil))
-		if err != nil {
-			break // pool exhausted
-		}
-		_, found := m[excluded]
-		require.False(t, found, "non-whitelisted provider selected from backup pool")
-	}
-}
-
 // TestProviderWhitelist_FilterBlockedRecovery asserts the blocked-provider recovery fallback never
 // returns a non-whitelisted provider, even though it was whitelisted when it got blocked (the
 // whitelist can change via the hourly refresh; line ~1290).

--- a/protocol/lavasession/provider_whitelist_filter_test.go
+++ b/protocol/lavasession/provider_whitelist_filter_test.go
@@ -1,0 +1,201 @@
+package lavasession
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// whitelistAllowingAllExcept builds a loaded whitelist that permits every provider produced by
+// createPairingList for the given chain, except the one excluded address.
+func whitelistAllowingAllExcept(t *testing.T, chainID, excluded string) *ProviderWhitelist {
+	t.Helper()
+	entries := make([]string, 0, numberOfProviders)
+	for p := 0; p < numberOfProviders; p++ {
+		addr := providerStr + strconv.Itoa(p)
+		if addr == excluded {
+			continue
+		}
+		entries = append(entries, fmt.Sprintf(`{"address":%q,"chains":[%q]}`, addr, chainID))
+	}
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(`{"providers":[%s]}`, strings.Join(entries, ",")))))
+	return pw
+}
+
+// TestProviderWhitelist_FilterHelpers covers the building blocks deterministically: the list
+// filter drops only non-whitelisted addresses, and passthrough holds when unset/unloaded.
+func TestProviderWhitelist_FilterHelpers(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	all := []string{providerStr + "0", providerStr + "1", providerStr + "2"}
+
+	// No whitelist configured -> passthrough (input unchanged, everything allowed).
+	require.Nil(t, csm.providerWhitelist)
+	require.Equal(t, all, csm.filterAllowedProviders(all))
+	require.True(t, csm.isProviderAllowed(providerStr+"0"))
+
+	// Whitelist excluding provider0 -> filtered out of the list and individually disallowed.
+	excluded := providerStr + "0"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	require.Equal(t, []string{providerStr + "1", providerStr + "2"}, csm.filterAllowedProviders(all))
+	require.False(t, csm.isProviderAllowed(excluded))
+	require.True(t, csm.isProviderAllowed(providerStr+"1"))
+}
+
+// TestProviderWhitelist_FilterOptimizerPath asserts the optimizer never returns a non-whitelisted
+// provider (the main selection path, line ~1086).
+func TestProviderWhitelist_FilterOptimizerPath(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	excluded := providerStr + "0"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	for i := 0; i < 100; i++ {
+		addrs, err := csm.getValidProviderAddresses(ctx, 1, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, "", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, addrs)
+		require.NotContains(t, addrs, excluded)
+	}
+}
+
+// TestProviderWhitelist_FilterHeaderSelect asserts a header-selected provider must be whitelisted
+// (whitelist wins over the per-request provider hint).
+func TestProviderWhitelist_FilterHeaderSelect(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	excluded := providerStr + "0"
+	allowed := providerStr + "1"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	// Selecting the non-whitelisted provider via header fails.
+	_, err := csm.getValidProviderAddresses(ctx, 1, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, "", excluded)
+	require.Error(t, err)
+	// Selecting a whitelisted provider via header returns exactly it.
+	addrs, err := csm.getValidProviderAddresses(ctx, 1, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, "", allowed)
+	require.NoError(t, err)
+	require.Equal(t, []string{allowed}, addrs)
+}
+
+// TestProviderWhitelist_FilterStickySession asserts a sticky session pinned to a now-non-whitelisted
+// provider does not relay to it (the sticky shortcut, line ~1116).
+func TestProviderWhitelist_FilterStickySession(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	excluded := providerStr + "0"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+
+	// Pin a sticky session to the excluded provider.
+	csm.stickySessions.Set("sticky-id", &StickySession{Provider: excluded, Epoch: csm.atomicReadCurrentEpoch()})
+
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	addrs, err := csm.getValidProviderAddresses(ctx, 1, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, "sticky-id", "")
+	require.NoError(t, err)
+	require.NotContains(t, addrs, excluded)
+}
+
+// TestProviderWhitelist_FilterBackupProviders asserts the emergency backup fallback never selects
+// a non-whitelisted provider (separate store, line ~1361).
+func TestProviderWhitelist_FilterBackupProviders(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	// Same addresses serve as both main pairing and backups; we only exercise the backup path.
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), createPairingList("", true)))
+	excluded := providerStr + "0"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+
+	ignored := &ignoredProviders{providers: map[string]struct{}{}, currentEpoch: csm.atomicReadCurrentEpoch()}
+	// Drain the backup pool; the excluded provider must never be returned.
+	for i := 0; i < numberOfProviders*2; i++ {
+		m, err := csm.getValidConsumerSessionsWithProviderFromBackupProviderList(ctx, ignored, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, 0, NewUsedProviders(nil))
+		if err != nil {
+			break // pool exhausted
+		}
+		_, found := m[excluded]
+		require.False(t, found, "non-whitelisted provider selected from backup pool")
+	}
+}
+
+// TestProviderWhitelist_FilterBlockedRecovery asserts the blocked-provider recovery fallback never
+// returns a non-whitelisted provider, even though it was whitelisted when it got blocked (the
+// whitelist can change via the hourly refresh; line ~1290).
+func TestProviderWhitelist_FilterBlockedRecovery(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	excluded := providerStr + "0"
+	allowed := providerStr + "5"
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+
+	// Simulate both providers being blocked this epoch (excluded was delisted after being blocked).
+	csm.lock.Lock()
+	csm.currentlyBlockedProviderAddresses = []string{excluded, allowed}
+	csm.lock.Unlock()
+
+	ignored := &ignoredProviders{providers: map[string]struct{}{}, currentEpoch: csm.atomicReadCurrentEpoch()}
+	m, err := csm.tryGetConsumerSessionWithProviderFromBlockedProviderList(ctx, 1, ignored, cuForFirstRequest, servicedBlockNumber, "", nil, common.NO_STATE, 0, NewUsedProviders(nil))
+	require.NoError(t, err)
+	_, foundExcluded := m[excluded]
+	require.False(t, foundExcluded, "non-whitelisted provider recovered from blocked list")
+	_, foundAllowed := m[allowed]
+	require.True(t, foundAllowed, "whitelisted blocked provider should still be recoverable")
+}
+
+// TestProviderWhitelist_GetSessionsRestrictsToWhitelisted drives the real GetSessions entry point
+// (not an internal selection method) and asserts every returned session goes to the single
+// whitelisted provider.
+func TestProviderWhitelist_GetSessionsRestrictsToWhitelisted(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	allowed := providerStr + "5"
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(`{"providers":[{"address":%q,"chains":[%q]}]}`, allowed, csm.rpcEndpoint.ChainID))))
+	csm.SetProviderWhitelist(pw)
+
+	for i := 0; i < 10; i++ {
+		css, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+		require.NoError(t, err)
+		require.Len(t, css, 1)
+		for providerAddr, cs := range css {
+			require.Equal(t, allowed, providerAddr)
+			// release the session so the loop doesn't exhaust the per-provider session pool
+			require.NoError(t, csm.OnSessionDone(cs.Session, servicedBlockNumber, cuForFirstRequest, time.Millisecond, cs.Session.CalculateExpectedLatency(2*time.Millisecond), 1, numberOfProviders, numberOfProviders, false, nil))
+		}
+	}
+}
+
+// TestProviderWhitelist_GetSessionsEmptyIntersectionNoResetStorm asserts that when the whitelist
+// excludes every paired provider for this chain, GetSessions fails cleanly and, crucially, does
+// NOT trigger validAddresses resets. This is the reason the filter is applied at the selection
+// call site rather than inside CalculateAddonValidAddresses (which validatePairingListNotEmpty
+// drives, and which would reset-loop on an empty set).
+func TestProviderWhitelist_GetSessionsEmptyIntersectionNoResetStorm(t *testing.T) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
+	// Whitelist names only a provider on a different chain -> empty intersection for this chain.
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"someoneElse","chains":["OTHERCHAIN"]}]}`)))
+	csm.SetProviderWhitelist(pw)
+
+	resetsBefore := csm.atomicReadNumberOfResets()
+	for i := 0; i < 5; i++ {
+		_, err := csm.GetSessions(ctx, 1, cuForFirstRequest, NewUsedProviders(nil), servicedBlockNumber, "", nil, common.NO_STATE, 0, "", "")
+		require.Error(t, err) // no whitelisted providers for this chain -> clean failure, not a hang
+	}
+	require.Equal(t, resetsBefore, csm.atomicReadNumberOfResets(), "emptying the candidate set via whitelist must not trigger validAddresses resets")
+}

--- a/protocol/lavasession/provider_whitelist_filter_test.go
+++ b/protocol/lavasession/provider_whitelist_filter_test.go
@@ -13,19 +13,20 @@ import (
 )
 
 // whitelistAllowingAllExcept builds a loaded whitelist that permits every provider produced by
-// createPairingList for the given chain, except the one excluded address.
-func whitelistAllowingAllExcept(t *testing.T, chainID, excluded string) *ProviderWhitelist {
+// createPairingList for the given chain and region, except the one excluded address.
+func whitelistAllowingAllExcept(t *testing.T, chainID, region, excluded string) *ProviderWhitelist {
 	t.Helper()
-	entries := make([]string, 0, numberOfProviders)
+	addrs := make([]string, 0, numberOfProviders)
 	for p := 0; p < numberOfProviders; p++ {
 		addr := providerStr + strconv.Itoa(p)
 		if addr == excluded {
 			continue
 		}
-		entries = append(entries, fmt.Sprintf(`{"address":%q,"chains":[%q]}`, addr, chainID))
+		addrs = append(addrs, strconv.Quote(addr))
 	}
 	pw := NewProviderWhitelist()
-	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(`{"providers":[%s]}`, strings.Join(entries, ",")))))
+	doc := fmt.Sprintf(`{"chains":{%q:{%q:[%s]}}}`, chainID, region, strings.Join(addrs, ","))
+	require.NoError(t, pw.UpdateFromBytes([]byte(doc)))
 	return pw
 }
 
@@ -33,6 +34,7 @@ func whitelistAllowingAllExcept(t *testing.T, chainID, excluded string) *Provide
 // filter drops only non-whitelisted addresses, and passthrough holds when unset/unloaded.
 func TestProviderWhitelist_FilterHelpers(t *testing.T) {
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	all := []string{providerStr + "0", providerStr + "1", providerStr + "2"}
 
 	// No whitelist configured -> passthrough (input unchanged, everything allowed).
@@ -42,10 +44,29 @@ func TestProviderWhitelist_FilterHelpers(t *testing.T) {
 
 	// Whitelist excluding provider0 -> filtered out of the list and individually disallowed.
 	excluded := providerStr + "0"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, "EU", excluded))
 	require.Equal(t, []string{providerStr + "1", providerStr + "2"}, csm.filterAllowedProviders(all))
 	require.False(t, csm.isProviderAllowed(excluded))
 	require.True(t, csm.isProviderAllowed(providerStr+"1"))
+}
+
+// TestProviderWhitelist_FilterByConsumerGeolocation asserts the list filters by the consumer's
+// region: a provider listed only for another region is dropped, exactly as if it weren't listed.
+// This is the core MAG-1987 behavior for a per-region gateway.
+func TestProviderWhitelist_FilterByConsumerGeolocation(t *testing.T) {
+	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU // this gateway is an EU consumer
+	all := []string{providerStr + "0", providerStr + "1"}
+
+	// provider0 whitelisted for EU (the consumer's region), provider1 only for AS.
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(
+		`{"chains":{%q:{"EU":[%q],"AS":[%q]}}}`, csm.rpcEndpoint.ChainID, providerStr+"0", providerStr+"1"))))
+	csm.SetProviderWhitelist(pw)
+
+	require.Equal(t, []string{providerStr + "0"}, csm.filterAllowedProviders(all))
+	require.True(t, csm.isProviderAllowed(providerStr+"0"))
+	require.False(t, csm.isProviderAllowed(providerStr+"1")) // AS-only -> not for this EU consumer
 }
 
 // TestProviderWhitelist_FilterOptimizerPath asserts the optimizer never returns a non-whitelisted
@@ -53,9 +74,10 @@ func TestProviderWhitelist_FilterHelpers(t *testing.T) {
 func TestProviderWhitelist_FilterOptimizerPath(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	excluded := providerStr + "0"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, "EU", excluded))
 
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()
@@ -72,10 +94,11 @@ func TestProviderWhitelist_FilterOptimizerPath(t *testing.T) {
 func TestProviderWhitelist_FilterHeaderSelect(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	excluded := providerStr + "0"
 	allowed := providerStr + "1"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, "EU", excluded))
 
 	csm.lock.RLock()
 	defer csm.lock.RUnlock()
@@ -93,9 +116,10 @@ func TestProviderWhitelist_FilterHeaderSelect(t *testing.T) {
 func TestProviderWhitelist_FilterStickySession(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	excluded := providerStr + "0"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, "EU", excluded))
 
 	// Pin a sticky session to the excluded provider.
 	csm.stickySessions.Set("sticky-id", &StickySession{Provider: excluded, Epoch: csm.atomicReadCurrentEpoch()})
@@ -113,10 +137,11 @@ func TestProviderWhitelist_FilterStickySession(t *testing.T) {
 func TestProviderWhitelist_FilterBlockedRecovery(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	excluded := providerStr + "0"
 	allowed := providerStr + "5"
-	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, excluded))
+	csm.SetProviderWhitelist(whitelistAllowingAllExcept(t, csm.rpcEndpoint.ChainID, "EU", excluded))
 
 	// Simulate both providers being blocked this epoch (excluded was delisted after being blocked).
 	csm.lock.Lock()
@@ -138,10 +163,11 @@ func TestProviderWhitelist_FilterBlockedRecovery(t *testing.T) {
 func TestProviderWhitelist_GetSessionsRestrictsToWhitelisted(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	allowed := providerStr + "5"
 	pw := NewProviderWhitelist()
-	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(`{"providers":[{"address":%q,"chains":[%q]}]}`, allowed, csm.rpcEndpoint.ChainID))))
+	require.NoError(t, pw.UpdateFromBytes([]byte(fmt.Sprintf(`{"chains":{%q:{"EU":[%q]}}}`, csm.rpcEndpoint.ChainID, allowed))))
 	csm.SetProviderWhitelist(pw)
 
 	for i := 0; i < 10; i++ {
@@ -164,10 +190,11 @@ func TestProviderWhitelist_GetSessionsRestrictsToWhitelisted(t *testing.T) {
 func TestProviderWhitelist_GetSessionsEmptyIntersectionNoResetStorm(t *testing.T) {
 	ctx := context.Background()
 	csm := CreateConsumerSessionManager()
+	csm.rpcEndpoint.Geolocation = geoEU
 	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, createPairingList("", true), nil))
 	// Whitelist names only a provider on a different chain -> empty intersection for this chain.
 	pw := NewProviderWhitelist()
-	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"someoneElse","chains":["OTHERCHAIN"]}]}`)))
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"OTHERCHAIN":{"EU":["someoneElse"]}}}`)))
 	csm.SetProviderWhitelist(pw)
 
 	resetsBefore := csm.atomicReadNumberOfResets()

--- a/protocol/lavasession/provider_whitelist_test.go
+++ b/protocol/lavasession/provider_whitelist_test.go
@@ -100,16 +100,37 @@ func TestProviderWhitelist_UpdateFromFilesUnions(t *testing.T) {
 	require.False(t, pw.IsAllowed("LAV1", "provider0"))
 }
 
-func TestProviderWhitelist_UpdateFromFilesSkipsNonConforming(t *testing.T) {
+func TestProviderWhitelist_UpdateFromFilesSkipsNonWhitelist(t *testing.T) {
 	pw := NewProviderWhitelist()
 	files := map[string][]byte{
 		"whitelist.json": []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`),
-		"spec.json":      []byte(`{"proposal":{"specs":[{"index":"ETH1"}]}}`), // not a whitelist -> skipped
-		"garbage.json":   []byte(`not json at all`),                           // skipped
+		"spec.json":      []byte(`{"proposal":{"specs":[{"index":"ETH1"}]}}`), // valid JSON, no "providers" -> skipped
 	}
-	// Succeeds because at least one file is a valid whitelist; non-conforming files are ignored.
+	// Succeeds because at least one file is a valid whitelist; files that are valid JSON but aren't
+	// whitelist documents are skipped (mixed-repo support).
 	require.NoError(t, pw.UpdateFromFiles(files))
 	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+// TestProviderWhitelist_UpdateFromFilesMalformedKeepsPrevious pins the all-or-nothing contract for
+// a corrupt file: a file that fetched OK but is malformed JSON fails the whole refresh and leaves
+// the last-known-good snapshot intact, instead of swapping in a partial union that silently drops
+// the good file's chains. (A malformed JSON file is distinct from a valid-JSON non-whitelist file,
+// which is still skipped — see TestProviderWhitelist_UpdateFromFilesSkipsNonWhitelist.)
+func TestProviderWhitelist_UpdateFromFilesMalformedKeepsPrevious(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+
+	files := map[string][]byte{
+		"good.json":    []byte(`{"providers":[{"address":"providerX","chains":["NEAR"]}]}`),
+		"corrupt.json": []byte(`not json at all`), // malformed -> hard failure, no swap
+	}
+	require.Error(t, pw.UpdateFromFiles(files))
+	// The previous snapshot is untouched: the good file's NEAR provider was NOT swapped in, and the
+	// original ETH1 provider is still allowed.
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.False(t, pw.IsAllowed("NEAR", "providerX"))
 }
 
 func TestProviderWhitelist_UpdateFromFilesAllInvalidKeepsPrevious(t *testing.T) {

--- a/protocol/lavasession/provider_whitelist_test.go
+++ b/protocol/lavasession/provider_whitelist_test.go
@@ -1,0 +1,140 @@
+package lavasession
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const sampleWhitelistJSON = `{
+  "providers": [
+    { "address": "provider0", "chains": ["ETH1", "LAV1"] },
+    { "address": "provider1", "chains": ["ETH1"] },
+    { "address": "provider2", "chains": ["NEAR"] }
+  ]
+}`
+
+func TestProviderWhitelist_NotLoadedIsPassthrough(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.False(t, pw.Enabled())
+	// Until a list loads, everything is allowed (current relay behavior).
+	require.True(t, pw.IsAllowed("ETH1", "anyProvider"))
+	require.True(t, pw.IsAllowed("anyChain", "anyProvider"))
+}
+
+func TestProviderWhitelist_IsAllowedHitAndMiss(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	require.True(t, pw.Enabled())
+
+	// Hits: (provider, chain) pairs present in the list.
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("LAV1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", "provider1"))
+	require.True(t, pw.IsAllowed("NEAR", "provider2"))
+
+	// Misses: provider present but not on that chain.
+	require.False(t, pw.IsAllowed("LAV1", "provider1")) // provider1 is only on ETH1
+	require.False(t, pw.IsAllowed("NEAR", "provider0"))
+	// Miss: provider not in the list at all.
+	require.False(t, pw.IsAllowed("ETH1", "providerX"))
+	// Miss: chain not in the list at all.
+	require.False(t, pw.IsAllowed("BTC", "provider0"))
+}
+
+func TestProviderWhitelist_PerChainIsolation(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	// The same provider is allowed on one chain and denied on another.
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.False(t, pw.IsAllowed("NEAR", "provider0"))
+}
+
+func TestProviderWhitelist_EmptyListAllowsNobody(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// A loaded-but-empty whitelist is "allow nobody" (intentional whitelist semantics).
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[]}`)))
+	require.True(t, pw.Enabled())
+	require.False(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelist_MalformedKeepsPrevious(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+
+	// A malformed update must error and leave the last-known-good snapshot intact.
+	require.Error(t, pw.UpdateFromBytes([]byte(`{ not valid json `)))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelist_MissingProvidersFieldRejected(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// A document without a "providers" key is not a whitelist (e.g. a spec file) and is rejected,
+	// rather than being treated as an empty (allow-nobody) whitelist.
+	require.Error(t, pw.UpdateFromBytes([]byte(`{"proposal":{"specs":[]}}`)))
+	require.False(t, pw.Enabled())
+}
+
+func TestProviderWhitelist_AtomicSwapReplacesList(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", "provider1"))
+
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"provider1","chains":["ETH1"]}]}`)))
+	require.False(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", "provider1"))
+}
+
+func TestProviderWhitelist_UpdateFromFilesUnions(t *testing.T) {
+	pw := NewProviderWhitelist()
+	files := map[string][]byte{
+		"a.json": []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`),
+		"b.json": []byte(`{"providers":[{"address":"provider1","chains":["ETH1","LAV1"]}]}`),
+	}
+	require.NoError(t, pw.UpdateFromFiles(files))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", "provider1"))
+	require.True(t, pw.IsAllowed("LAV1", "provider1"))
+	require.False(t, pw.IsAllowed("LAV1", "provider0"))
+}
+
+func TestProviderWhitelist_UpdateFromFilesSkipsNonConforming(t *testing.T) {
+	pw := NewProviderWhitelist()
+	files := map[string][]byte{
+		"whitelist.json": []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`),
+		"spec.json":      []byte(`{"proposal":{"specs":[{"index":"ETH1"}]}}`), // not a whitelist -> skipped
+		"garbage.json":   []byte(`not json at all`),                           // skipped
+	}
+	// Succeeds because at least one file is a valid whitelist; non-conforming files are ignored.
+	require.NoError(t, pw.UpdateFromFiles(files))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelist_UpdateFromFilesAllInvalidKeepsPrevious(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+
+	files := map[string][]byte{
+		"spec.json":    []byte(`{"proposal":{"specs":[]}}`),
+		"garbage.json": []byte(`nope`),
+	}
+	// No file is a valid whitelist -> error, and the previous snapshot is preserved.
+	require.Error(t, pw.UpdateFromFiles(files))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelist_IgnoresEmptyAddressAndChain(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[
+		{"address":"","chains":["ETH1"]},
+		{"address":"provider0","chains":["",""]},
+		{"address":"provider1","chains":["ETH1",""]}
+	]}`)))
+	// Entry with empty address contributes nothing; empty chain ids are skipped.
+	require.True(t, pw.Enabled())
+	require.True(t, pw.IsAllowed("ETH1", "provider1"))
+	require.False(t, pw.IsAllowed("ETH1", "provider0")) // only had empty chains
+	require.False(t, pw.IsAllowed("ETH1", ""))
+}

--- a/protocol/lavasession/provider_whitelist_test.go
+++ b/protocol/lavasession/provider_whitelist_test.go
@@ -3,23 +3,30 @@ package lavasession
 import (
 	"testing"
 
+	planstypes "github.com/lavanet/lava/v5/x/plans/types"
 	"github.com/stretchr/testify/require"
 )
 
+// region codes used by the tests, matching the on-chain geolocation enum.
+const (
+	geoEU = uint64(planstypes.Geolocation_EU) // 2
+	geoAS = uint64(planstypes.Geolocation_AS) // 32
+)
+
 const sampleWhitelistJSON = `{
-  "providers": [
-    { "address": "provider0", "chains": ["ETH1", "LAV1"] },
-    { "address": "provider1", "chains": ["ETH1"] },
-    { "address": "provider2", "chains": ["NEAR"] }
-  ]
+  "chains": {
+    "ETH1": { "EU": ["provider0", "provider1"] },
+    "LAV1": { "EU": ["provider0"] },
+    "NEAR": { "AS": ["provider2"] }
+  }
 }`
 
 func TestProviderWhitelist_NotLoadedIsPassthrough(t *testing.T) {
 	pw := NewProviderWhitelist()
 	require.False(t, pw.Enabled())
 	// Until a list loads, everything is allowed (current relay behavior).
-	require.True(t, pw.IsAllowed("ETH1", "anyProvider"))
-	require.True(t, pw.IsAllowed("anyChain", "anyProvider"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "anyProvider"))
+	require.True(t, pw.IsAllowed("anyChain", geoAS, "anyProvider"))
 }
 
 func TestProviderWhitelist_IsAllowedHitAndMiss(t *testing.T) {
@@ -27,89 +34,164 @@ func TestProviderWhitelist_IsAllowedHitAndMiss(t *testing.T) {
 	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
 	require.True(t, pw.Enabled())
 
-	// Hits: (provider, chain) pairs present in the list.
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.True(t, pw.IsAllowed("LAV1", "provider0"))
-	require.True(t, pw.IsAllowed("ETH1", "provider1"))
-	require.True(t, pw.IsAllowed("NEAR", "provider2"))
+	// Hits: (provider, chain, region) tuples present in the list.
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("LAV1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
+	require.True(t, pw.IsAllowed("NEAR", geoAS, "provider2"))
 
 	// Misses: provider present but not on that chain.
-	require.False(t, pw.IsAllowed("LAV1", "provider1")) // provider1 is only on ETH1
-	require.False(t, pw.IsAllowed("NEAR", "provider0"))
+	require.False(t, pw.IsAllowed("LAV1", geoEU, "provider1")) // provider1 is only on ETH1
+	require.False(t, pw.IsAllowed("NEAR", geoAS, "provider0"))
+	// Misses: right chain and provider, but wrong region.
+	require.False(t, pw.IsAllowed("ETH1", geoAS, "provider0")) // provider0 is EU-only for ETH1
+	require.False(t, pw.IsAllowed("NEAR", geoEU, "provider2")) // provider2 is AS-only for NEAR
 	// Miss: provider not in the list at all.
-	require.False(t, pw.IsAllowed("ETH1", "providerX"))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "providerX"))
 	// Miss: chain not in the list at all.
-	require.False(t, pw.IsAllowed("BTC", "provider0"))
+	require.False(t, pw.IsAllowed("BTC", geoEU, "provider0"))
 }
 
 func TestProviderWhitelist_PerChainIsolation(t *testing.T) {
 	pw := NewProviderWhitelist()
 	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
 	// The same provider is allowed on one chain and denied on another.
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.False(t, pw.IsAllowed("NEAR", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("NEAR", geoEU, "provider0"))
+}
+
+func TestProviderWhitelist_PerGeolocationIsolation(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	// The same (provider, chain) is allowed in its region and denied from another region. This is
+	// the core MAG-1987 requirement: an EU gateway and an AS gateway gate the same chain differently.
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoAS, "provider0"))
+}
+
+func TestProviderWhitelist_SameProviderMultipleRegions(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// Pau's "Provider1 in both EU and Asia" case: one provider listed under two regions for a chain.
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"EU":["provider0","provider1"],"AS":["provider1"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
+	require.True(t, pw.IsAllowed("ETH1", geoAS, "provider1"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoAS, "provider0")) // provider0 is EU-only
+}
+
+func TestProviderWhitelist_GLRegionMatchesAnyGeo(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// "GL" means "allowed from any region" — an escape hatch that recovers chain-only behavior.
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"GL":["provider0"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoAS, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", 0, "provider0")) // even an unset consumer geo matches GL
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
+}
+
+func TestProviderWhitelist_NamedAndNumericRegionsEquivalent(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// A region key may be the raw bitmask ("2") instead of the name ("EU"); both parse identically.
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"2":["provider0"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoAS, "provider0"))
+}
+
+func TestProviderWhitelist_CombinedRegionKeyMatchesEither(t *testing.T) {
+	pw := NewProviderWhitelist()
+	// A comma-combined region key whitelists the provider for any of the listed regions.
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"EU,AS":["provider0"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoAS, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", uint64(planstypes.Geolocation_AF), "provider0"))
+}
+
+func TestProviderWhitelist_InvalidRegionRejectedKeepsPrevious(t *testing.T) {
+	pw := NewProviderWhitelist()
+	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+
+	// "US" is not a region code (the codes are USC/USE/USW) — a hard error, last-known-good kept.
+	require.Error(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"US":["provider0"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
 func TestProviderWhitelist_EmptyListAllowsNobody(t *testing.T) {
 	pw := NewProviderWhitelist()
 	// A loaded-but-empty whitelist is "allow nobody" (intentional whitelist semantics).
-	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[]}`)))
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{}}`)))
 	require.True(t, pw.Enabled())
-	require.False(t, pw.IsAllowed("ETH1", "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
 func TestProviderWhitelist_MalformedKeepsPrevious(t *testing.T) {
 	pw := NewProviderWhitelist()
 	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 
 	// A malformed update must error and leave the last-known-good snapshot intact.
 	require.Error(t, pw.UpdateFromBytes([]byte(`{ not valid json `)))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
-func TestProviderWhitelist_MissingProvidersFieldRejected(t *testing.T) {
+func TestProviderWhitelist_MissingChainsFieldRejected(t *testing.T) {
 	pw := NewProviderWhitelist()
-	// A document without a "providers" key is not a whitelist (e.g. a spec file) and is rejected,
-	// rather than being treated as an empty (allow-nobody) whitelist.
+	// A document without a "chains" key is not a whitelist (e.g. a spec file) and is rejected, rather
+	// than being treated as an empty (allow-nobody) whitelist.
 	require.Error(t, pw.UpdateFromBytes([]byte(`{"proposal":{"specs":[]}}`)))
 	require.False(t, pw.Enabled())
 }
 
+func TestProviderWhitelist_OldSchemaRejectedLoudly(t *testing.T) {
+	oldSchema := []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)
+
+	// A single-source load of an un-migrated file errors (so the fetcher logs it), rather than
+	// silently loading nothing.
+	pw := NewProviderWhitelist()
+	require.Error(t, pw.UpdateFromBytes(oldSchema))
+	require.False(t, pw.Enabled())
+
+	// In a multi-file load it must fail the WHOLE refresh (it is NOT skipped like an unrelated file),
+	// so an old file can't quietly drop the consumer into passthrough.
+	require.Error(t, pw.UpdateFromFiles(map[string][]byte{"old.json": oldSchema}))
+}
+
 func TestProviderWhitelist_AtomicSwapReplacesList(t *testing.T) {
 	pw := NewProviderWhitelist()
-	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.False(t, pw.IsAllowed("ETH1", "provider1"))
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"EU":["provider0"]}}}`)))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
 
-	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[{"address":"provider1","chains":["ETH1"]}]}`)))
-	require.False(t, pw.IsAllowed("ETH1", "provider0"))
-	require.True(t, pw.IsAllowed("ETH1", "provider1"))
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{"ETH1":{"EU":["provider1"]}}}`)))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
 }
 
 func TestProviderWhitelist_UpdateFromFilesUnions(t *testing.T) {
 	pw := NewProviderWhitelist()
 	files := map[string][]byte{
-		"a.json": []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`),
-		"b.json": []byte(`{"providers":[{"address":"provider1","chains":["ETH1","LAV1"]}]}`),
+		"a.json": []byte(`{"chains":{"ETH1":{"EU":["provider0"]}}}`),
+		"b.json": []byte(`{"chains":{"ETH1":{"AS":["provider1"]},"LAV1":{"EU":["provider1"]}}}`),
 	}
 	require.NoError(t, pw.UpdateFromFiles(files))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.True(t, pw.IsAllowed("ETH1", "provider1"))
-	require.True(t, pw.IsAllowed("LAV1", "provider1"))
-	require.False(t, pw.IsAllowed("LAV1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoAS, "provider1"))
+	require.True(t, pw.IsAllowed("LAV1", geoEU, "provider1"))
+	// The union keeps the regions distinct: provider1 was only listed for ETH1 in AS.
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
+	require.False(t, pw.IsAllowed("LAV1", geoEU, "provider0"))
 }
 
 func TestProviderWhitelist_UpdateFromFilesSkipsNonWhitelist(t *testing.T) {
 	pw := NewProviderWhitelist()
 	files := map[string][]byte{
-		"whitelist.json": []byte(`{"providers":[{"address":"provider0","chains":["ETH1"]}]}`),
-		"spec.json":      []byte(`{"proposal":{"specs":[{"index":"ETH1"}]}}`), // valid JSON, no "providers" -> skipped
+		"whitelist.json": []byte(`{"chains":{"ETH1":{"EU":["provider0"]}}}`),
+		"spec.json":      []byte(`{"proposal":{"specs":[{"index":"ETH1"}]}}`), // valid JSON, no "chains" -> skipped
 	}
 	// Succeeds because at least one file is a valid whitelist; files that are valid JSON but aren't
 	// whitelist documents are skipped (mixed-repo support).
 	require.NoError(t, pw.UpdateFromFiles(files))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
 // TestProviderWhitelist_UpdateFromFilesMalformedKeepsPrevious pins the all-or-nothing contract for
@@ -120,17 +202,17 @@ func TestProviderWhitelist_UpdateFromFilesSkipsNonWhitelist(t *testing.T) {
 func TestProviderWhitelist_UpdateFromFilesMalformedKeepsPrevious(t *testing.T) {
 	pw := NewProviderWhitelist()
 	require.NoError(t, pw.UpdateFromBytes([]byte(sampleWhitelistJSON)))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 
 	files := map[string][]byte{
-		"good.json":    []byte(`{"providers":[{"address":"providerX","chains":["NEAR"]}]}`),
+		"good.json":    []byte(`{"chains":{"NEAR":{"AS":["providerX"]}}}`),
 		"corrupt.json": []byte(`not json at all`), // malformed -> hard failure, no swap
 	}
 	require.Error(t, pw.UpdateFromFiles(files))
 	// The previous snapshot is untouched: the good file's NEAR provider was NOT swapped in, and the
 	// original ETH1 provider is still allowed.
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.False(t, pw.IsAllowed("NEAR", "providerX"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("NEAR", geoAS, "providerX"))
 }
 
 func TestProviderWhitelist_UpdateFromFilesAllInvalidKeepsPrevious(t *testing.T) {
@@ -143,19 +225,18 @@ func TestProviderWhitelist_UpdateFromFilesAllInvalidKeepsPrevious(t *testing.T) 
 	}
 	// No file is a valid whitelist -> error, and the previous snapshot is preserved.
 	require.Error(t, pw.UpdateFromFiles(files))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
-func TestProviderWhitelist_IgnoresEmptyAddressAndChain(t *testing.T) {
+func TestProviderWhitelist_IgnoresEmptyAddressChainAndRegion(t *testing.T) {
 	pw := NewProviderWhitelist()
-	require.NoError(t, pw.UpdateFromBytes([]byte(`{"providers":[
-		{"address":"","chains":["ETH1"]},
-		{"address":"provider0","chains":["",""]},
-		{"address":"provider1","chains":["ETH1",""]}
-	]}`)))
-	// Entry with empty address contributes nothing; empty chain ids are skipped.
+	require.NoError(t, pw.UpdateFromBytes([]byte(`{"chains":{
+		"":{"EU":["provider0"]},
+		"ETH1":{"":["provider0"],"EU":["","provider1"]}
+	}}`)))
+	// Empty chain id, empty region key, and empty address all contribute nothing.
 	require.True(t, pw.Enabled())
-	require.True(t, pw.IsAllowed("ETH1", "provider1"))
-	require.False(t, pw.IsAllowed("ETH1", "provider0")) // only had empty chains
-	require.False(t, pw.IsAllowed("ETH1", ""))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider0")) // only appeared under empty chain/region
+	require.False(t, pw.IsAllowed("ETH1", geoEU, ""))
 }

--- a/protocol/rpcconsumer/provider_whitelist_fetcher.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher.go
@@ -19,23 +19,30 @@ const providerWhitelistRetryInterval = 30 * time.Second
 // ProviderWhitelistFetcher periodically loads the consumer provider whitelist from its source and
 // applies it to the shared *lavasession.ProviderWhitelist. The source is either:
 //   - a GitHub/GitLab directory URL, fetched with the exact same machinery as specs
-//     (specfetcher), authenticated with the existing github/gitlab tokens; or
+//     (specfetcher); or
 //   - a local JSON file path.
+//
+// For remote sources it authenticates with the dedicated --providers-whitelist-token when set,
+// otherwise it falls back to the shared --github-token / --gitlab-token (picked by provider),
+// matching how specs are authenticated. This lets the whitelist live in a different repo with a
+// different credential than the specs.
 //
 // A single fetcher serves all chains (the whitelist is global; each per-chain session manager
 // queries it with its own ChainID). It is only constructed/started when a source is configured,
 // so when the flag is empty no refresh loop runs at all.
 type ProviderWhitelistFetcher struct {
 	source          string
+	whitelistToken  string // dedicated token for the whitelist source; falls back to github/gitlab token when empty
 	githubToken     string
 	gitlabToken     string
 	refreshInterval time.Duration
 	target          *lavasession.ProviderWhitelist
 }
 
-func NewProviderWhitelistFetcher(source, githubToken, gitlabToken string, refreshInterval time.Duration, target *lavasession.ProviderWhitelist) *ProviderWhitelistFetcher {
+func NewProviderWhitelistFetcher(source, whitelistToken, githubToken, gitlabToken string, refreshInterval time.Duration, target *lavasession.ProviderWhitelist) *ProviderWhitelistFetcher {
 	return &ProviderWhitelistFetcher{
 		source:          source,
+		whitelistToken:  whitelistToken,
 		githubToken:     githubToken,
 		gitlabToken:     gitlabToken,
 		refreshInterval: refreshInterval,
@@ -105,15 +112,7 @@ func (f *ProviderWhitelistFetcher) loadOnce(ctx context.Context) bool {
 }
 
 func (f *ProviderWhitelistFetcher) loadFromRemote(ctx context.Context) bool {
-	// Pick the token by provider, mirroring how specs are loaded (statetracker.loadAllSpecsFromRemoteRepo).
-	token := ""
-	if specfetcher.IsGitHubURL(f.source) {
-		token = f.githubToken
-	} else if specfetcher.IsGitLabURL(f.source) {
-		token = f.gitlabToken
-	}
-
-	files, err := specfetcher.FetchAllFilesFromRemote(ctx, f.source, token)
+	files, err := specfetcher.FetchAllFilesFromRemote(ctx, f.source, f.resolveTokenForSource())
 	if err != nil {
 		utils.LavaFormatError("failed fetching provider whitelist from remote, keeping previous list", err, utils.LogAttr("source", f.source))
 		return false
@@ -123,6 +122,23 @@ func (f *ProviderWhitelistFetcher) loadFromRemote(ctx context.Context) bool {
 		return false
 	}
 	return true
+}
+
+// resolveTokenForSource returns the auth token to use for the whitelist remote fetch. The
+// dedicated --providers-whitelist-token wins when set; otherwise it falls back to the shared
+// --github-token / --gitlab-token, picked by the source's provider (mirroring how specs are
+// authenticated in statetracker.loadAllSpecsFromRemoteRepo).
+func (f *ProviderWhitelistFetcher) resolveTokenForSource() string {
+	if f.whitelistToken != "" {
+		return f.whitelistToken
+	}
+	if specfetcher.IsGitHubURL(f.source) {
+		return f.githubToken
+	}
+	if specfetcher.IsGitLabURL(f.source) {
+		return f.gitlabToken
+	}
+	return ""
 }
 
 func (f *ProviderWhitelistFetcher) loadFromFile() bool {

--- a/protocol/rpcconsumer/provider_whitelist_fetcher.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher.go
@@ -114,14 +114,28 @@ func (f *ProviderWhitelistFetcher) loadOnce(ctx context.Context) bool {
 func (f *ProviderWhitelistFetcher) loadFromRemote(ctx context.Context) bool {
 	files, err := specfetcher.FetchAllFilesFromRemote(ctx, f.source, f.resolveTokenForSource())
 	if err != nil {
-		utils.LavaFormatError("failed fetching provider whitelist from remote, keeping previous list", err, utils.LogAttr("source", f.source))
+		f.logLoadFailure("failed fetching provider whitelist from remote", err)
 		return false
 	}
 	if err := f.target.UpdateFromFiles(files); err != nil {
-		utils.LavaFormatError("failed parsing provider whitelist from remote, keeping previous list", err, utils.LogAttr("source", f.source))
+		f.logLoadFailure("failed parsing provider whitelist from remote", err)
 		return false
 	}
 	return true
+}
+
+// logLoadFailure logs a load/refresh failure with wording that reflects what the consumer actually
+// does next, which differs by lifecycle stage:
+//   - before the first successful load (startup) nothing is in place, so the consumer stays in
+//     passthrough and relays to ALL providers until a load succeeds;
+//   - after a list has loaded, the failure is non-destructive: the last-known-good snapshot is kept
+//     and keeps gating relays.
+func (f *ProviderWhitelistFetcher) logLoadFailure(msg string, err error) {
+	if f.target != nil && f.target.Enabled() {
+		utils.LavaFormatError(msg+"; keeping the last-known-good whitelist", err, utils.LogAttr("source", f.source))
+		return
+	}
+	utils.LavaFormatError(msg+"; no whitelist loaded yet, consumer is ALLOWING ALL relays (passthrough) until the first successful load", err, utils.LogAttr("source", f.source))
 }
 
 // resolveTokenForSource returns the auth token to use for the whitelist remote fetch. The
@@ -144,11 +158,11 @@ func (f *ProviderWhitelistFetcher) resolveTokenForSource() string {
 func (f *ProviderWhitelistFetcher) loadFromFile() bool {
 	content, err := os.ReadFile(f.source)
 	if err != nil {
-		utils.LavaFormatError("failed reading provider whitelist file, keeping previous list", err, utils.LogAttr("source", f.source))
+		f.logLoadFailure("failed reading provider whitelist file", err)
 		return false
 	}
 	if err := f.target.UpdateFromBytes(content); err != nil {
-		utils.LavaFormatError("failed parsing provider whitelist file, keeping previous list", err, utils.LogAttr("source", f.source))
+		f.logLoadFailure("failed parsing provider whitelist file", err)
 		return false
 	}
 	return true

--- a/protocol/rpcconsumer/provider_whitelist_fetcher.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher.go
@@ -69,24 +69,9 @@ func (f *ProviderWhitelistFetcher) Start(ctx context.Context) {
 
 	// Initial load: retry quickly until the first success so the consumer doesn't relay in
 	// passthrough for a whole refresh interval if the source is briefly unavailable at startup.
-	if !f.loadOnce(ctx) {
-		retryInterval := providerWhitelistRetryInterval
-		if f.refreshInterval > 0 && f.refreshInterval < retryInterval {
-			retryInterval = f.refreshInterval
-		}
-		retry := time.NewTicker(retryInterval)
-		defer retry.Stop()
-	initialLoad:
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-retry.C:
-				if f.loadOnce(ctx) {
-					break initialLoad
-				}
-			}
-		}
+	if !f.loadOnce(ctx) && !f.retryInitialLoad(ctx) {
+		// ctx was cancelled before the first successful load.
+		return
 	}
 
 	ticker := time.NewTicker(f.refreshInterval)
@@ -97,6 +82,29 @@ func (f *ProviderWhitelistFetcher) Start(ctx context.Context) {
 			return
 		case <-ticker.C:
 			f.loadOnce(ctx)
+		}
+	}
+}
+
+// retryInitialLoad polls the source on a short interval until the first load succeeds, returning
+// true once it does. It returns false if ctx is cancelled first. The retry ticker is scoped to this
+// function so it stops as soon as the initial load completes, rather than ticking uselessly for the
+// rest of the fetcher's lifetime.
+func (f *ProviderWhitelistFetcher) retryInitialLoad(ctx context.Context) bool {
+	retryInterval := providerWhitelistRetryInterval
+	if f.refreshInterval > 0 && f.refreshInterval < retryInterval {
+		retryInterval = f.refreshInterval
+	}
+	retry := time.NewTicker(retryInterval)
+	defer retry.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-retry.C:
+			if f.loadOnce(ctx) {
+				return true
+			}
 		}
 	}
 }

--- a/protocol/rpcconsumer/provider_whitelist_fetcher.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher.go
@@ -1,0 +1,139 @@
+package rpcconsumer
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/lavasession"
+	"github.com/lavanet/lava/v5/utils"
+	"github.com/lavanet/lava/v5/utils/specfetcher"
+)
+
+// providerWhitelistRetryInterval is the short interval used to retry the initial whitelist load
+// until it first succeeds. This avoids a long fail-open window: if the source is briefly
+// unreachable at startup, we keep retrying quickly instead of waiting a full refresh interval.
+const providerWhitelistRetryInterval = 30 * time.Second
+
+// ProviderWhitelistFetcher periodically loads the consumer provider whitelist from its source and
+// applies it to the shared *lavasession.ProviderWhitelist. The source is either:
+//   - a GitHub/GitLab directory URL, fetched with the exact same machinery as specs
+//     (specfetcher), authenticated with the existing github/gitlab tokens; or
+//   - a local JSON file path.
+//
+// A single fetcher serves all chains (the whitelist is global; each per-chain session manager
+// queries it with its own ChainID). It is only constructed/started when a source is configured,
+// so when the flag is empty no refresh loop runs at all.
+type ProviderWhitelistFetcher struct {
+	source          string
+	githubToken     string
+	gitlabToken     string
+	refreshInterval time.Duration
+	target          *lavasession.ProviderWhitelist
+}
+
+func NewProviderWhitelistFetcher(source, githubToken, gitlabToken string, refreshInterval time.Duration, target *lavasession.ProviderWhitelist) *ProviderWhitelistFetcher {
+	return &ProviderWhitelistFetcher{
+		source:          source,
+		githubToken:     githubToken,
+		gitlabToken:     gitlabToken,
+		refreshInterval: refreshInterval,
+		target:          target,
+	}
+}
+
+// Start performs an initial load (retrying on a short interval until the first success) and then
+// refreshes on refreshInterval until ctx is cancelled. Intended to run in its own goroutine.
+func (f *ProviderWhitelistFetcher) Start(ctx context.Context) {
+	if f.source == "" || f.target == nil {
+		return
+	}
+	// Defensive floor: guarantees a valid ticker interval even if this fetcher is constructed
+	// directly with a zero/negative interval (the cobra wiring already applies the same default).
+	if f.refreshInterval <= 0 {
+		f.refreshInterval = common.DefaultProvidersWhitelistRefreshInterval
+	}
+
+	utils.LavaFormatInfo("starting provider whitelist fetcher",
+		utils.LogAttr("source", f.source),
+		utils.LogAttr("refresh_interval", f.refreshInterval),
+	)
+
+	// Initial load: retry quickly until the first success so the consumer doesn't relay in
+	// passthrough for a whole refresh interval if the source is briefly unavailable at startup.
+	if !f.loadOnce(ctx) {
+		retryInterval := providerWhitelistRetryInterval
+		if f.refreshInterval > 0 && f.refreshInterval < retryInterval {
+			retryInterval = f.refreshInterval
+		}
+		retry := time.NewTicker(retryInterval)
+		defer retry.Stop()
+	initialLoad:
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-retry.C:
+				if f.loadOnce(ctx) {
+					break initialLoad
+				}
+			}
+		}
+	}
+
+	ticker := time.NewTicker(f.refreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			f.loadOnce(ctx)
+		}
+	}
+}
+
+// loadOnce fetches the whitelist from its source and applies it to the target, returning true on
+// success. On failure the previous (last-known-good) whitelist is left intact; the consumer keeps
+// using it, and if nothing has loaded yet it stays in passthrough.
+func (f *ProviderWhitelistFetcher) loadOnce(ctx context.Context) bool {
+	if specfetcher.IsRemoteRepoURL(f.source) {
+		return f.loadFromRemote(ctx)
+	}
+	return f.loadFromFile()
+}
+
+func (f *ProviderWhitelistFetcher) loadFromRemote(ctx context.Context) bool {
+	// Pick the token by provider, mirroring how specs are loaded (statetracker.loadAllSpecsFromRemoteRepo).
+	token := ""
+	if specfetcher.IsGitHubURL(f.source) {
+		token = f.githubToken
+	} else if specfetcher.IsGitLabURL(f.source) {
+		token = f.gitlabToken
+	}
+
+	files, err := specfetcher.FetchAllFilesFromRemote(ctx, f.source, token)
+	if err != nil {
+		utils.LavaFormatError("failed fetching provider whitelist from remote, keeping previous list", err, utils.LogAttr("source", f.source))
+		return false
+	}
+	if err := f.target.UpdateFromFiles(files); err != nil {
+		utils.LavaFormatError("failed parsing provider whitelist from remote, keeping previous list", err, utils.LogAttr("source", f.source))
+		return false
+	}
+	return true
+}
+
+func (f *ProviderWhitelistFetcher) loadFromFile() bool {
+	content, err := os.ReadFile(f.source)
+	if err != nil {
+		utils.LavaFormatError("failed reading provider whitelist file, keeping previous list", err, utils.LogAttr("source", f.source))
+		return false
+	}
+	if err := f.target.UpdateFromBytes(content); err != nil {
+		utils.LavaFormatError("failed parsing provider whitelist file, keeping previous list", err, utils.LogAttr("source", f.source))
+		return false
+	}
+	return true
+}

--- a/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
@@ -21,7 +21,7 @@ func writeTempWhitelist(t *testing.T, content string) string {
 func TestProviderWhitelistFetcher_LoadFromLocalFile(t *testing.T) {
 	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1","LAV1"]}]}`)
 	pw := lavasession.NewProviderWhitelist()
-	fetcher := NewProviderWhitelistFetcher(path, "", "", time.Hour, pw)
+	fetcher := NewProviderWhitelistFetcher(path, "", "", "", time.Hour, pw)
 
 	require.True(t, fetcher.loadOnce(context.Background()))
 	require.True(t, pw.Enabled())
@@ -33,7 +33,7 @@ func TestProviderWhitelistFetcher_LoadFromLocalFile(t *testing.T) {
 func TestProviderWhitelistFetcher_MalformedRefreshKeepsPrevious(t *testing.T) {
 	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)
 	pw := lavasession.NewProviderWhitelist()
-	fetcher := NewProviderWhitelistFetcher(path, "", "", time.Hour, pw)
+	fetcher := NewProviderWhitelistFetcher(path, "", "", "", time.Hour, pw)
 
 	require.True(t, fetcher.loadOnce(context.Background()))
 	require.True(t, pw.IsAllowed("ETH1", "provider0"))
@@ -46,10 +46,29 @@ func TestProviderWhitelistFetcher_MalformedRefreshKeepsPrevious(t *testing.T) {
 
 func TestProviderWhitelistFetcher_MissingFileKeepsPassthrough(t *testing.T) {
 	pw := lavasession.NewProviderWhitelist()
-	fetcher := NewProviderWhitelistFetcher(filepath.Join(t.TempDir(), "does-not-exist.json"), "", "", time.Hour, pw)
+	fetcher := NewProviderWhitelistFetcher(filepath.Join(t.TempDir(), "does-not-exist.json"), "", "", "", time.Hour, pw)
 
 	require.False(t, fetcher.loadOnce(context.Background()))
 	// Never loaded -> stays in passthrough.
 	require.False(t, pw.Enabled())
 	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelistFetcher_ResolveTokenForSource(t *testing.T) {
+	const (
+		ghURL = "https://github.com/owner/repo/tree/main/dir"
+		glURL = "https://gitlab.com/owner/repo/-/tree/main/dir"
+		local = "/tmp/whitelist.json"
+	)
+
+	// A dedicated whitelist token wins regardless of the source's provider.
+	require.Equal(t, "dedicated", NewProviderWhitelistFetcher(ghURL, "dedicated", "gh", "gl", time.Hour, nil).resolveTokenForSource())
+	require.Equal(t, "dedicated", NewProviderWhitelistFetcher(glURL, "dedicated", "gh", "gl", time.Hour, nil).resolveTokenForSource())
+
+	// With no dedicated token, fall back to the provider-specific token.
+	require.Equal(t, "gh", NewProviderWhitelistFetcher(ghURL, "", "gh", "gl", time.Hour, nil).resolveTokenForSource())
+	require.Equal(t, "gl", NewProviderWhitelistFetcher(glURL, "", "gh", "gl", time.Hour, nil).resolveTokenForSource())
+
+	// A local file source needs no token.
+	require.Equal(t, "", NewProviderWhitelistFetcher(local, "", "gh", "gl", time.Hour, nil).resolveTokenForSource())
 }

--- a/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
@@ -1,0 +1,55 @@
+package rpcconsumer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lavanet/lava/v5/protocol/lavasession"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempWhitelist(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "whitelist.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestProviderWhitelistFetcher_LoadFromLocalFile(t *testing.T) {
+	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1","LAV1"]}]}`)
+	pw := lavasession.NewProviderWhitelist()
+	fetcher := NewProviderWhitelistFetcher(path, "", "", time.Hour, pw)
+
+	require.True(t, fetcher.loadOnce(context.Background()))
+	require.True(t, pw.Enabled())
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("LAV1", "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", "provider1"))
+}
+
+func TestProviderWhitelistFetcher_MalformedRefreshKeepsPrevious(t *testing.T) {
+	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)
+	pw := lavasession.NewProviderWhitelist()
+	fetcher := NewProviderWhitelistFetcher(path, "", "", time.Hour, pw)
+
+	require.True(t, fetcher.loadOnce(context.Background()))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+
+	// Overwrite the source with malformed content; the refresh fails and keeps the last-good list.
+	require.NoError(t, os.WriteFile(path, []byte(`{ not valid json `), 0o600))
+	require.False(t, fetcher.loadOnce(context.Background()))
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}
+
+func TestProviderWhitelistFetcher_MissingFileKeepsPassthrough(t *testing.T) {
+	pw := lavasession.NewProviderWhitelist()
+	fetcher := NewProviderWhitelistFetcher(filepath.Join(t.TempDir(), "does-not-exist.json"), "", "", time.Hour, pw)
+
+	require.False(t, fetcher.loadOnce(context.Background()))
+	// Never loaded -> stays in passthrough.
+	require.False(t, pw.Enabled())
+	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+}

--- a/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
+++ b/protocol/rpcconsumer/provider_whitelist_fetcher_test.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/lavanet/lava/v5/protocol/lavasession"
+	planstypes "github.com/lavanet/lava/v5/x/plans/types"
 	"github.com/stretchr/testify/require"
 )
+
+const geoEU = uint64(planstypes.Geolocation_EU) // 2
 
 func writeTempWhitelist(t *testing.T, content string) string {
 	t.Helper()
@@ -19,29 +22,29 @@ func writeTempWhitelist(t *testing.T, content string) string {
 }
 
 func TestProviderWhitelistFetcher_LoadFromLocalFile(t *testing.T) {
-	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1","LAV1"]}]}`)
+	path := writeTempWhitelist(t, `{"chains":{"ETH1":{"EU":["provider0"]},"LAV1":{"EU":["provider0"]}}}`)
 	pw := lavasession.NewProviderWhitelist()
 	fetcher := NewProviderWhitelistFetcher(path, "", "", "", time.Hour, pw)
 
 	require.True(t, fetcher.loadOnce(context.Background()))
 	require.True(t, pw.Enabled())
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
-	require.True(t, pw.IsAllowed("LAV1", "provider0"))
-	require.False(t, pw.IsAllowed("ETH1", "provider1"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
+	require.True(t, pw.IsAllowed("LAV1", geoEU, "provider0"))
+	require.False(t, pw.IsAllowed("ETH1", geoEU, "provider1"))
 }
 
 func TestProviderWhitelistFetcher_MalformedRefreshKeepsPrevious(t *testing.T) {
-	path := writeTempWhitelist(t, `{"providers":[{"address":"provider0","chains":["ETH1"]}]}`)
+	path := writeTempWhitelist(t, `{"chains":{"ETH1":{"EU":["provider0"]}}}`)
 	pw := lavasession.NewProviderWhitelist()
 	fetcher := NewProviderWhitelistFetcher(path, "", "", "", time.Hour, pw)
 
 	require.True(t, fetcher.loadOnce(context.Background()))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 
 	// Overwrite the source with malformed content; the refresh fails and keeps the last-good list.
 	require.NoError(t, os.WriteFile(path, []byte(`{ not valid json `), 0o600))
 	require.False(t, fetcher.loadOnce(context.Background()))
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
 func TestProviderWhitelistFetcher_MissingFileKeepsPassthrough(t *testing.T) {
@@ -51,7 +54,7 @@ func TestProviderWhitelistFetcher_MissingFileKeepsPassthrough(t *testing.T) {
 	require.False(t, fetcher.loadOnce(context.Background()))
 	// Never loaded -> stays in passthrough.
 	require.False(t, pw.Enabled())
-	require.True(t, pw.IsAllowed("ETH1", "provider0"))
+	require.True(t, pw.IsAllowed("ETH1", geoEU, "provider0"))
 }
 
 func TestProviderWhitelistFetcher_ResolveTokenForSource(t *testing.T) {

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -271,7 +271,7 @@ func (rpcc *RPCConsumer) Start(ctx context.Context, options *rpcConsumerStartOpt
 			refreshInterval = common.DefaultProvidersWhitelistRefreshInterval
 		}
 		rpcc.providerWhitelist = lavasession.NewProviderWhitelist()
-		whitelistFetcher := NewProviderWhitelistFetcher(whitelistSource, options.cmdFlags.GitHubToken, options.cmdFlags.GitLabToken, refreshInterval, rpcc.providerWhitelist)
+		whitelistFetcher := NewProviderWhitelistFetcher(whitelistSource, options.cmdFlags.ProvidersWhitelistToken, options.cmdFlags.GitHubToken, options.cmdFlags.GitLabToken, refreshInterval, rpcc.providerWhitelist)
 		go whitelistFetcher.Start(ctx)
 	}
 
@@ -852,6 +852,7 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 				DebugAddress:                      viper.GetString("debug-address"),
 				ResponseCompression:               viper.GetString(common.ResponseCompressionFlag),
 				ProvidersWhitelistConfig:          viper.GetString(common.ProvidersWhitelistConfigFlag),
+				ProvidersWhitelistToken:           viper.GetString(common.ProvidersWhitelistTokenFlag),
 				ProvidersWhitelistRefreshInterval: viper.GetDuration(common.ProvidersWhitelistRefreshIntervalFlag),
 			}
 
@@ -946,6 +947,7 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 	cmdRPCConsumer.Flags().String(common.GitHubTokenFlag, "", "GitHub personal access token for accessing private repositories and higher API rate limits (5,000 requests/hour vs 60 for unauthenticated)")
 	cmdRPCConsumer.Flags().String(common.GitLabTokenFlag, "", "GitLab personal access token for accessing private repositories (supports gitlab.com and self-hosted instances)")
 	cmdRPCConsumer.Flags().String(common.ProvidersWhitelistConfigFlag, "", "provider whitelist source: a local JSON file path or a GitHub/GitLab directory URL (fetched the same way as specs). When set, the consumer relays only to whitelisted (provider, chain) pairs; empty keeps the current relay behavior. Addresses are matched exactly and must be the provider's on-chain bech32 address (e.g. lava@1...)")
+	cmdRPCConsumer.Flags().String(common.ProvidersWhitelistTokenFlag, "", "dedicated access token for a remote provider-whitelist source (use when the whitelist repo needs a different credential than the specs); falls back to --github-token / --gitlab-token when empty")
 	cmdRPCConsumer.Flags().Duration(common.ProvidersWhitelistRefreshIntervalFlag, common.DefaultProvidersWhitelistRefreshInterval, "how often to re-fetch the provider whitelist (only used when --providers-whitelist-config is set)")
 	cmdRPCConsumer.Flags().IntVar(&relaycore.RelayRetryLimit, common.SetRelayRetryLimitFlag, 2, "max total relay retry attempts across all error types (node and protocol errors combined; 0 disables retries)")
 	cmdRPCConsumer.Flags().BoolVar(&rpcInterfaceMessages.BatchNodeErrorOnAny, common.BatchNodeErrorOnAnyFlag, false, "if true, batch requests are treated as node errors if ANY sub-request fails; if false (default), only if ALL fail")

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -116,6 +116,10 @@ type AnalyticsServerAddresses struct {
 }
 type RPCConsumer struct {
 	consumerStateTracker ConsumerStateTrackerInf
+	// providerWhitelist is the shared, hourly-refreshed allowlist restricting which providers the
+	// consumer relays to. It is built once in Start when configured (nil otherwise) and injected
+	// into every per-chain ConsumerSessionManager in CreateConsumerEndpoint.
+	providerWhitelist *lavasession.ProviderWhitelist
 }
 
 type rpcConsumerStartOptions struct {
@@ -256,6 +260,21 @@ func (rpcc *RPCConsumer) Start(ctx context.Context, options *rpcConsumerStartOpt
 	consumerStateTracker.RegisterForVersionUpdates(ctx, version.Version, &upgrade.ProtocolVersion{})
 	relaysMonitorAggregator := metrics.NewRelaysMonitorAggregator(options.cmdFlags.RelaysHealthIntervalFlag, consumerMetricsManager)
 	policyUpdaters := &common.SafeSyncMap[string, *updaters.PolicyUpdater]{}
+
+	// Provider whitelist: when a source is configured, build the shared whitelist once and start
+	// its background refresher (hourly by default). It is injected into every per-chain session
+	// manager below. When the flag is empty, the whitelist stays nil (passthrough / current
+	// behavior) and no refresh loop is started at all.
+	if whitelistSource := options.cmdFlags.ProvidersWhitelistConfig; whitelistSource != "" {
+		refreshInterval := options.cmdFlags.ProvidersWhitelistRefreshInterval
+		if refreshInterval <= 0 {
+			refreshInterval = common.DefaultProvidersWhitelistRefreshInterval
+		}
+		rpcc.providerWhitelist = lavasession.NewProviderWhitelist()
+		whitelistFetcher := NewProviderWhitelistFetcher(whitelistSource, options.cmdFlags.GitHubToken, options.cmdFlags.GitLabToken, refreshInterval, rpcc.providerWhitelist)
+		go whitelistFetcher.Start(ctx)
+	}
+
 	for _, rpcEndpoint := range options.rpcEndpoints {
 		go func(rpcEndpoint *lavasession.RPCEndpoint) error {
 			defer wg.Done()
@@ -526,6 +545,8 @@ func (rpcc *RPCConsumer) CreateConsumerEndpoint(
 	// Create active subscription provider storage for each unique chain
 	activeSubscriptionProvidersStorage := lavasession.NewActiveSubscriptionProvidersStorage()
 	consumerSessionManager := lavasession.NewConsumerSessionManager(rpcEndpoint, optimizer, consumerMetricsManager, consumerAddr.String(), activeSubscriptionProvidersStorage)
+	// Inject the shared provider whitelist (nil when not configured -> passthrough).
+	consumerSessionManager.SetProviderWhitelist(rpcc.providerWhitelist)
 
 	// Set callback to get Lava blockchain block height for RelaySession.Epoch
 	consumerSessionManager.SetLavaBlockHeightCallback(func() int64 {
@@ -816,20 +837,22 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 			weightedSelectorConfig.MinSelectionChance = viper.GetFloat64(common.ProviderOptimizerMinSelectionChance)
 			weightedSelectorConfig.Strategy = strategyFlag.Strategy
 			consumerPropagatedFlags := common.ConsumerCmdFlags{
-				HeadersFlag:              viper.GetString(common.CorsHeadersFlag),
-				CredentialsFlag:          viper.GetString(common.CorsCredentialsFlag),
-				OriginFlag:               viper.GetString(common.CorsOriginFlag),
-				MethodsFlag:              viper.GetString(common.CorsMethodsFlag),
-				CDNCacheDuration:         viper.GetString(common.CDNCacheDurationFlag),
-				RelaysHealthEnableFlag:   viper.GetBool(common.RelaysHealthEnableFlag),
-				RelaysHealthIntervalFlag: viper.GetDuration(common.RelayHealthIntervalFlag),
-				DebugRelays:              viper.GetBool(DebugRelaysFlagName),
-				StaticSpecPaths:          viper.GetStringSlice(common.UseStaticSpecFlag),
-				GitHubToken:              viper.GetString(common.GitHubTokenFlag),
-				GitLabToken:              viper.GetString(common.GitLabTokenFlag),
-				EnableSelectionStats:     viper.GetBool(common.EnableSelectionStatsHeaderFlag),
-				DebugAddress:             viper.GetString("debug-address"),
-				ResponseCompression:      viper.GetString(common.ResponseCompressionFlag),
+				HeadersFlag:                       viper.GetString(common.CorsHeadersFlag),
+				CredentialsFlag:                   viper.GetString(common.CorsCredentialsFlag),
+				OriginFlag:                        viper.GetString(common.CorsOriginFlag),
+				MethodsFlag:                       viper.GetString(common.CorsMethodsFlag),
+				CDNCacheDuration:                  viper.GetString(common.CDNCacheDurationFlag),
+				RelaysHealthEnableFlag:            viper.GetBool(common.RelaysHealthEnableFlag),
+				RelaysHealthIntervalFlag:          viper.GetDuration(common.RelayHealthIntervalFlag),
+				DebugRelays:                       viper.GetBool(DebugRelaysFlagName),
+				StaticSpecPaths:                   viper.GetStringSlice(common.UseStaticSpecFlag),
+				GitHubToken:                       viper.GetString(common.GitHubTokenFlag),
+				GitLabToken:                       viper.GetString(common.GitLabTokenFlag),
+				EnableSelectionStats:              viper.GetBool(common.EnableSelectionStatsHeaderFlag),
+				DebugAddress:                      viper.GetString("debug-address"),
+				ResponseCompression:               viper.GetString(common.ResponseCompressionFlag),
+				ProvidersWhitelistConfig:          viper.GetString(common.ProvidersWhitelistConfigFlag),
+				ProvidersWhitelistRefreshInterval: viper.GetDuration(common.ProvidersWhitelistRefreshIntervalFlag),
 			}
 
 			rpcConsumerSharedState := viper.GetBool(common.SharedStateFlag)
@@ -922,6 +945,8 @@ rpcconsumer consumer_examples/full_consumer_example.yml --cache-be "127.0.0.1:77
 	cmdRPCConsumer.Flags().StringArray(common.UseStaticSpecFlag, nil, "load specs from file, directory, or remote URL (GitHub/GitLab). Can be specified multiple times; later sources override earlier ones for same chain ID")
 	cmdRPCConsumer.Flags().String(common.GitHubTokenFlag, "", "GitHub personal access token for accessing private repositories and higher API rate limits (5,000 requests/hour vs 60 for unauthenticated)")
 	cmdRPCConsumer.Flags().String(common.GitLabTokenFlag, "", "GitLab personal access token for accessing private repositories (supports gitlab.com and self-hosted instances)")
+	cmdRPCConsumer.Flags().String(common.ProvidersWhitelistConfigFlag, "", "provider whitelist source: a local JSON file path or a GitHub/GitLab directory URL (fetched the same way as specs). When set, the consumer relays only to whitelisted (provider, chain) pairs; empty keeps the current relay behavior. Addresses are matched exactly and must be the provider's on-chain bech32 address (e.g. lava@1...)")
+	cmdRPCConsumer.Flags().Duration(common.ProvidersWhitelistRefreshIntervalFlag, common.DefaultProvidersWhitelistRefreshInterval, "how often to re-fetch the provider whitelist (only used when --providers-whitelist-config is set)")
 	cmdRPCConsumer.Flags().IntVar(&relaycore.RelayRetryLimit, common.SetRelayRetryLimitFlag, 2, "max total relay retry attempts across all error types (node and protocol errors combined; 0 disables retries)")
 	cmdRPCConsumer.Flags().BoolVar(&rpcInterfaceMessages.BatchNodeErrorOnAny, common.BatchNodeErrorOnAnyFlag, false, "if true, batch requests are treated as node errors if ANY sub-request fails; if false (default), only if ALL fail")
 	cmdRPCConsumer.Flags().Float64(common.ProbeUpdateWeightFlagName, scoreutils.DefaultProbeUpdateWeight, "weight multiplier for provider-optimizer probe updates (liveness/latency); must be > 0")

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
@@ -85,6 +85,29 @@ $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer3 --chain
 
 wait_next_block
 
+# Provider whitelist: build the list from the ACTUAL staked provider addresses, since keys are
+# regenerated on every setup (a hardcoded list would exclude all providers next run). We allow
+# servicer1 and servicer3 for LAV1 and intentionally leave servicer2 out, so the consumer is seen
+# relaying only to the two whitelisted providers (servicer2 is filtered). Written to a gitignored
+# path under testutil/debugging.
+PROVIDER_WHITELIST_FILE="${__dir}/../../testutil/debugging/provider_whitelist.json"
+WHITELIST_PROVIDER_1=$(lavad keys show servicer1 -a)
+WHITELIST_PROVIDER_3=$(lavad keys show servicer3 -a)
+cat > "$PROVIDER_WHITELIST_FILE" <<EOF
+{
+  "providers": [
+    { "address": "$WHITELIST_PROVIDER_1", "chains": ["LAV1"] },
+    { "address": "$WHITELIST_PROVIDER_3", "chains": ["LAV1"] }
+  ]
+}
+EOF
+echo "[Provider Whitelist] wrote $PROVIDER_WHITELIST_FILE (allow servicer1=$WHITELIST_PROVIDER_1, servicer3=$WHITELIST_PROVIDER_3; servicer2 excluded)"
+
+#screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
+#127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
+#--providers-whitelist-config '$PROVIDER_WHITELIST_FILE' --providers-whitelist-refresh-interval 30s \
+#$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level trace --from user1 --chain-id lava --cache-be 127.0.0.1:20100 --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
+
 screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
 127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level trace --from user1 --chain-id lava --cache-be 127.0.0.1:20100 --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
@@ -109,7 +109,7 @@ echo "[Provider Whitelist] wrote $PROVIDER_WHITELIST_FILE (allow servicer1=$WHIT
 #$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level trace --from user1 --chain-id lava --cache-be 127.0.0.1:20100 --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
 
 screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
-127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
+127.0.0.1:3360 LAV1 rest I can 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
 $EXTRA_PORTAL_FLAGS --geolocation 1 --log_level trace --from user1 --chain-id lava --cache-be 127.0.0.1:20100 --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
 
 echo "--- setting up screens done ---"

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers.sh
@@ -93,12 +93,15 @@ wait_next_block
 PROVIDER_WHITELIST_FILE="${__dir}/../../testutil/debugging/provider_whitelist.json"
 WHITELIST_PROVIDER_1=$(lavad keys show servicer1 -a)
 WHITELIST_PROVIDER_3=$(lavad keys show servicer3 -a)
+# Schema is chain -> geolocation -> allowed providers. The providers and the consumer all run with
+# --geolocation 1 (USC), so servicer1/servicer3 are whitelisted under "USC".
 cat > "$PROVIDER_WHITELIST_FILE" <<EOF
 {
-  "providers": [
-    { "address": "$WHITELIST_PROVIDER_1", "chains": ["LAV1"] },
-    { "address": "$WHITELIST_PROVIDER_3", "chains": ["LAV1"] }
-  ]
+  "chains": {
+    "LAV1": {
+      "USC": ["$WHITELIST_PROVIDER_1", "$WHITELIST_PROVIDER_3"]
+    }
+  }
 }
 EOF
 echo "[Provider Whitelist] wrote $PROVIDER_WHITELIST_FILE (allow servicer1=$WHITELIST_PROVIDER_1, servicer3=$WHITELIST_PROVIDER_3; servicer2 excluded)"

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers_github.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers_github.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+. "${__dir}"/../vars/variables.sh
+
+# GitHub variant of init_lava_only_with_node_three_providers.sh: instead of pointing the consumer at
+# a local whitelist file, it publishes the per-run whitelist to a remote git repo and has the
+# consumer fetch it with --providers-whitelist-config / --providers-whitelist-token.
+#
+# Nothing repo-specific is hardcoded -- configure it entirely through these environment variables:
+#   PROVIDERS_WHITELIST_TOKEN  read-only token the CONSUMER uses to fetch the whitelist repo
+#   PROVIDERS_WHITELIST_URL    whitelist directory URL, e.g. https://github.com/<owner>/<repo>/tree/main
+#   WHITELIST_REPO_DIR         path to a local clone of that repo (the script writes + git-pushes here)
+#
+# Example:
+#   export PROVIDERS_WHITELIST_TOKEN=<read_only_token>
+#   export PROVIDERS_WHITELIST_URL=https://github.com/<owner>/<repo>/tree/main
+#   export WHITELIST_REPO_DIR=/path/to/<repo>
+#
+# Fail fast if any are missing. In particular, without the token the consumer falls back to the
+# (empty) --github-token, fetches unauthenticated, 404s on a private repo, and silently passes
+# through (allowing ALL relays) -- which looks like success. Abort before the long node spin-up.
+missing=""
+[ -z "${PROVIDERS_WHITELIST_TOKEN}" ] && missing="$missing PROVIDERS_WHITELIST_TOKEN"
+[ -z "${PROVIDERS_WHITELIST_URL}" ] && missing="$missing PROVIDERS_WHITELIST_URL"
+[ -z "${WHITELIST_REPO_DIR}" ] && missing="$missing WHITELIST_REPO_DIR"
+if [ -n "$missing" ]; then
+    echo "ERROR: set these environment variables before running:$missing" >&2
+    echo "  PROVIDERS_WHITELIST_TOKEN  read-only token the consumer uses to fetch the whitelist repo" >&2
+    echo "  PROVIDERS_WHITELIST_URL    whitelist directory URL, e.g. https://github.com/<owner>/<repo>/tree/main" >&2
+    echo "  WHITELIST_REPO_DIR         local clone of that repo (the script writes + pushes the list here)" >&2
+    exit 1
+fi
+
+LOGS_DIR=${__dir}/../../testutil/debugging/logs
+mkdir -p $LOGS_DIR
+rm $LOGS_DIR/*.log
+
+killall screen
+screen -wipe
+
+echo "[Test Setup] installing all binaries"
+make install-all
+
+echo "[Test Setup] setting up a new lava node"
+screen -d -m -S node bash -c "./scripts/start_env_dev.sh"
+screen -ls
+echo "[Test Setup] sleeping 20 seconds for node to finish setup (if its not enough increase timeout)"
+sleep 5
+wait_for_lava_node_to_start
+
+GASPRICE="0.00002ulava"
+specs=$(get_all_specs)
+lavad tx gov submit-legacy-proposal spec-add $specs --lava-dev-test -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE &
+wait_next_block
+wait_next_block
+lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+sleep 4
+
+# Plans proposal
+lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/test_plans/default.json,./cookbook/plans/test_plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
+wait_next_block
+lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+
+sleep 4
+CLIENTSTAKE="500000000000ulava"
+PROVIDERSTAKE="500000000000ulava"
+
+PROVIDER1_LISTENER="127.0.0.1:2220"
+PROVIDER2_LISTENER="127.0.0.1:2221"
+PROVIDER3_LISTENER="127.0.0.1:2222"
+
+lavad tx subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
+lavad tx pairing stake-provider "LAV1" $PROVIDERSTAKE "$PROVIDER1_LISTENER,1" 1 $(operator_address) -y --from servicer1  --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE;
+wait_next_block
+lavad tx pairing stake-provider "LAV1" $PROVIDERSTAKE "$PROVIDER2_LISTENER,1" 1 $(operator_address) -y --from servicer2  --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE;
+wait_next_block
+lavad tx pairing stake-provider "LAV1" $PROVIDERSTAKE "$PROVIDER3_LISTENER,1" 1 $(operator_address) -y --from servicer3  --provider-moniker "dummyMoniker" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE;
+
+
+sleep_until_next_epoch
+wait_next_block
+
+echo "[Chaning Epoch Storage Params] submitting param change vote"
+lavad tx gov submit-legacy-proposal param-change ./cookbook/param_changes/param_change_epoch_params.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE;
+wait_next_block
+wait_next_block
+lavad tx gov vote 3 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices 0.00002ulava;
+
+screen -d -m -S cache_consumer bash -c "source ~/.bashrc; lavap cache \
+127.0.0.1:20100 --metrics_address 0.0.0.0:20200 --log_level debug 2>&1 | tee $LOGS_DIR/CACHE_CONSUMER.log" && sleep 0.25
+sleep 2;
+
+screen -d -m -S provider1 bash -c "source ~/.bashrc; lavap rpcprovider \
+$PROVIDER1_LISTENER LAV1 rest '$LAVA_REST' \
+$PROVIDER1_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' \
+$PROVIDER1_LISTENER LAV1 grpc '$LAVA_GRPC' \
+$EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer1 --chain-id lava --metrics-listen-address ":7766" 2>&1 | tee $LOGS_DIR/PROVIDER1.log" && sleep 0.25
+
+screen -d -m -S provider2 bash -c "source ~/.bashrc; lavap rpcprovider \
+$PROVIDER2_LISTENER LAV1 rest '$LAVA_REST' \
+$PROVIDER2_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' \
+$PROVIDER2_LISTENER LAV1 grpc '$LAVA_GRPC' \
+$EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer2 --chain-id lava --metrics-listen-address ":7756" 2>&1 | tee $LOGS_DIR/PROVIDER2.log" && sleep 0.25
+
+screen -d -m -S provider3 bash -c "source ~/.bashrc; lavap rpcprovider \
+$PROVIDER3_LISTENER LAV1 rest '$LAVA_REST' \
+$PROVIDER3_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' \
+$PROVIDER3_LISTENER LAV1 grpc '$LAVA_GRPC' \
+$EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer3 --chain-id lava --metrics-listen-address ":7746" 2>&1 | tee $LOGS_DIR/PROVIDER3.log" && sleep 0.25
+
+
+wait_next_block
+
+# Provider whitelist: build the list from the ACTUAL staked provider addresses, since keys are
+# regenerated on every setup (a hardcoded list would exclude all providers next run). We allow
+# servicer1 and servicer3 for LAV1 and intentionally leave servicer2 out, so the consumer is seen
+# relaying only to the two whitelisted providers (servicer2 is filtered).
+#
+# The consumer fetches this list from the remote repo (PROVIDERS_WHITELIST_URL). Because addresses
+# change every run, we write THIS run's addresses into the local clone (WHITELIST_REPO_DIR), commit,
+# and push using your own git credentials -- NOT the read-only PROVIDERS_WHITELIST_TOKEN, which only
+# lets the consumer read. Both are supplied via environment (validated at the top of this script).
+PROVIDER_WHITELIST_FILE="${WHITELIST_REPO_DIR}/provider_whitelist.json"
+
+if [ ! -d "${WHITELIST_REPO_DIR}/.git" ]; then
+    echo "ERROR: WHITELIST_REPO_DIR ($WHITELIST_REPO_DIR) is not a git clone. Clone your whitelist repo there (the same repo PROVIDERS_WHITELIST_URL points at)." >&2
+    exit 1
+fi
+
+WHITELIST_PROVIDER_1=$(lavad keys show servicer1 -a)
+WHITELIST_PROVIDER_3=$(lavad keys show servicer3 -a)
+cat > "$PROVIDER_WHITELIST_FILE" <<EOF
+{
+  "providers": [
+    { "address": "$WHITELIST_PROVIDER_1", "chains": ["LAV1"] },
+    { "address": "$WHITELIST_PROVIDER_3", "chains": ["LAV1"] }
+  ]
+}
+EOF
+echo "[Provider Whitelist] wrote $PROVIDER_WHITELIST_FILE (allow servicer1=$WHITELIST_PROVIDER_1, servicer3=$WHITELIST_PROVIDER_3; servicer2 excluded)"
+
+# Commit & push so the consumer can fetch it. Push the clone's current branch (must match the branch
+# in PROVIDERS_WHITELIST_URL). Empty-commit guard: if addresses happen to be unchanged, `git commit`
+# errors on "nothing to commit" -- tolerate that and still push.
+WHITELIST_BRANCH=$(git -C "$WHITELIST_REPO_DIR" rev-parse --abbrev-ref HEAD)
+git -C "$WHITELIST_REPO_DIR" add provider_whitelist.json
+git -C "$WHITELIST_REPO_DIR" commit -m "test: provider whitelist for this run (servicer1, servicer3)" || echo "[Provider Whitelist] nothing to commit (addresses unchanged)"
+if ! git -C "$WHITELIST_REPO_DIR" push origin "$WHITELIST_BRANCH"; then
+    echo "ERROR: failed to push provider_whitelist.json to the whitelist repo; consumer would fetch a stale/missing list and pass through. Aborting." >&2
+    exit 1
+fi
+echo "[Provider Whitelist] pushed to $PROVIDERS_WHITELIST_URL"
+# Give GitHub's raw CDN a moment to serve the new commit before the consumer fetches it.
+sleep 3
+
+screen -d -m -S consumers bash -c "source ~/.bashrc; lavap rpcconsumer \
+127.0.0.1:3360 LAV1 rest 127.0.0.1:3361 LAV1 tendermintrpc 127.0.0.1:3362 LAV1 grpc \
+--providers-whitelist-config '$PROVIDERS_WHITELIST_URL' --providers-whitelist-token '$PROVIDERS_WHITELIST_TOKEN' --providers-whitelist-refresh-interval 30s \
+$EXTRA_PORTAL_FLAGS --geolocation 1 --log_level trace --from user1 --chain-id lava --cache-be 127.0.0.1:20100 --allow-insecure-provider-dialing --metrics-listen-address ":7779" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
+
+echo "--- setting up screens done ---"
+screen -ls
+
+echo "Provider 1 command:"
+echo "lavap rpcprovider $PROVIDER1_LISTENER LAV1 rest '$LAVA_REST' $PROVIDER1_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' $PROVIDER1_LISTENER LAV1 grpc '$LAVA_GRPC' $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer1 --chain-id lava --metrics-listen-address ':7766'"
+
+echo "Provider 2 command:"
+echo "lavap rpcprovider $PROVIDER2_LISTENER LAV1 rest '$LAVA_REST' $PROVIDER2_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' $PROVIDER2_LISTENER LAV1 grpc '$LAVA_GRPC' $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer2 --chain-id lava --metrics-listen-address ':7756'"
+
+echo "Provider 3 command:"
+echo "lavap rpcprovider $PROVIDER3_LISTENER LAV1 rest '$LAVA_REST' $PROVIDER3_LISTENER LAV1 tendermintrpc '$LAVA_RPC,$LAVA_RPC_WS' $PROVIDER3_LISTENER LAV1 grpc '$LAVA_GRPC' $EXTRA_PROVIDER_FLAGS --geolocation 1 --log_level debug --from servicer3 --chain-id lava --metrics-listen-address ':7746'"

--- a/scripts/pre_setups/init_lava_only_with_node_three_providers_github.sh
+++ b/scripts/pre_setups/init_lava_only_with_node_three_providers_github.sh
@@ -132,12 +132,15 @@ fi
 
 WHITELIST_PROVIDER_1=$(lavad keys show servicer1 -a)
 WHITELIST_PROVIDER_3=$(lavad keys show servicer3 -a)
+# Schema is chain -> geolocation -> allowed providers. The providers and the consumer below all run
+# with --geolocation 1 (USC), so servicer1/servicer3 are whitelisted under "USC".
 cat > "$PROVIDER_WHITELIST_FILE" <<EOF
 {
-  "providers": [
-    { "address": "$WHITELIST_PROVIDER_1", "chains": ["LAV1"] },
-    { "address": "$WHITELIST_PROVIDER_3", "chains": ["LAV1"] }
-  ]
+  "chains": {
+    "LAV1": {
+      "USC": ["$WHITELIST_PROVIDER_1", "$WHITELIST_PROVIDER_3"]
+    }
+  }
 }
 EOF
 echo "[Provider Whitelist] wrote $PROVIDER_WHITELIST_FILE (allow servicer1=$WHITELIST_PROVIDER_1, servicer3=$WHITELIST_PROVIDER_3; servicer2 excluded)"

--- a/utils/specfetcher/api.go
+++ b/utils/specfetcher/api.go
@@ -57,10 +57,16 @@ func FetchAllSpecsFromRemote(ctx context.Context, repoURL, token string) (map[st
 // exact same GitHub/GitLab machinery as spec fetching (URL parsing, directory listing,
 // authenticated raw download); callers parse the bytes with their own schema.
 //
+// Unlike spec fetching, this is all-or-nothing (Config.FailOnPartial): if any file fails to
+// fetch, the call returns an error and no files. The sole caller (the consumer provider
+// whitelist) replaces its snapshot wholesale, so a partial result would silently drop the
+// missing files' chains; failing instead lets the caller keep its last-known-good list.
+//
 // URL format is identical to specs, e.g. https://github.com/{owner}/{repo}/tree/{branch}/{path}
 func FetchAllFilesFromRemote(ctx context.Context, repoURL, token string) (map[string][]byte, error) {
 	config := DefaultConfig()
 	config.Token = token
+	config.FailOnPartial = true
 	fetcher := New(config)
 	return fetcher.FetchAllRawFiles(ctx, repoURL)
 }

--- a/utils/specfetcher/api.go
+++ b/utils/specfetcher/api.go
@@ -52,6 +52,19 @@ func FetchAllSpecsFromRemote(ctx context.Context, repoURL, token string) (map[st
 	return fetcher.FetchAllSpecs(ctx, repoURL)
 }
 
+// FetchAllFilesFromRemote fetches all .json files from a remote repository directory and
+// returns their raw contents keyed by source URL, without interpreting them. It uses the
+// exact same GitHub/GitLab machinery as spec fetching (URL parsing, directory listing,
+// authenticated raw download); callers parse the bytes with their own schema.
+//
+// URL format is identical to specs, e.g. https://github.com/{owner}/{repo}/tree/{branch}/{path}
+func FetchAllFilesFromRemote(ctx context.Context, repoURL, token string) (map[string][]byte, error) {
+	config := DefaultConfig()
+	config.Token = token
+	fetcher := New(config)
+	return fetcher.FetchAllRawFiles(ctx, repoURL)
+}
+
 // IsGitHubURL returns true if the URL is a GitHub repository URL.
 func IsGitHubURL(rawURL string) bool {
 	info, err := ParseRepoURL(rawURL)

--- a/utils/specfetcher/fetcher.go
+++ b/utils/specfetcher/fetcher.go
@@ -105,6 +105,21 @@ func (f *Fetcher) FetchSpec(ctx context.Context, repoURL, chainID string) (types
 
 // FetchAllSpecs fetches all specs from a remote repository.
 func (f *Fetcher) FetchAllSpecs(ctx context.Context, repoURL string) (map[string]types.Spec, error) {
+	rawFiles, err := f.FetchAllRawFiles(ctx, repoURL)
+	if err != nil {
+		return nil, err
+	}
+	return parseSpecsFromRawFiles(rawFiles)
+}
+
+// FetchAllRawFiles fetches all .json files from a remote repository directory and returns
+// their raw contents keyed by source URL, without interpreting them.
+//
+// This is the shared fetch path: specs build on it (parsing each file into types.Spec via
+// parseSpecsFromRawFiles), and other JSON configs with their own unrelated schema — such as
+// the consumer provider whitelist — reuse the exact same GitHub/GitLab machinery here and
+// parse the returned bytes themselves.
+func (f *Fetcher) FetchAllRawFiles(ctx context.Context, repoURL string) (map[string][]byte, error) {
 	info, err := ParseRepoURL(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repository URL: %w", err)
@@ -112,9 +127,9 @@ func (f *Fetcher) FetchAllSpecs(ctx context.Context, repoURL string) (map[string
 
 	switch info.Provider {
 	case ProviderGitHub:
-		return f.fetchFromGitHub(ctx, info)
+		return f.fetchRawFromGitHub(ctx, info)
 	case ProviderGitLab:
-		return f.fetchFromGitLab(ctx, info)
+		return f.fetchRawFromGitLab(ctx, info)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", info.Provider)
 	}
@@ -215,10 +230,11 @@ func containsGitLabSeparator(parts []string) bool {
 	return false
 }
 
-// fetchResult holds the result of fetching a single spec file.
+// fetchResult holds the result of fetching a single file.
 type fetchResult struct {
-	specs  map[string]types.Spec
-	errors []string
+	url     string
+	content []byte
+	errors  []string
 }
 
 // doRequest performs an HTTP request with the configured client and timeout.
@@ -235,8 +251,12 @@ func (f *Fetcher) doRequest(ctx context.Context, method, url string, setHeaders 
 	return f.config.HTTPClient.Do(req)
 }
 
-// fetchFilesParallel fetches multiple files in parallel and parses them as specs.
-func (f *Fetcher) fetchFilesParallel(ctx context.Context, fileURLs []string, setHeaders func(*http.Request)) (map[string]types.Spec, error) {
+// fetchRawFilesParallel fetches multiple files in parallel and returns their raw contents
+// keyed by source URL. It does not interpret the contents (no spec/whitelist parsing).
+//
+// Mirrors the previous spec fetch semantics: it fails only when zero files were fetched, and
+// logs a warning (rather than failing) when some files fail while others succeed.
+func (f *Fetcher) fetchRawFilesParallel(ctx context.Context, fileURLs []string, setHeaders func(*http.Request)) (map[string][]byte, error) {
 	resultChan := make(chan fetchResult, len(fileURLs))
 	semaphore := make(chan struct{}, f.config.MaxConcurrency)
 
@@ -245,7 +265,7 @@ func (f *Fetcher) fetchFilesParallel(ctx context.Context, fileURLs []string, set
 			semaphore <- struct{}{}        // acquire
 			defer func() { <-semaphore }() // release
 
-			result := fetchResult{specs: make(map[string]types.Spec)}
+			result := fetchResult{url: url}
 
 			fetchCtx, cancel := context.WithTimeout(ctx, f.config.FileFetchTimeout)
 			defer cancel()
@@ -271,44 +291,70 @@ func (f *Fetcher) fetchFilesParallel(ctx context.Context, fileURLs []string, set
 				return
 			}
 
-			var proposal specutils.SpecAddProposalJSON
-			if err := json.Unmarshal(content, &proposal); err != nil {
-				result.errors = append(result.errors, fmt.Sprintf("%s: failed to parse JSON: %v", url, err))
-				resultChan <- result
-				return
-			}
-
-			for _, spec := range proposal.Proposal.Specs {
-				result.specs[spec.Index] = spec
-			}
+			result.content = content
 			resultChan <- result
 		}(fileURL)
 	}
 
 	// Collect results
-	specs := make(map[string]types.Spec)
+	files := make(map[string][]byte)
 	var fetchErrors []string
 
 	for i := 0; i < len(fileURLs); i++ {
 		result := <-resultChan
-		for k, v := range result.specs {
-			specs[k] = v
+		if result.content != nil {
+			files[result.url] = result.content
 		}
 		fetchErrors = append(fetchErrors, result.errors...)
 	}
 
-	if len(specs) == 0 {
+	if len(files) == 0 {
 		if len(fetchErrors) > 0 {
-			return nil, fmt.Errorf("failed to fetch specs: %s", strings.Join(fetchErrors, "; "))
+			return nil, fmt.Errorf("failed to fetch files: %s", strings.Join(fetchErrors, "; "))
+		}
+		return nil, fmt.Errorf("no files found")
+	}
+
+	// Log any fetch errors (partial failures are tolerated)
+	if len(fetchErrors) > 0 {
+		utils.LavaFormatWarning("Some files failed to fetch", nil,
+			utils.LogAttr("error_count", len(fetchErrors)),
+			utils.LogAttr("errors", strings.Join(fetchErrors, "; ")))
+	}
+
+	return files, nil
+}
+
+// parseSpecsFromRawFiles interprets raw file contents (from fetchRawFilesParallel) as spec
+// add-proposals and returns the contained specs keyed by chain ID (Index). It fails only when
+// no spec could be parsed from any file, mirroring the previous fetch-and-parse behavior.
+func parseSpecsFromRawFiles(rawFiles map[string][]byte) (map[string]types.Spec, error) {
+	specs := make(map[string]types.Spec)
+	var parseErrors []string
+
+	for fileURL, content := range rawFiles {
+		var proposal specutils.SpecAddProposalJSON
+		if err := json.Unmarshal(content, &proposal); err != nil {
+			parseErrors = append(parseErrors, fmt.Sprintf("%s: failed to parse JSON: %v", fileURL, err))
+			continue
+		}
+		for _, spec := range proposal.Proposal.Specs {
+			specs[spec.Index] = spec
+		}
+	}
+
+	if len(specs) == 0 {
+		if len(parseErrors) > 0 {
+			return nil, fmt.Errorf("failed to parse specs: %s", strings.Join(parseErrors, "; "))
 		}
 		return nil, fmt.Errorf("no specs found")
 	}
 
-	// Log any fetch errors
-	if len(fetchErrors) > 0 {
-		utils.LavaFormatWarning("Some spec files failed to fetch", nil,
-			utils.LogAttr("error_count", len(fetchErrors)),
-			utils.LogAttr("errors", strings.Join(fetchErrors, "; ")))
+	// Log any parse errors (partial failures are tolerated)
+	if len(parseErrors) > 0 {
+		utils.LavaFormatWarning("Some spec files failed to parse", nil,
+			utils.LogAttr("error_count", len(parseErrors)),
+			utils.LogAttr("errors", strings.Join(parseErrors, "; ")))
 	}
 
 	// Log loaded specs

--- a/utils/specfetcher/fetcher.go
+++ b/utils/specfetcher/fetcher.go
@@ -55,6 +55,13 @@ type Config struct {
 
 	// HTTPClient allows custom HTTP client (useful for testing)
 	HTTPClient *http.Client
+
+	// FailOnPartial makes a multi-file fetch all-or-nothing: if ANY file fails to fetch, the whole
+	// fetch returns an error and no files are returned. The default (false) is the spec behavior,
+	// which tolerates partial failures (some specs beat none). Callers whose consumers replace a
+	// last-known-good snapshot wholesale — the provider whitelist — set this so a transient
+	// per-file failure can't silently drop a chain's entries from the new snapshot.
+	FailOnPartial bool
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -313,6 +320,13 @@ func (f *Fetcher) fetchRawFilesParallel(ctx context.Context, fileURLs []string, 
 			return nil, fmt.Errorf("failed to fetch files: %s", strings.Join(fetchErrors, "; "))
 		}
 		return nil, fmt.Errorf("no files found")
+	}
+
+	// In all-or-nothing mode any per-file failure fails the whole fetch, so the caller can keep its
+	// previous snapshot instead of swapping in a partial set (see Config.FailOnPartial).
+	if f.config.FailOnPartial && len(fetchErrors) > 0 {
+		return nil, fmt.Errorf("partial fetch failure (%d of %d files failed), refusing partial result: %s",
+			len(fetchErrors), len(fileURLs), strings.Join(fetchErrors, "; "))
 	}
 
 	// Log any fetch errors (partial failures are tolerated)

--- a/utils/specfetcher/github.go
+++ b/utils/specfetcher/github.go
@@ -9,15 +9,15 @@ import (
 	"strings"
 
 	"github.com/lavanet/lava/v5/utils"
-	"github.com/lavanet/lava/v5/x/spec/types"
 )
 
-// fetchFromGitHub fetches all specs from a GitHub repository.
-func (f *Fetcher) fetchFromGitHub(ctx context.Context, info *RepoInfo) (map[string]types.Spec, error) {
+// fetchRawFromGitHub fetches all .json files from a GitHub repository directory and returns
+// their raw contents keyed by source URL (no spec/whitelist interpretation).
+func (f *Fetcher) fetchRawFromGitHub(ctx context.Context, info *RepoInfo) (map[string][]byte, error) {
 	// Build the API URL for listing directory contents
 	apiURL := f.buildGitHubAPIURL(info)
 
-	utils.LavaFormatInfo("Fetching spec file list from GitHub",
+	utils.LavaFormatInfo("Fetching file list from GitHub",
 		utils.LogAttr("api_url", apiURL))
 
 	if f.config.Token != "" {
@@ -50,14 +50,14 @@ func (f *Fetcher) fetchFromGitHub(ctx context.Context, info *RepoInfo) (map[stri
 	}
 
 	if len(fileURLs) == 0 {
-		return nil, fmt.Errorf("no .json spec files found in repository")
+		return nil, fmt.Errorf("no .json files found in repository")
 	}
 
-	utils.LavaFormatInfo("Found spec files to fetch",
+	utils.LavaFormatInfo("Found files to fetch",
 		utils.LogAttr("file_count", len(fileURLs)))
 
-	// Fetch all spec files in parallel
-	return f.fetchFilesParallel(ctx, fileURLs, f.setGitHubHeaders)
+	// Fetch all files in parallel
+	return f.fetchRawFilesParallel(ctx, fileURLs, f.setGitHubHeaders)
 }
 
 // buildGitHubAPIURL constructs the GitHub API URL for listing directory contents.

--- a/utils/specfetcher/gitlab.go
+++ b/utils/specfetcher/gitlab.go
@@ -10,15 +10,15 @@ import (
 	"strings"
 
 	"github.com/lavanet/lava/v5/utils"
-	"github.com/lavanet/lava/v5/x/spec/types"
 )
 
-// fetchFromGitLab fetches all specs from a GitLab repository.
-func (f *Fetcher) fetchFromGitLab(ctx context.Context, info *RepoInfo) (map[string]types.Spec, error) {
+// fetchRawFromGitLab fetches all .json files from a GitLab repository directory and returns
+// their raw contents keyed by source URL (no spec/whitelist interpretation).
+func (f *Fetcher) fetchRawFromGitLab(ctx context.Context, info *RepoInfo) (map[string][]byte, error) {
 	// Build the API URL for listing directory contents
 	apiURL := f.buildGitLabTreeAPIURL(info)
 
-	utils.LavaFormatInfo("Fetching spec file list from GitLab",
+	utils.LavaFormatInfo("Fetching file list from GitLab",
 		utils.LogAttr("api_url", apiURL))
 
 	if f.config.Token != "" {
@@ -51,14 +51,14 @@ func (f *Fetcher) fetchFromGitLab(ctx context.Context, info *RepoInfo) (map[stri
 	}
 
 	if len(fileURLs) == 0 {
-		return nil, fmt.Errorf("no .json spec files found in repository")
+		return nil, fmt.Errorf("no .json files found in repository")
 	}
 
-	utils.LavaFormatInfo("Found spec files to fetch",
+	utils.LavaFormatInfo("Found files to fetch",
 		utils.LogAttr("file_count", len(fileURLs)))
 
-	// Fetch all spec files in parallel
-	return f.fetchFilesParallel(ctx, fileURLs, f.setGitLabHeaders)
+	// Fetch all files in parallel
+	return f.fetchRawFilesParallel(ctx, fileURLs, f.setGitLabHeaders)
 }
 
 // buildGitLabTreeAPIURL constructs the GitLab API URL for listing directory contents.

--- a/utils/specfetcher/raw_fetch_test.go
+++ b/utils/specfetcher/raw_fetch_test.go
@@ -57,6 +57,35 @@ func TestFetchAllRawFiles_GitHub(t *testing.T) {
 	require.True(t, gotBodies[bBody])
 }
 
+// TestFetchAllRawFiles_PartialFailureTolerantVsStrict pins the two opposite contracts that share
+// this fetch path. The directory lists two files but only a.json is served (b.json -> 404), so the
+// fetch is partial. FetchAllRawFiles (spec default) tolerates it and returns the one file that
+// succeeded; the strict mode used by the whitelist (Config.FailOnPartial) instead fails the whole
+// fetch so the caller can keep its last-known-good snapshot rather than swap in a partial set.
+func TestFetchAllRawFiles_PartialFailureTolerantVsStrict(t *testing.T) {
+	const repoURL = "https://github.com/owner/repo/tree/main/dir"
+	listing := `[{"name":"a.json","type":"file"},{"name":"b.json","type":"file"}]`
+	aBody := `{"providers":[{"address":"provider0","chains":["ETH1"]}]}`
+	responses := map[string]string{
+		"https://api.github.com/repos/owner/repo/contents/dir?ref=main": listing,
+		"https://raw.githubusercontent.com/owner/repo/main/dir/a.json":  aBody,
+		// b.json is intentionally absent -> the mock returns 404 for it (a per-file fetch failure).
+	}
+
+	// Tolerant (spec default): partial failure still returns the files that succeeded.
+	tolerant := newMockFetcher(responses)
+	files, err := tolerant.FetchAllRawFiles(context.Background(), repoURL)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	// Strict (whitelist): any per-file failure fails the whole fetch.
+	strictConfig := Config{HTTPClient: &http.Client{Transport: &mockRoundTripper{responses: responses}}, FailOnPartial: true}
+	strict := New(strictConfig)
+	_, err = strict.FetchAllRawFiles(context.Background(), repoURL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "partial fetch failure")
+}
+
 // TestFetchAllSpecs_GitHubStillWorks guards the behavior-preserving refactor: FetchAllSpecs now
 // layers on FetchAllRawFiles, and must still parse the fetched files into specs keyed by index.
 func TestFetchAllSpecs_GitHubStillWorks(t *testing.T) {

--- a/utils/specfetcher/raw_fetch_test.go
+++ b/utils/specfetcher/raw_fetch_test.go
@@ -1,0 +1,73 @@
+package specfetcher
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockRoundTripper serves canned responses keyed by exact request URL, so the GitHub fetch path
+// can be exercised end-to-end without network access (via Config.HTTPClient).
+type mockRoundTripper struct {
+	responses map[string]string
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, ok := m.responses[req.URL.String()]
+	status := http.StatusOK
+	if !ok {
+		body, status = "not found", http.StatusNotFound
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newMockFetcher(responses map[string]string) *Fetcher {
+	return New(Config{HTTPClient: &http.Client{Transport: &mockRoundTripper{responses: responses}}})
+}
+
+// TestFetchAllRawFiles_GitHub verifies the shared raw-fetch path: list a directory via the
+// contents API and download each .json file's raw bytes, ignoring non-json and directories.
+func TestFetchAllRawFiles_GitHub(t *testing.T) {
+	listing := `[{"name":"a.json","type":"file"},{"name":"b.json","type":"file"},{"name":"readme.md","type":"file"},{"name":"sub","type":"dir"}]`
+	aBody := `{"providers":[{"address":"provider0","chains":["ETH1"]}]}`
+	bBody := `{"anything":"goes"}`
+	f := newMockFetcher(map[string]string{
+		"https://api.github.com/repos/owner/repo/contents/dir?ref=main": listing,
+		"https://raw.githubusercontent.com/owner/repo/main/dir/a.json":  aBody,
+		"https://raw.githubusercontent.com/owner/repo/main/dir/b.json":  bBody,
+	})
+
+	files, err := f.FetchAllRawFiles(context.Background(), "https://github.com/owner/repo/tree/main/dir")
+	require.NoError(t, err)
+	require.Len(t, files, 2) // only the two .json files of type "file"
+
+	gotBodies := map[string]bool{}
+	for _, content := range files {
+		gotBodies[string(content)] = true
+	}
+	require.True(t, gotBodies[aBody])
+	require.True(t, gotBodies[bBody])
+}
+
+// TestFetchAllSpecs_GitHubStillWorks guards the behavior-preserving refactor: FetchAllSpecs now
+// layers on FetchAllRawFiles, and must still parse the fetched files into specs keyed by index.
+func TestFetchAllSpecs_GitHubStillWorks(t *testing.T) {
+	listing := `[{"name":"eth.json","type":"file"}]`
+	specBody := `{"proposal":{"specs":[{"index":"ETH1"}]}}`
+	f := newMockFetcher(map[string]string{
+		"https://api.github.com/repos/owner/repo/contents/dir?ref=main":  listing,
+		"https://raw.githubusercontent.com/owner/repo/main/dir/eth.json": specBody,
+	})
+
+	specs, err := f.FetchAllSpecs(context.Background(), "https://github.com/owner/repo/tree/main/dir")
+	require.NoError(t, err)
+	require.Contains(t, specs, "ETH1")
+}


### PR DESCRIPTION
## Summary

Adds an operator-controlled **provider whitelist** to `rpcconsumer` that restricts which providers the consumer is willing to relay to, keyed by `(provider, chain, geolocation)`.

- **List present (configured + loaded):** the consumer relays **only** to whitelisted providers for its chain **and its own region** (`--geolocation`).
- **List absent (flag empty, or not yet loaded):** the consumer keeps its **current relay behavior** (relay to any paired provider).

The list is a JSON document, refreshed **hourly** (interval configurable) in the background, sourced from **GitHub/GitLab or a local file**. When the flag is empty, no refresh loop runs at all.

### Why geolocation (MAG-1987)

The Cosmos pilot needs per-region control — *"1 spec per geolocation and per chain"* — so a top-performing provider can be whitelisted for one region (e.g. EU) and blocked from others. Because Lava's on-chain geolocation pairing filter is disabled, a consumer's pairing already spans all regions; this client-side filter is what pins each per-region gateway to its chosen providers.

## Configuration

```
--providers-whitelist-config            local JSON file path OR a GitHub/GitLab directory URL
--providers-whitelist-refresh-interval  default 1h
--providers-whitelist-token             dedicated token for a remote source in a different repo;
                                         falls back to --github-token / --gitlab-token when empty
```

GitHub/GitLab fetching reuses the **exact same machinery as specs** (URL parsing, contents-API directory listing, authenticated raw download, timeouts). A remote source lists **one directory** and loads only the **top-level `.json` files** in it (subdirectories and non-json files ignored); their `chains` maps are unioned.

### JSON schema

Keyed **chain → geolocation → providers**:

```json
{
  "chains": {
    "ETH1": { "EU": ["lava@1abc...", "lava@1def..."], "AS": ["lava@1ghi...", "lava@1abc..."] },
    "LAV1": { "EU": ["lava@1abc..."] }
  }
}
```

Region keys are the on-chain codes parsed by `planstypes.ParseGeoEnum`: a name (`EU`, `AS`, `AF`, `AU`, `USC`/`USE`/`USW`), a raw bitmask (`2`), a comma-combined set (`EU,AS`), or `GL` (any region). Addresses are matched exactly (on-chain bech32). The same provider may appear under multiple regions.

## Geolocation matching

Each per-chain CSM queries the whitelist with its own `ChainID` **and the consumer's `--geolocation`**. A `GL` bucket matches any region; otherwise the consumer's geolocation must overlap the region bitmask (which reduces to equality for a single-region gateway). This is a **per-region-gateway** model — production runs one consumer per region (e.g. EU = `--geolocation 2`), each relaying only to the providers listed for its region.

## Design notes

- **`ProviderWhitelist`** (`lavasession`): immutable index (`chain → geo → provider set`) behind an `atomic.Pointer`, so the per-relay `IsAllowed` hot path is lock-free; the hourly refresh swaps the pointer atomically. Passthrough until the first successful load.
- **Selection paths guarded (4):** optimizer, header-select, and sticky session (all via the single `validAddresses` filter), plus blocked-provider recovery (per-candidate guard — the list refreshes on its own clock, so a provider whitelisted when blocked can be de-listed before recovery). *Note: the emergency backup-provider fallback is not whitelist-filtered.*
- Filtering is applied at the **selection call site**, not inside `CalculateAddonValidAddresses`, so an empty intersection degrades to a clean `PairingListEmptyError` rather than triggering `validAddresses` reset loops (covered by a regression test).
- **specfetcher refactor** is behavior-preserving: `FetchAllSpecs` layers on `FetchAllRawFiles`; existing spec behavior is unchanged.
- **Token resolution:** `--providers-whitelist-token` wins when set; otherwise falls back to `--github-token` / `--gitlab-token` by provider (testable `resolveTokenForSource`).
- **Fail-closed semantics:** startup fetch failure retries on a short interval until the first success; transient/malformed refreshes keep the last-known-good list; an empty (but loaded) list is logged loudly and relays to nobody.
- **Old-schema rejection:** an old top-level `{"providers":[...]}` file is now rejected with a **hard error** (not silently skipped), so an un-migrated file can't drop the consumer into passthrough.

## Migration

The schema changed from `{"providers":[...]}` (chain-only) to `{"chains":{...}}` (chain → geolocation → providers). Old-format files are rejected loudly — the whitelist file must be converted to the new structure and rolled out **together** with this build.

## Scope

`rpcconsumer` only. `rpcsmartrouter` shares the selection code but is injected no whitelist, so it stays in current behavior.

## Docs

`docs/provider-whitelist.md` covers purpose, flags, JSON schema, region codes, the per-region-gateway model, repo layout, GitHub-like-specs fetching, the guarded selection paths, migration, and fail modes.

## Testing

- **Value type:** parse/empty/malformed, hit/miss, per-chain **and per-geolocation** isolation, same-provider-in-multiple-regions, `GL` wildcard, named-vs-numeric region keys, invalid-region rejection, old-schema rejection, union + skip non-conforming across files.
- **CSM filter:** exclusion across the guarded selection paths, filter-by-consumer-geolocation, a `GetSessions` end-to-end test, and an empty-intersection "no reset storm" regression test.
- **Fetcher:** local-file load, last-known-good on malformed refresh, passthrough when the source is missing, and token resolution.
- **specfetcher:** `FetchAllRawFiles` over a mocked GitHub API, and a spec-path parity test.
- `go build ./...`, `go vet`, gofmt, and the `lavasession` / `rpcconsumer` / `specfetcher` suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
