### PR TITLE
fix(app): raise gov MaxMetadataLen for the spec-add test proposal

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -645,7 +645,7 @@ func New(
 	// If evidence needs to be handled for the app, set routes in router here and seal
 	app.EvidenceKeeper = *evidenceKeeper
 
-	govConfig := govtypes.Config{MaxMetadataLen: 4000} // 1640 TODO fix it from spec test proposal
+	govConfig := govtypes.Config{MaxMetadataLen: 100000} // raised to fit the all-specs spec-add test proposal (~5.7KB)
 	govKeeper := govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.AccountKeeper, app.BankKeeper,
 		app.StakingKeeper, app.MsgServiceRouter(), govConfig,


### PR DESCRIPTION
## Summary

`app/app.go` capped gov proposal metadata at `MaxMetadataLen: 4000` — and that line literally carried `// 1640 TODO fix it from spec test proposal`. The `specs/` set has grown since, so the all-specs `spec-add` governance proposal used by the local dev-setup scripts (e.g. `scripts/pre_setups/init_lava_only_with_node_three_providers.sh`) now needs ~5683 bytes of metadata and fails to submit with `metadata too long: 5683`. The result: the chain spec never registers, which in turn blocks provider/consumer startup in those local setups.

This raises the cap to `100000`.

## Change
```go
-govConfig := govtypes.Config{MaxMetadataLen: 4000} // 1640 TODO fix it from spec test proposal
+govConfig := govtypes.Config{MaxMetadataLen: 100000} // raised to fit the all-specs spec-add test proposal (~5.7KB)
```

## Verification
With this change, `make install-all` + `scripts/pre_setups/init_lava_only_with_node_three_providers.sh` brings the chain up cleanly: the LAV1 spec registers, 3 providers stake, the subscription activates, and the consumer serves relays end-to-end (REST relays return live blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
