### PR TITLE
feat(consumer): per-chain latency cutoff for random provider selection

### DIFF
--- a/config/eth_latency_cutoff_consumer.yml
+++ b/config/eth_latency_cutoff_consumer.yml
@@ -1,0 +1,9 @@
+# Consumer config for the per-chain latency-cutoff E2E setup.
+# Providers whose measured QoS latency exceeds max-provider-latency (seconds) are
+# put aside during the general random selection. 0 / omitted disables the cutoff.
+# Used by scripts/pre_setups/init_eth_latency_cutoff.sh (cutoff mode).
+endpoints:
+  - chain-id: ETH1
+    api-interface: jsonrpc
+    network-address: 127.0.0.1:3333
+    max-provider-latency: 1.0

--- a/config/eth_latency_cutoff_consumer_disabled.yml
+++ b/config/eth_latency_cutoff_consumer_disabled.yml
@@ -1,0 +1,9 @@
+# Consumer config for the per-chain latency-cutoff E2E setup, cutoff DISABLED.
+# max-provider-latency: 0 turns the feature off (no provider is put aside) - used by the
+# regression-disabled mode to prove default behaviour is unchanged.
+# See eth_latency_cutoff_consumer.yml for the enabled (1.0) variant.
+endpoints:
+  - chain-id: ETH1
+    api-interface: jsonrpc
+    network-address: 127.0.0.1:3333
+    max-provider-latency: 0

--- a/config/rpcconsumer.yml
+++ b/config/rpcconsumer.yml
@@ -17,3 +17,4 @@ endpoints:
     - chain-id: ETH1
       api-interface: jsonrpc
       network-address: 127.0.0.1:3333
