### PR TITLE
fix(provider): log batch request hash-skip at debug level

### DIFF
--- a/protocol/rpcprovider/provider_state_machine.go
+++ b/protocol/rpcprovider/provider_state_machine.go
@@ -44,11 +44,14 @@ func NewProviderStateMachine(chainId string, relayRetriesManager lavaprotocol.Re
 func (psm *ProviderStateMachine) SendNodeMessage(ctx context.Context, chainMsg chainlib.ChainMessage, request *pairingtypes.RelayRequest) (*chainlib.RelayReplyWrapper, time.Duration, error) {
 	hash, hashErr := chainMsg.GetRawRequestHash()
 	requestHashString := ""
-	// Batch requests intentionally return WontCalculateBatchHash - this is expected, not a warning.
-	// Only log warning for unexpected hash failures on single requests.
+	// Batch requests intentionally return WontCalculateBatchHash - this is expected, not a failure.
+	// Log it at debug level so it stays discoverable when diagnosing retry behavior without adding
+	// production noise; only log a warning for unexpected hash failures on single requests.
 	isBatchRequest := errors.Is(hashErr, rpcInterfaceMessages.WontCalculateBatchHash)
 	if hashErr != nil && !isBatchRequest {
 		utils.LavaFormatWarning("Failed converting message to hash", hashErr, utils.LogAttr("url", request.RelayData.ApiUrl), utils.LogAttr("data", string(request.RelayData.Data)))
+	} else if isBatchRequest {
+		utils.LavaFormatDebug("batch request: skipping hash-based retry (expected for JSON-RPC batches)", utils.LogAttr("url", request.RelayData.ApiUrl), utils.LogAttr("data", string(request.RelayData.Data)))
 	} else if hashErr == nil {
 		requestHashString = string(hash)
 	}


### PR DESCRIPTION
## What

JSON-RPC **batch** requests intentionally return `WontCalculateBatchHash` from `GetRawRequestHash()`, so they skip the hash-based node-error retry path on the provider. This logs that case at **debug** level in `protocol/rpcprovider/provider_state_machine.go`.

## Why

The batch hash-skip has bounced between two extremes:
- Originally (#1660) it logged a **warning** (`"Failed converting message to hash"`) — misleading noise that looks like a failure when it's actually expected behavior.
- It was then **suppressed entirely** (#2195) — quiet, but the signal is gone when diagnosing why a batch wasn't retried.

`debug` is the middle ground: discoverable when investigating batch retry behavior, invisible in normal production logs. This also matches the consumer side, which already handles the same case quietly (`relay_processor.go`).

## Scope

- **Logging only.** No change to retry behavior — batches still skip retries by design (provider returns after the first attempt; consumer gates in `relaypolicy/policy.go` via `IsBatch && DisableBatchRetry` and `HashErr != nil`).
- The `warn` for genuine single-request hash failures is unchanged.

```go
} else if isBatchRequest {
    utils.LavaFormatDebug("batch request: skipping hash-based retry (expected for JSON-RPC batches)", ...)
}
```

## Verification

- `go build ./protocol/... ./cmd/...` ✓
- `gofmt` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