+      # max-provider-latency: 1.0  # optional, seconds; put aside providers slower than this during random selection (0/omitted = disabled)

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1153,7 +1153,7 @@ func (csm *ConsumerSessionManager) filterHighLatencyProviders(ctx context.Contex
 		// safety fallback: every candidate is over the cutoff - keep the full pool
 		utils.LavaFormatDebug("latency cutoff skipped, all providers above threshold",
 			utils.LogAttr("maxProviderLatency", maxLatency),
-			utils.LogAttr("filteredCount", len(slowProviders)),
+			utils.LogAttr("slowProviders", slowProviders),
 			utils.LogAttr("chainId", csm.rpcEndpoint.ChainID),
 			utils.LogAttr("GUID", ctx),
 		)
@@ -1167,7 +1167,7 @@ func (csm *ConsumerSessionManager) filterHighLatencyProviders(ctx context.Contex
 	if len(slowProviders) > 0 {
 		utils.LavaFormatTrace("latency cutoff applied",
 			utils.LogAttr("maxProviderLatency", maxLatency),
-			utils.LogAttr("filtered", slowProviders),
+			utils.LogAttr("slowProviders", slowProviders),
 			utils.LogAttr("chainId", csm.rpcEndpoint.ChainID),
 			utils.LogAttr("GUID", ctx),
 		)

--- a/protocol/lavasession/consumer_session_manager.go
+++ b/protocol/lavasession/consumer_session_manager.go
@@ -1032,6 +1032,9 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		for k, v := range ignoredProvidersList {
 			ignoredProvidersListCopy[k] = v
 		}
+		// Put aside providers whose QoS latency exceeds the per-chain cutoff (general random selection only).
+		// Rides on the ignored-providers set so the optimizer never picks them.
+		csm.filterHighLatencyProviders(ctx, validAddresses, ignoredProvidersListCopy)
 		for i := 0; i < wantedProviders; i++ {
 			provider, selectionStats := csm.providerOptimizer.ChooseProviderWithStats(ctx, validAddresses, ignoredProvidersListCopy, cu, requestedBlock)
 			if len(provider) == 0 {
@@ -1105,6 +1108,70 @@ func (csm *ConsumerSessionManager) getValidProviderAddresses(ctx context.Context
 		return []string{providers[0]}, nil
 	}
 	return providers, nil
+}
+
+// filterHighLatencyProviders puts aside providers whose QoS latency exceeds the per-chain cutoff
+// (rpcEndpoint.MaxProviderLatency, in seconds) by adding them to the ignored-providers set, so the
+// optimizer never picks them during the general random selection.
+//
+// Safety fallback: the cutoff is applied only if at least one candidate stays under the threshold.
+// If every candidate is over the threshold (or has no QoS data yet), nothing is filtered and the
+// full pool is kept, so relays keep flowing even when the whole pairing is slow.
+func (csm *ConsumerSessionManager) filterHighLatencyProviders(ctx context.Context, validAddresses []string, ignoredProvidersList map[string]struct{}) {
+	maxLatency := csm.rpcEndpoint.MaxProviderLatency
+	if maxLatency <= 0 {
+		// cutoff disabled
+		return
+	}
+
+	slowProviders := make(map[string]struct{})
+	remaining := 0
+	for _, providerAddress := range validAddresses {
+		if _, ok := ignoredProvidersList[providerAddress]; ok {
+			continue
+		}
+		qos, _ := csm.providerOptimizer.GetReputationReportForProvider(providerAddress)
+		if qos == nil {
+			// no QoS data yet (cold start) - treat as under threshold, do not filter
+			remaining++
+			continue
+		}
+		latency, err := qos.Latency.Float64()
+		if err != nil {
+			// cannot resolve latency - do not filter on a value we can't read
+			remaining++
+			continue
+		}
+		if latency > maxLatency {
+			slowProviders[providerAddress] = struct{}{}
+			continue
+		}
+		remaining++
+	}
+
+	if remaining == 0 {
+		// safety fallback: every candidate is over the cutoff - keep the full pool
+		utils.LavaFormatDebug("latency cutoff skipped, all providers above threshold",
+			utils.LogAttr("maxProviderLatency", maxLatency),
+			utils.LogAttr("filteredCount", len(slowProviders)),
+			utils.LogAttr("chainId", csm.rpcEndpoint.ChainID),
+			utils.LogAttr("GUID", ctx),
+		)
+		return
+	}
+
+	for providerAddress := range slowProviders {
+		ignoredProvidersList[providerAddress] = struct{}{}
+	}
+
+	if len(slowProviders) > 0 {
+		utils.LavaFormatTrace("latency cutoff applied",
+			utils.LogAttr("maxProviderLatency", maxLatency),
+			utils.LogAttr("filtered", slowProviders),
+			utils.LogAttr("chainId", csm.rpcEndpoint.ChainID),
+			utils.LogAttr("GUID", ctx),
+		)
+	}
 }
 
 // On cases where the valid provider list is empty, by being already used in this attempt, and we got to a point

--- a/protocol/lavasession/consumer_session_manager_latency_filter_test.go
+++ b/protocol/lavasession/consumer_session_manager_latency_filter_test.go
@@ -1,0 +1,229 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/lavanet/lava/v5/protocol/provideroptimizer"
+	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLatencyOptimizer is a minimal ProviderOptimizer used to drive
+// filterHighLatencyProviders with controlled per-provider QoS latency.
+// Only GetReputationReportForProvider carries meaningful behavior; the rest
+// of the interface is stubbed out as it is not exercised by the filter.
+type stubLatencyOptimizer struct {
+	reports map[string]*pairingtypes.QualityOfServiceReport
+}
+
+func (s *stubLatencyOptimizer) GetReputationReportForProvider(address string) (*pairingtypes.QualityOfServiceReport, time.Time) {
+	return s.reports[address], time.Time{}
+}
+
+func (s *stubLatencyOptimizer) AppendProbeRelayData(providerAddress string, latency time.Duration, success bool) {
+}
+func (s *stubLatencyOptimizer) AppendRelayFailure(providerAddress string) {}
+func (s *stubLatencyOptimizer) AppendRelayData(providerAddress string, latency time.Duration, cu, syncBlock uint64) {
+}
+
+func (s *stubLatencyOptimizer) ChooseProvider(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []string {
+	return nil
+}
+
+func (s *stubLatencyOptimizer) ChooseProviderWithStats(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) ([]string, *provideroptimizer.SelectionStats) {
+	return nil, nil
+}
+
+func (s *stubLatencyOptimizer) ChooseBestProvider(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []string {
+	return nil
+}
+
+func (s *stubLatencyOptimizer) ChooseBestProviderWithStats(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) ([]string, *provideroptimizer.SelectionStats) {
+	return nil, nil
+}
+
+func (s *stubLatencyOptimizer) Strategy() provideroptimizer.Strategy {
+	return provideroptimizer.StrategyBalanced
+}
+func (s *stubLatencyOptimizer) UpdateWeights(map[string]int64, uint64) {}
+
+// qosWithLatency builds a QoS report with the given latency (in seconds) and
+// neutral availability/sync, which is all filterHighLatencyProviders reads.
+func qosWithLatency(latencySeconds string) *pairingtypes.QualityOfServiceReport {
+	return &pairingtypes.QualityOfServiceReport{
+		Latency:      sdk.MustNewDecFromStr(latencySeconds),
+		Availability: sdk.OneDec(),
+		Sync:         sdk.OneDec(),
+	}
+}
+
+// newLatencyFilterCSM returns a ConsumerSessionManager wired with a stub
+// optimizer and the given per-chain latency cutoff.
+func newLatencyFilterCSM(maxLatency float64, reports map[string]*pairingtypes.QualityOfServiceReport) *ConsumerSessionManager {
+	return &ConsumerSessionManager{
+		rpcEndpoint:       &RPCEndpoint{ChainID: "test", ApiInterface: "jsonrpc", MaxProviderLatency: maxLatency},
+		providerOptimizer: &stubLatencyOptimizer{reports: reports},
+	}
+}
+
+func TestFilterHighLatencyProviders_ExcludesSlow(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"fast", "slow"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"fast": qosWithLatency("0.5"),
+		"slow": qosWithLatency("1.5"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	_, slowIgnored := ignored["slow"]
+	_, fastIgnored := ignored["fast"]
+	require.True(t, slowIgnored, "provider above cutoff should be put aside")
+	require.False(t, fastIgnored, "provider below cutoff should remain selectable")
+}
+
+func TestFilterHighLatencyProviders_KeepsAllFast(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"a", "b"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"a": qosWithLatency("0.2"),
+		"b": qosWithLatency("0.99"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	require.Empty(t, ignored, "no provider above cutoff should be filtered")
+}
+
+func TestFilterHighLatencyProviders_FallbackWhenAllSlow(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"x", "y"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"x": qosWithLatency("2.0"),
+		"y": qosWithLatency("3.0"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	require.Empty(t, ignored, "safety fallback should keep the full pool when every provider is above the cutoff")
+}
+
+func TestFilterHighLatencyProviders_Disabled(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"slow"}
+	csm := newLatencyFilterCSM(0, map[string]*pairingtypes.QualityOfServiceReport{
+		"slow": qosWithLatency("5.0"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	require.Empty(t, ignored, "cutoff of 0 must disable filtering")
+}
+
+func TestFilterHighLatencyProviders_ColdStartNotFiltered(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"known", "coldstart"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"known": qosWithLatency("0.5"),
+		// "coldstart" has no QoS report -> GetReputationReportForProvider returns nil
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	require.Empty(t, ignored, "providers with no QoS data must be treated as under threshold")
+}
+
+func TestFilterHighLatencyProviders_PreservesExistingIgnored(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"fast", "slow", "alreadyIgnored"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"fast":           qosWithLatency("0.3"),
+		"slow":           qosWithLatency("2.0"),
+		"alreadyIgnored": qosWithLatency("0.1"),
+	})
+
+	ignored := map[string]struct{}{"alreadyIgnored": {}}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	_, alreadyIgnored := ignored["alreadyIgnored"]
+	_, slowIgnored := ignored["slow"]
+	require.True(t, alreadyIgnored, "pre-existing ignored providers must remain ignored")
+	require.True(t, slowIgnored, "slow provider should be added on top of existing ignored set")
+	require.Len(t, ignored, 2)
+}
+
+// Test 6: latency exactly equal to the cutoff is NOT filtered (comparison is strict ">").
+func TestFilterHighLatencyProviders_ThresholdBoundaryExclusiveGreater(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"exact", "justOver"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"exact":    qosWithLatency("1.0"),   // == cutoff -> kept
+		"justOver": qosWithLatency("1.001"), // > cutoff -> filtered
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	_, exactIgnored := ignored["exact"]
+	_, justOverIgnored := ignored["justOver"]
+	require.False(t, exactIgnored, "latency equal to the cutoff must not be filtered (strict >)")
+	require.True(t, justOverIgnored, "latency just above the cutoff must be filtered")
+}
+
+// Test 7: with several providers, EVERY slow one is put aside while all fast ones remain,
+// so a multi-provider batch can be filled exclusively from fast providers.
+func TestFilterHighLatencyProviders_MultipleProvidersFiltersAllSlow(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"fast1", "slow1", "fast2", "slow2", "fast3"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		"fast1": qosWithLatency("0.10"),
+		"slow1": qosWithLatency("1.50"),
+		"fast2": qosWithLatency("0.40"),
+		"slow2": qosWithLatency("2.20"),
+		"fast3": qosWithLatency("0.90"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	require.Len(t, ignored, 2, "both slow providers should be filtered")
+	for _, slow := range []string{"slow1", "slow2"} {
+		_, ok := ignored[slow]
+		require.True(t, ok, "slow provider %s should be filtered", slow)
+	}
+	for _, fast := range []string{"fast1", "fast2", "fast3"} {
+		_, ok := ignored[fast]
+		require.False(t, ok, "fast provider %s should remain selectable", fast)
+	}
+}
+
+// Test 8: mixed cold-start + slow + fast. The cold-start (no QoS) and fast providers
+// count as "remaining", so the fallback does NOT trigger and the slow one is filtered.
+func TestFilterHighLatencyProviders_MixedColdStartSlowFast(t *testing.T) {
+	ctx := context.Background()
+	validAddresses := []string{"coldstart", "slow", "fast"}
+	csm := newLatencyFilterCSM(1.0, map[string]*pairingtypes.QualityOfServiceReport{
+		// "coldstart" has no QoS report -> treated as under threshold
+		"slow": qosWithLatency("2.0"),
+		"fast": qosWithLatency("0.3"),
+	})
+
+	ignored := map[string]struct{}{}
+	csm.filterHighLatencyProviders(ctx, validAddresses, ignored)
+
+	_, slowIgnored := ignored["slow"]
+	_, coldIgnored := ignored["coldstart"]
+	_, fastIgnored := ignored["fast"]
+	require.True(t, slowIgnored, "slow provider should be filtered when fast/cold-start providers remain")
+	require.False(t, coldIgnored, "cold-start provider must not be filtered")
+	require.False(t, fastIgnored, "fast provider must not be filtered")
+	require.Len(t, ignored, 1)
+}

--- a/protocol/lavasession/consumer_session_manager_latency_selection_test.go
+++ b/protocol/lavasession/consumer_session_manager_latency_selection_test.go
@@ -63,10 +63,12 @@ func (s *smartStubOptimizer) ChooseBestProvider(ctx context.Context, allAddresse
 	return firstNotIgnored(allAddresses, ignoredProviders)
 }
 
-func (s *smartStubOptimizer) Strategy() provideroptimizer.Strategy { return provideroptimizer.StrategyBalanced }
-func (s *smartStubOptimizer) UpdateWeights(map[string]int64, uint64) {}
-func (s *smartStubOptimizer) AppendProbeRelayData(string, time.Duration, bool) {}
-func (s *smartStubOptimizer) AppendRelayFailure(string) {}
+func (s *smartStubOptimizer) Strategy() provideroptimizer.Strategy {
+	return provideroptimizer.StrategyBalanced
+}
+func (s *smartStubOptimizer) UpdateWeights(map[string]int64, uint64)                {}
+func (s *smartStubOptimizer) AppendProbeRelayData(string, time.Duration, bool)      {}
+func (s *smartStubOptimizer) AppendRelayFailure(string)                             {}
 func (s *smartStubOptimizer) AppendRelayData(string, time.Duration, uint64, uint64) {}
 
 // setupCSMForSelection builds a fully-wired ConsumerSessionManager with the smart

--- a/protocol/lavasession/consumer_session_manager_latency_selection_test.go
+++ b/protocol/lavasession/consumer_session_manager_latency_selection_test.go
@@ -1,0 +1,151 @@
+package lavasession
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/provideroptimizer"
+	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
+	"github.com/stretchr/testify/require"
+)
+
+// smartStubOptimizer is a ProviderOptimizer that drives getValidProviderAddresses
+// without the real weighted-selection machinery: it returns the first non-ignored
+// address (so the ignored set fully controls which providers can be picked) and
+// reports per-provider latency from a configurable map. Providers without an
+// explicit entry default to a fast latency, so only explicitly-slow providers are
+// candidates for the cutoff.
+type smartStubOptimizer struct {
+	reports map[string]*pairingtypes.QualityOfServiceReport
+}
+
+func newSmartStubOptimizer() *smartStubOptimizer {
+	return &smartStubOptimizer{reports: map[string]*pairingtypes.QualityOfServiceReport{}}
+}
+
+func (s *smartStubOptimizer) setLatency(address, latencySeconds string) {
+	s.reports[address] = qosWithLatency(latencySeconds)
+}
+
+func (s *smartStubOptimizer) GetReputationReportForProvider(address string) (*pairingtypes.QualityOfServiceReport, time.Time) {
+	if r, ok := s.reports[address]; ok {
+		return r, time.Time{}
+	}
+	// default: fast, well under any sane cutoff
+	return qosWithLatency("0.05"), time.Time{}
+}
+
+func firstNotIgnored(allAddresses []string, ignoredProviders map[string]struct{}) []string {
+	for _, addr := range allAddresses {
+		if _, ok := ignoredProviders[addr]; ok {
+			continue
+		}
+		return []string{addr}
+	}
+	return []string{}
+}
+
+func (s *smartStubOptimizer) ChooseProviderWithStats(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) ([]string, *provideroptimizer.SelectionStats) {
+	return firstNotIgnored(allAddresses, ignoredProviders), nil
+}
+
+func (s *smartStubOptimizer) ChooseBestProviderWithStats(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) ([]string, *provideroptimizer.SelectionStats) {
+	return firstNotIgnored(allAddresses, ignoredProviders), nil
+}
+
+func (s *smartStubOptimizer) ChooseProvider(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []string {
+	return firstNotIgnored(allAddresses, ignoredProviders)
+}
+
+func (s *smartStubOptimizer) ChooseBestProvider(ctx context.Context, allAddresses []string, ignoredProviders map[string]struct{}, cu uint64, requestedBlock int64) []string {
+	return firstNotIgnored(allAddresses, ignoredProviders)
+}
+
+func (s *smartStubOptimizer) Strategy() provideroptimizer.Strategy { return provideroptimizer.StrategyBalanced }
+func (s *smartStubOptimizer) UpdateWeights(map[string]int64, uint64) {}
+func (s *smartStubOptimizer) AppendProbeRelayData(string, time.Duration, bool) {}
+func (s *smartStubOptimizer) AppendRelayFailure(string) {}
+func (s *smartStubOptimizer) AppendRelayData(string, time.Duration, uint64, uint64) {}
+
+// setupCSMForSelection builds a fully-wired ConsumerSessionManager with the smart
+// stub optimizer and a real pairing list, returning the valid provider addresses.
+func setupCSMForSelection(t *testing.T, maxLatency float64) (*ConsumerSessionManager, *smartStubOptimizer, []string) {
+	ctx := context.Background()
+	csm := CreateConsumerSessionManager()
+	stub := newSmartStubOptimizer()
+	csm.providerOptimizer = stub
+	csm.rpcEndpoint.MaxProviderLatency = maxLatency
+
+	pairingList := createPairingList("", true)
+	require.NoError(t, csm.UpdateAllProviders(firstEpochHeight, pairingList, nil))
+
+	csm.lock.RLock()
+	valid := csm.getValidAddresses("", nil, ctx)
+	csm.lock.RUnlock()
+	require.GreaterOrEqual(t, len(valid), 2, "need at least two valid providers for the test")
+	return csm, stub, valid
+}
+
+// callGetValidProviderAddresses runs the selection under the read lock the function expects.
+func callGetValidProviderAddresses(csm *ConsumerSessionManager, ctx context.Context, wanted int, stateful uint32, stickiness, selectedProvider string) ([]string, error) {
+	csm.lock.RLock()
+	defer csm.lock.RUnlock()
+	return csm.getValidProviderAddresses(ctx, wanted, map[string]struct{}{}, cuForFirstRequest, servicedBlockNumber, "", nil, stateful, stickiness, selectedProvider)
+}
+
+// Test 1: end-to-end general random selection excludes the slow provider and still
+// fills the batch from the remaining (fast) providers.
+func TestLatencySelection_GeneralPathExcludesSlowProvider(t *testing.T) {
+	ctx := context.Background()
+	csm, stub, valid := setupCSMForSelection(t, 1.0)
+	slow := valid[0]
+	stub.setLatency(slow, "1.5")
+
+	addresses, err := callGetValidProviderAddresses(csm, ctx, len(valid), common.NO_STATE, "", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, addresses)
+	require.NotContains(t, addresses, slow, "slow provider must not be selected in the general path")
+	require.Len(t, addresses, len(valid)-1, "all fast providers should remain selectable")
+}
+
+// Test 3: stickiness path is unaffected by the cutoff - a sticky session pinned to a
+// slow provider still returns it.
+func TestLatencySelection_StickinessUnaffected(t *testing.T) {
+	ctx := context.Background()
+	csm, stub, valid := setupCSMForSelection(t, 1.0)
+	slow := valid[0]
+	stub.setLatency(slow, "5.0")
+	csm.stickySessions.Set("sticky-id", &StickySession{Provider: slow, Epoch: firstEpochHeight})
+
+	addresses, err := callGetValidProviderAddresses(csm, ctx, 1, common.NO_STATE, "sticky-id", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{slow}, addresses, "sticky session must return its pinned provider regardless of latency")
+}
+
+// Test 4: stateful (select-all) path is unaffected by the cutoff - the slow provider
+// is still included in the returned set.
+func TestLatencySelection_StatefulUnaffected(t *testing.T) {
+	ctx := context.Background()
+	csm, stub, valid := setupCSMForSelection(t, 1.0)
+	slow := valid[0]
+	stub.setLatency(slow, "5.0")
+
+	addresses, err := callGetValidProviderAddresses(csm, ctx, len(valid), common.CONSISTENCY_SELECT_ALL_PROVIDERS, "", "")
+	require.NoError(t, err)
+	require.Contains(t, addresses, slow, "stateful select-all must include the slow provider")
+}
+
+// Test 5: header/static selected-provider path is unaffected by the cutoff - the
+// explicitly selected slow provider is still returned.
+func TestLatencySelection_SelectedProviderUnaffected(t *testing.T) {
+	ctx := context.Background()
+	csm, stub, valid := setupCSMForSelection(t, 1.0)
+	slow := valid[0]
+	stub.setLatency(slow, "5.0")
+
+	addresses, err := callGetValidProviderAddresses(csm, ctx, 1, common.NO_STATE, "", slow)
+	require.NoError(t, err)
+	require.Equal(t, []string{slow}, addresses, "explicitly selected provider must be returned regardless of latency")
+}

--- a/protocol/lavasession/consumer_session_manager_test.go
+++ b/protocol/lavasession/consumer_session_manager_test.go
@@ -166,7 +166,7 @@ func CreateConsumerSessionManager() *ConsumerSessionManager {
 	rand.InitRandomSeed()
 	optimizer := provideroptimizer.NewProviderOptimizer(provideroptimizer.StrategyBalanced, 0, 1, nil, "dontcare")
 	optimizer.SetDeterministicSeed(1234567)
-	return NewConsumerSessionManager(&RPCEndpoint{"stub", "stub", "stub", false, "/", 0}, optimizer, nil, "lava@test", NewActiveSubscriptionProvidersStorage())
+	return NewConsumerSessionManager(&RPCEndpoint{"stub", "stub", "stub", false, "/", 0, 0}, optimizer, nil, "lava@test", NewActiveSubscriptionProvidersStorage())
 }
 
 func TestMain(m *testing.M) {

--- a/protocol/lavasession/consumer_types.go
+++ b/protocol/lavasession/consumer_types.go
@@ -252,6 +252,10 @@ type RPCEndpoint struct {
 	TLSEnabled      bool   `yaml:"tls-enabled,omitempty" json:"tls-enabled,omitempty" mapstructure:"tls-enabled"`
 	HealthCheckPath string `yaml:"health-check-path,omitempty" json:"health-check-path,omitempty" mapstructure:"health-check-path"` // health check status code 200 path, default is "/"
 	Geolocation     uint64 `yaml:"geolocation,omitempty" json:"geolocation,omitempty" mapstructure:"geolocation"`
+	// MaxProviderLatency is the per-chain QoS latency cutoff (in seconds) used during the general random
+	// provider selection. Providers whose EWMA latency exceeds this value are put aside and not picked.
+	// 0 (default) disables the cutoff. Static, header-selected, sticky and stateful selections are unaffected.
+	MaxProviderLatency float64 `yaml:"max-provider-latency,omitempty" json:"max-provider-latency,omitempty" mapstructure:"max-provider-latency"`
 }
 
 func (endpoint *RPCEndpoint) String() (retStr string) {

--- a/protocol/rpcconsumer/README.md
+++ b/protocol/rpcconsumer/README.md
@@ -49,6 +49,7 @@ endpoints:
   - chain-id: ETH1
     api-interface: jsonrpc
     network-address: 127.0.0.1:3333
+    max-provider-latency: 1.0
   - chain-id: OSMOSIS
     api-interface: rest
     network-address: 127.0.0.1:3334
@@ -62,6 +63,14 @@ endpoints:
 - `chain-id`: Blockchain identifier (e.g., ETH1, OSMOSIS, LAV1)
 - `api-interface`: API type (jsonrpc, rest, tendermintrpc, grpc)
 - `network-address`: IP:PORT where the consumer will listen for requests
+- `max-provider-latency` (optional): QoS latency cutoff **in seconds** for this
+  endpoint. During the general random provider selection, providers whose
+  measured latency exceeds this value are put aside and not picked. `0`
+  (default, or omitted) disables the cutoff. Configured per endpoint, so a chain
+  exposed over multiple `api-interface`s must set it on each entry. As a safety
+  fallback, the cutoff is ignored when *every* paired provider is above the
+  threshold, so relays keep flowing even when the whole pairing is slow.
+  Static, header-selected, sticky, and stateful selections are unaffected.
 
 ## Usage
 

--- a/protocol/rpcconsumer/rpcconsumer_endpoints_test.go
+++ b/protocol/rpcconsumer/rpcconsumer_endpoints_test.go
@@ -1,0 +1,37 @@
+package rpcconsumer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// Test 2: the per-chain max-provider-latency field is parsed from the YAML endpoints
+// config into RPCEndpoint.MaxProviderLatency, and defaults to 0 when omitted.
+func TestParseEndpoints_MaxProviderLatency(t *testing.T) {
+	yamlConfig := `
+endpoints:
+  - chain-id: ETH1
+    api-interface: jsonrpc
+    network-address: 127.0.0.1:3333
+    max-provider-latency: 1.5
+  - chain-id: LAV1
+    api-interface: rest
+    network-address: 127.0.0.1:3340
+`
+	v := viper.New()
+	v.SetConfigType("yml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(yamlConfig)))
+
+	endpoints, err := ParseEndpoints(v, 1)
+	require.NoError(t, err)
+	require.Len(t, endpoints, 2)
+
+	require.Equal(t, "ETH1", endpoints[0].ChainID)
+	require.Equal(t, 1.5, endpoints[0].MaxProviderLatency, "max-provider-latency must be parsed from YAML")
+
+	require.Equal(t, "LAV1", endpoints[1].ChainID)
+	require.Equal(t, float64(0), endpoints[1].MaxProviderLatency, "omitted max-provider-latency must default to 0 (disabled)")
+}

--- a/scripts/pre_setups/init_eth_latency_cutoff.sh
+++ b/scripts/pre_setups/init_eth_latency_cutoff.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# E2E setup for the per-chain latency cutoff (max-provider-latency).
+#
+# Stands up a dev lava node + 3 ETH1 providers, each backed by its own mock RPC
+# server (scripts/mock_rpc_server) so we can inject latency per provider. The
+# consumer is started with a config file carrying max-provider-latency.
+#
+# Modes (1st arg, default "cutoff"):
+#   cutoff               provider3 slow, consumer cutoff = 1.0  -> provider3 put aside
+#   regression-disabled  provider3 slow, consumer cutoff = 0    -> provider3 still selected (feature off)
+#   regression-fallback  ALL providers slow, cutoff = 1.0       -> safety fallback keeps full pool
+#
+# After it is up, verify with: scripts/test/verify_latency_cutoff.sh <mode>
+#
+# Note: the mock delay is whole seconds (>=1). We use 2s with a 1.0s cutoff so a
+# slow relay still succeeds (registers as high latency, not an availability
+# failure). Keep the consumer relay timeout above 2s.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$__dir"/../useful_commands.sh
+
+MODE="${1:-cutoff}"
+ROOT="$__dir/../.."
+LOGS_DIR="$ROOT/testutil/debugging/logs"
+mkdir -p "$LOGS_DIR"
+rm -f "$LOGS_DIR"/*.log
+
+GASPRICE="0.00002ulava"
+PROVIDERSTAKE="500000000000ulava"
+
+# mock backend ports and provider listeners (index 1..3)
+MOCK_PORTS=(19991 19992 19993)
+PROVIDER_LISTENERS=("127.0.0.1:2221" "127.0.0.1:2222" "127.0.0.1:2223")
+PROVIDER_METRICS=(7776 7777 7778)
+SERVICERS=(servicer1 servicer2 servicer3)
+
+# cutoff value + which providers are slow, per mode
+CUTOFF="1.0"
+SLOW_INDEXES=(3)
+case "$MODE" in
+  cutoff)               CUTOFF="1.0"; SLOW_INDEXES=(3) ;;
+  regression-disabled)  CUTOFF="0";   SLOW_INDEXES=(3) ;;
+  regression-fallback)  CUTOFF="1.0"; SLOW_INDEXES=(1 2 3) ;;
+  *) echo "unknown mode: $MODE (use cutoff | regression-disabled | regression-fallback)"; exit 1 ;;
+esac
+echo "[Setup] mode=$MODE  cutoff=$CUTOFF  slow_providers=${SLOW_INDEXES[*]}"
+
+killall screen 2>/dev/null
+screen -wipe 2>/dev/null
+
+echo "[Setup] installing binaries"
+make install-all
+
+echo "[Setup] starting dev lava node"
+screen -d -m -S node bash -c "$ROOT/scripts/start_env_dev.sh"
+sleep 5
+wait_for_lava_node_to_start
+
+# The full spec bundle (get_all_specs) exceeds the gov proposal metadata limit, so we
+# register only the closure needed for a provider/consumer on ETH1 in a single proposal:
+# the lava chain spec LAV1 and its imports (COSMOSSDK -> TENDERMINT, IBC), plus ETH1.
+# One proposal -> one vote (the 4s voting period makes multi-proposal loops racy).
+echo "[Setup] proposing specs (LAV1+ETH1 closure)"
+specs="specs/mainnet-1/specs/ibc.json,specs/mainnet-1/specs/tendermint.json,specs/mainnet-1/specs/cosmossdk.json,specs/testnet-2/specs/lava.json,specs/mainnet-1/specs/ethereum.json"
+lavad tx gov submit-legacy-proposal spec-add $specs --lava-dev-test -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
+wait_next_block
+lavad tx gov vote 1 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+sleep 5
+
+echo "[Setup] proposing plans"
+lavad tx gov submit-legacy-proposal plans-add ./cookbook/plans/test_plans/default.json,./cookbook/plans/test_plans/temporary-add.json -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
+wait_next_block
+lavad tx gov vote 2 yes -y --from alice --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+sleep 5
+
+echo "[Setup] subscription + staking 3 ETH1 providers"
+lavad tx subscription buy DefaultPlan $(lavad keys show user1 -a) -y --from user1 --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+wait_next_block
+for i in 0 1 2; do
+  lavad tx pairing stake-provider "ETH1" $PROVIDERSTAKE "${PROVIDER_LISTENERS[$i]},1" 1 $(operator_address) -y \
+    --from ${SERVICERS[$i]} --provider-moniker "${SERVICERS[$i]}" --gas-adjustment "1.5" --gas "auto" --gas-prices $GASPRICE
+  wait_next_block
+done
+
+echo "[Setup] starting 3 mock backends"
+for i in 0 1 2; do
+  port=${MOCK_PORTS[$i]}
+  screen -d -m -S mock$((i+1)) bash -c "cd $ROOT; go run ./scripts/mock_rpc_server -port $port 2>&1 | tee $LOGS_DIR/MOCK$((i+1)).log"
+done
+sleep 3
+
+echo "[Setup] applying latency to slow providers: ${SLOW_INDEXES[*]}"
+for idx in "${SLOW_INDEXES[@]}"; do
+  port=${MOCK_PORTS[$((idx-1))]}
+  # 2s sticky delay -> above the 1.0s cutoff, relay still succeeds
+  curl -s "http://127.0.0.1:$port/control?wait=2&sticky=1" && echo " -> provider$idx (mock :$port) slowed to 2s"
+done
+
+sleep_until_next_epoch
+
+# The mock RPC server is not a real eth node, so it cannot satisfy the ETH1 spec's
+# provider-startup verifications (chain-id, pruning, historical-block distance, ...).
+# We hand the provider a local copy of the ETH1 spec with those verifications stripped
+# (--use-static-spec). The provider still proxies real relays to the mock (so the injected
+# latency is preserved); only the unfakeable node validation is skipped. The consumer keeps
+# using the on-chain ETH1 spec for pairing.
+echo "[Setup] generating verification-stripped static spec"
+STATIC_SPEC="$LOGS_DIR/eth1_static_spec.json"
+python3 - "$ROOT/specs/mainnet-1/specs/ethereum.json" "$STATIC_SPEC" <<'PY'
+import json, sys
+src, dst = sys.argv[1], sys.argv[2]
+d = json.load(open(src))
+for s in d["proposal"]["specs"]:
+    for ac in s.get("api_collections", []):
+        ac["verifications"] = []
+json.dump(d, open(dst, "w"))
+PY
+
+echo "[Setup] starting providers"
+for i in 0 1 2; do
+  # http-only node url + --skip-websocket-verification (the mock has no ws; eth_blockNumber
+  # only uses http) + --use-static-spec to skip the node-validation the mock can't pass.
+  screen -d -m -S provider$((i+1)) bash -c "source ~/.bashrc; lavap rpcprovider \
+    ${PROVIDER_LISTENERS[$i]} ETH1 jsonrpc 'http://127.0.0.1:${MOCK_PORTS[$i]}' \
+    --use-static-spec $STATIC_SPEC --skip-websocket-verification \
+    --geolocation 1 --log_level debug --from ${SERVICERS[$i]} --chain-id lava \
+    --metrics-listen-address \":${PROVIDER_METRICS[$i]}\" 2>&1 | tee $LOGS_DIR/PROVIDER$((i+1)).log" && sleep 0.25
+done
+sleep 8
+
+# Select the committed consumer config that matches this mode's cutoff (these live in the
+# config/ dir, which is a viper search path, and are passed by name). The cutoff value is
+# the only thing that varies between modes, so two configs cover all three modes:
+#   cutoff / regression-fallback -> 1.0 (eth_latency_cutoff_consumer.yml)
+#   regression-disabled          -> 0   (eth_latency_cutoff_consumer_disabled.yml)
+if [ "$CUTOFF" = "0" ]; then
+  CONSUMER_CFG_NAME="eth_latency_cutoff_consumer_disabled.yml"
+else
+  CONSUMER_CFG_NAME="eth_latency_cutoff_consumer.yml"
+fi
+
+echo "[Setup] starting consumer (config: config/$CONSUMER_CFG_NAME, cutoff=$CUTOFF)"
+screen -d -m -S consumer bash -c "source ~/.bashrc; cd $ROOT; lavap rpcconsumer config/$CONSUMER_CFG_NAME \
+  --geolocation 1 --log_level debug --from user1 --chain-id lava \
+  --allow-insecure-provider-dialing --metrics-listen-address \":7779\" 2>&1 | tee $LOGS_DIR/CONSUMERS.log" && sleep 0.25
+
+echo "--- setup done (mode=$MODE) ---"
+echo "consumer:        http://127.0.0.1:3333"
+echo "consumer metrics: http://127.0.0.1:7779/metrics"
+echo "verify with:     scripts/test/verify_latency_cutoff.sh $MODE"
+screen -ls

--- a/scripts/test/e2e_latency_cutoff.sh
+++ b/scripts/test/e2e_latency_cutoff.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# One-command end-to-end runner for the per-chain latency cutoff.
+#
+# Brings up the full environment (chain + mocks + providers + consumer), waits for
+# it to be ready, runs the verification, then tears everything down. Wraps the two
+# reusable scripts:
+#   scripts/pre_setups/init_eth_latency_cutoff.sh   (env)
+#   scripts/test/verify_latency_cutoff.sh           (assertions)
+#
+# Usage:
+#   scripts/test/e2e_latency_cutoff.sh [cutoff|regression-disabled|regression-fallback|all]
+#   scripts/test/e2e_latency_cutoff.sh cutoff --keep    # leave the env running afterwards
+#
+# Exit code is non-zero if any mode's verification fails.
+
+__dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT="$__dir/../.."
+INIT="$ROOT/scripts/pre_setups/init_eth_latency_cutoff.sh"
+VERIFY="$ROOT/scripts/test/verify_latency_cutoff.sh"
+SETUP_LOG="/tmp/lava_latency_e2e_setup.log"
+
+ARG="${1:-cutoff}"
+KEEP=0
+[ "$2" = "--keep" ] && KEEP=1
+
+if [ "$ARG" = "all" ]; then
+  MODES=(cutoff regression-disabled regression-fallback)
+else
+  MODES=("$ARG")
+fi
+
+teardown() {
+  screen -ls 2>/dev/null | grep -oE '[0-9]+\.(node|provider[0-9]|consumer|mock[0-9])' | cut -d. -f1 \
+    | xargs -I{} screen -S {} -X quit 2>/dev/null
+  killall lavad lavap 2>/dev/null
+  pkill -f mock_rpc_server 2>/dev/null
+  sleep 2
+  screen -wipe >/dev/null 2>&1
+}
+
+wait_for_consumer() {
+  # wait until setup finished, then until the consumer actually serves a relay
+  local tries=0
+  echo "[e2e] waiting for setup to finish..."
+  until grep -q "setup done" "$SETUP_LOG" 2>/dev/null; do
+    sleep 5; tries=$((tries+1))
+    [ $tries -gt 180 ] && { echo "[e2e] setup timed out (no 'setup done' in $SETUP_LOG)"; tail -5 "$SETUP_LOG"; return 1; }
+  done
+  echo "[e2e] setup done; waiting for consumer to serve a relay (a fresh chain may need an epoch for pairing)..."
+  tries=0
+  local resp=""
+  # ~6 min: fresh-setup pairing/probing can take an epoch or two
+  while [ $tries -le 120 ]; do
+    resp=$(curl -s -m 6 -X POST http://127.0.0.1:3333 \
+           -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' 2>/dev/null)
+    echo "$resp" | grep -q result && { echo "[e2e] consumer serving."; return 0; }
+    sleep 3; tries=$((tries+1))
+    [ $((tries % 10)) -eq 0 ] && echo "[e2e]   still waiting (${tries}/120), last reply: ${resp:0:80}"
+  done
+  echo "[e2e] consumer never served a relay. last reply: ${resp:0:200}"
+  echo "[e2e] consumer log tail:"; tail -6 "$ROOT/testutil/debugging/logs/CONSUMERS.log" 2>/dev/null | sed 's/StackTrace.*//'
+  return 1
+}
+
+overall=0
+for mode in "${MODES[@]}"; do
+  echo "============================================================"
+  echo "[e2e] mode=$mode : bringing up environment"
+  echo "============================================================"
+  teardown
+  bash "$INIT" "$mode" > "$SETUP_LOG" 2>&1
+  if ! wait_for_consumer; then
+    echo "[e2e] FAILED ($mode): environment did not come up (see $SETUP_LOG)"
+    overall=1
+    continue
+  fi
+  echo "[e2e] environment ready, running verification"
+  if bash "$VERIFY" "$mode"; then
+    echo "[e2e] RESULT $mode: PASS"
+  else
+    echo "[e2e] RESULT $mode: FAIL"
+    overall=1
+  fi
+done
+
+if [ "$KEEP" -eq 1 ]; then
+  echo "[e2e] leaving environment running (--keep). Tear down with: killall lavad lavap; pkill -f mock_rpc_server"
+else
+  echo "[e2e] tearing down"
+  teardown
+fi
+
+[ "$overall" -eq 0 ] && echo "[e2e] ALL PASSED" || echo "[e2e] SOME FAILED"
+exit $overall

--- a/scripts/test/verify_latency_cutoff.sh
+++ b/scripts/test/verify_latency_cutoff.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Verifies the per-chain latency cutoff against a running env brought up by
+# scripts/pre_setups/init_eth_latency_cutoff.sh.
+#
+# Usage: scripts/test/verify_latency_cutoff.sh [cutoff|regression-disabled|regression-fallback]
+#
+# Approach: warm up so the slow provider's QoS latency climbs above the cutoff,
+# then snapshot the per-provider selection counter, send a measurement burst, and
+# snapshot again. Assert on the deltas:
+#   cutoff               -> slow provider gains ~0 selections; others keep growing
+#   regression-disabled  -> slow provider still gains selections (feature off)
+#   regression-fallback  -> all providers keep growing (fallback kept the pool)
+
+MODE="${1:-cutoff}"
+CONSUMER="http://127.0.0.1:3333"
+METRICS="http://127.0.0.1:7779/metrics"
+WARMUP=60
+MEASURE=100
+TOL=2   # allowed stray selections for a "put aside" provider
+
+P1=$(lavad keys show servicer1 -a)
+P2=$(lavad keys show servicer2 -a)
+P3=$(lavad keys show servicer3 -a)
+
+relay() {
+  curl -s -X POST -H 'Content-Type: application/json' "$CONSUMER" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' >/dev/null
+}
+
+# selection count for a provider address (0 if it has no metric line yet)
+count_for() {
+  curl -s "$METRICS" \
+    | awk -v p="$1" '$1 ~ /^lava_consumer_provider_selections/ && index($0, p) { print $NF; found=1 } END { if (!found) print 0 }' \
+    | head -n1
+}
+
+echo "[verify] mode=$MODE  warmup=$WARMUP measure=$MEASURE"
+echo "[verify] warming up..."
+for i in $(seq 1 $WARMUP); do relay; done
+
+b1=$(count_for "$P1"); b2=$(count_for "$P2"); b3=$(count_for "$P3")
+echo "[verify] baseline selections: p1=$b1 p2=$b2 p3(slow)=$b3"
+
+echo "[verify] measurement burst..."
+for i in $(seq 1 $MEASURE); do relay; done
+
+a1=$(count_for "$P1"); a2=$(count_for "$P2"); a3=$(count_for "$P3")
+d1=$((a1 - b1)); d2=$((a2 - b2)); d3=$((a3 - b3))
+echo "[verify] deltas: p1=+$d1 p2=+$d2 p3(slow)=+$d3"
+
+pass=1
+case "$MODE" in
+  cutoff)
+    # slow provider must be put aside; the two fast ones must absorb the traffic
+    [ "$d3" -le "$TOL" ] || { echo "FAIL: slow provider still selected (+$d3 > $TOL)"; pass=0; }
+    [ $((d1 + d2)) -gt 0 ] || { echo "FAIL: fast providers got no traffic"; pass=0; }
+    ;;
+  regression-disabled)
+    # cutoff disabled -> slow provider still participates (default behavior intact)
+    [ "$d3" -gt 0 ] || { echo "FAIL: slow provider was excluded with cutoff disabled"; pass=0; }
+    ;;
+  regression-fallback)
+    # everyone slow -> safety fallback keeps the full pool, all keep being selected
+    [ "$d1" -gt 0 ] && [ "$d2" -gt 0 ] && [ "$d3" -gt 0 ] || { echo "FAIL: fallback did not keep all providers"; pass=0; }
+    ;;
+  *) echo "unknown mode: $MODE"; exit 2 ;;
+esac
+
+if [ "$pass" -eq 1 ]; then echo "[verify] PASS ($MODE)"; exit 0; else echo "[verify] FAILED ($MODE)"; exit 1; fi


### PR DESCRIPTION
## Summary
Adds an optional per-chain latency cutoff for the consumer's random provider
selection. Providers whose measured QoS latency exceeds a configurable
`max-provider-latency` (seconds) are put aside during general random selection,
so slow providers stop receiving traffic while faster ones absorb it. Opt-in:
`max-provider-latency: 0` (or omitted) preserves current behaviour exactly.

### Behaviour
- Enabled (`> 0`): providers measured above the threshold are excluded from the general random pool.
- Safety fallback: if every provider is above the threshold, the full pool is kept (we never strand a chain).
- Cold start: providers with no latency measurement yet are not filtered.
- Unaffected: stickiness, stateful, and explicitly-selected-provider paths.

## Changes
- `protocol/lavasession/consumer_session_manager.go` — latency filtering in the general selection path.
- `protocol/lavasession/consumer_types.go` — `RPCEndpoint.MaxProviderLatency` field.
- `protocol/rpcconsumer` — parse `max-provider-latency` from the endpoints YAML (defaults to 0).
- `config/` — example consumer configs (enabled / disabled variants) + `rpcconsumer.yml` field.
- `protocol/rpcconsumer/README.md` — docs.
- Tests: unit + integration tests, plus a live E2E harness under `scripts/`.

## Testing
- New unit/integration tests: 14/14 pass (13 lavasession + 1 rpcconsumer).
- E2E harness (`scripts/test/e2e_latency_cutoff.sh all`): all 3 modes pass
  - `cutoff`: slow provider put aside (deltas `p1=+46 p2=+54 p3(slow)=+0`)
  - `regression-disabled`: cutoff off → slow provider still selected (`p3=+24`)
  - `regression-fallback`: all slow → fallback keeps full pool (`+100/+100/+100`)
- Full suite: `go build ./...` clean; no regressions across `x/...` and `protocol/...`.