### PR TITLE
feat: add grpcwebcompat package for canonical trailer encoding

### DIFF
--- a/protocol/chainlib/grpcproxy/grpcproxy.go
+++ b/protocol/chainlib/grpcproxy/grpcproxy.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/grpcwebcompat"
 	"github.com/lavanet/lava/v5/utils"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/net/http2"
@@ -47,16 +47,16 @@ func NewGRPCProxyWithReflection(cb ProxyCallBack, healthCheckPath string, cmdFla
 	s := grpc.NewServer(serverOpts...)
 	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
 
-	wrappedServer := grpcweb.WrapServer(s)
+	wrappedServer := grpcwebcompat.WrapServer(s)
 
 	// Create a separate gRPC server for reflection with standard protobuf codec
 	// This is needed because the main proxy server uses RawBytesCodec which breaks
 	// the reflection service's protobuf message serialization
-	var wrappedReflectionServer *grpcweb.WrappedGrpcServer
+	var wrappedReflectionServer http.Handler
 	if reflectionCallback != nil {
 		reflectionGrpcServer := grpc.NewServer(serverReceiveMaxMessageSize)
 		RegisterReflectionProxy(reflectionGrpcServer, reflectionCallback)
-		wrappedReflectionServer = grpcweb.WrapServer(reflectionGrpcServer)
+		wrappedReflectionServer = grpcwebcompat.WrapServer(reflectionGrpcServer)
 	}
 
 	handler := func(resp http.ResponseWriter, req *http.Request) {

--- a/protocol/chaintracker/chain_tracker.go
+++ b/protocol/chaintracker/chain_tracker.go
@@ -14,8 +14,8 @@ import (
 	"github.com/dgraph-io/ristretto/v2"
 	rand "github.com/lavanet/lava/v5/utils/rand"
 
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/grpcwebcompat"
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/protocol/metrics"
 	"github.com/lavanet/lava/v5/utils"
@@ -582,7 +582,7 @@ func (ct *ChainTracker) serve(ctx context.Context, listenAddr string) error {
 	}
 	s := grpc.NewServer()
 
-	wrappedServer := grpcweb.WrapServer(s)
+	wrappedServer := grpcwebcompat.WrapServer(s)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
 		// Set CORS headers
 		resp.Header().Set("Access-Control-Allow-Origin", "*")

--- a/protocol/grpcwebcompat/grpcwebcompat.go
+++ b/protocol/grpcwebcompat/grpcwebcompat.go
@@ -50,15 +50,15 @@ const trailerFrameFlag = 1 << 7
 // WrapServer wraps a gRPC server for gRPC-Web the same way grpcweb.WrapServer does,
 // except that gRPC-Web responses get a canonically encoded trailer frame.
 func WrapServer(server *grpc.Server, options ...grpcweb.Option) http.Handler {
-	return WrapHandler(server, grpcweb.WrapServer(server, options...))
+	return wrapHandler(server, grpcweb.WrapServer(server, options...))
 }
 
-// WrapHandler routes gRPC-Web requests to grpcHandler through this package's response
+// wrapHandler routes gRPC-Web requests to grpcHandler through this package's response
 // writer and everything else to fallback, which is expected to be the equivalent
 // grpcweb-wrapped handler.
-func WrapHandler(grpcHandler, fallback http.Handler) http.Handler {
+func wrapHandler(grpcHandler, fallback http.Handler) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		if IsGrpcWebRequest(req) {
+		if isGrpcWebRequest(req) {
 			serveGrpcWeb(grpcHandler, resp, req)
 			return
 		}
@@ -66,18 +66,42 @@ func WrapHandler(grpcHandler, fallback http.Handler) http.Handler {
 	})
 }
 
-// IsGrpcWebRequest reports whether req is a gRPC-Web request, using the same rule as
-// grpcweb.WrappedGrpcServer.IsGrpcWebRequest so that the two stay in agreement about
-// which requests this package takes over.
-func IsGrpcWebRequest(req *http.Request) bool {
+// isGrpcWebRequest reports whether req is a gRPC-Web request.
+//
+// The rule is character for character the one in
+// grpcweb.WrappedGrpcServer.IsGrpcWebRequest, case sensitivity included. Whatever this
+// does not claim is served by the fallback, so the two predicates have to agree
+// exactly: matching more than the fallback would route requests here that the rest of
+// the pipeline still rejects, and matching less would send gRPC-Web responses back
+// through the trailer encoding this package exists to avoid.
+func isGrpcWebRequest(req *http.Request) bool {
 	return req.Method == http.MethodPost && strings.HasPrefix(req.Header.Get("content-type"), grpcWebContentType)
 }
 
 func serveGrpcWeb(grpcHandler http.Handler, resp http.ResponseWriter, req *http.Request) {
+	requestContentType := req.Header.Get("content-type")
 	nativeReq, isTextFormat := toNativeGrpcRequest(req)
-	webResp := newResponseWriter(resp, isTextFormat)
+	webResp := newResponseWriter(resp, isTextFormat, requestContentType)
 	grpcHandler.ServeHTTP(webResp, nativeReq)
 	webResp.finishRequest()
+}
+
+// responseContentType picks the content type to report for a gRPC-Web response.
+//
+// The value is always assembled from this package's constants and never echoed from
+// the request: the request header is attacker controlled, and reflecting it into a
+// response header is a cross-site scripting sink (CodeQL go/reflected-xss). Only the
+// proto and json sub-types carry meaning here, so the request merely selects between
+// fixed strings.
+func responseContentType(baseContentType, requestContentType string) string {
+	switch {
+	case strings.HasSuffix(requestContentType, "+proto"):
+		return baseContentType + "+proto"
+	case strings.HasSuffix(requestContentType, "+json"):
+		return baseContentType + "+json"
+	default:
+		return baseContentType
+	}
 }
 
 // toNativeGrpcRequest rewrites a gRPC-Web request into the plain gRPC request the
@@ -118,16 +142,17 @@ type responseWriter struct {
 	contentType string
 }
 
-func newResponseWriter(resp http.ResponseWriter, isTextFormat bool) *responseWriter {
+func newResponseWriter(resp http.ResponseWriter, isTextFormat bool, requestContentType string) *responseWriter {
 	w := &responseWriter{
-		headers:     make(http.Header),
-		wrapped:     resp,
-		contentType: grpcWebContentType,
+		headers: make(http.Header),
+		wrapped: resp,
 	}
+	baseContentType := grpcWebContentType
 	if isTextFormat {
 		w.wrapped = newBase64ResponseWriter(w.wrapped)
-		w.contentType = grpcWebTextContentType
+		baseContentType = grpcWebTextContentType
 	}
+	w.contentType = responseContentType(baseContentType, requestContentType)
 	return w
 }
 
@@ -168,14 +193,13 @@ func (w *responseWriter) prepareHeaders() {
 		}
 		key = strings.Replace(key, http.TrailerPrefix, "", 1)
 		if strings.EqualFold(key, "content-type") {
-			replaced := make([]string, len(values))
-			for i, value := range values {
-				replaced[i] = strings.Replace(value, grpcContentType, w.contentType, 1)
-			}
-			values = replaced
+			// replaced below by a value this package controls, never by the one the
+			// grpc-go server derived from the request
+			continue
 		}
 		flushed[http.CanonicalHeaderKey(key)] = values
 	}
+	flushed.Set("Content-Type", w.contentType)
 
 	exposed := make([]string, 0, len(flushed)+2)
 	for key := range flushed {
@@ -185,7 +209,7 @@ func (w *responseWriter) prepareHeaders() {
 	// grpc-status and grpc-message travel in the body, but browsers still expect them
 	// to be listed here, matching grpcweb's behaviour.
 	exposed = append(exposed, "grpc-status", "grpc-message")
-	flushed.Set(http.CanonicalHeaderKey("access-control-expose-headers"), strings.Join(exposed, ", "))
+	flushed.Set("Access-Control-Expose-Headers", strings.Join(exposed, ", "))
 }
 
 func (w *responseWriter) finishRequest() {

--- a/protocol/grpcwebcompat/grpcwebcompat.go
+++ b/protocol/grpcwebcompat/grpcwebcompat.go
@@ -1,0 +1,323 @@
+// Package grpcwebcompat serves gRPC-Web requests with a canonically encoded
+// trailer frame.
+//
+// gRPC-Web moves the response trailers (which carry grpc-status/grpc-message)
+// out of the HTTP/2 TRAILERS frame and into the response body, as a final frame
+// whose payload is an HTTP/1 style header block. github.com/improbable-eng/grpc-web
+// builds that payload with http.Header.Write, which emits "key: value\r\n" -
+// note the optional whitespace between the colon and the value. RFC 7230 allows
+// that OWS and requires receivers to strip it, but a receiver that simply splits
+// on ':' reads grpc-status as " 0" and fails with:
+//
+//	transport: malformed grpc-status: strconv.ParseInt: parsing " 0": invalid syntax
+//
+// which surfaces as a Trailers-Only response - an Internal error and no message
+// at all for the caller.
+//
+// Envoy's grpc_web filter and the other reference implementations emit
+// "key:value\r\n" with no OWS, which every parser accepts, so that is what this
+// package writes. Values are also stripped of surrounding whitespace and of CR/LF
+// (which would otherwise corrupt the framing of the trailer block itself).
+//
+// Everything that is not a gRPC-Web request - native gRPC, CORS pre-flights,
+// gRPC-Websockets - is handed to the wrapped grpcweb server unchanged.
+package grpcwebcompat
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
+)
+
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+const (
+	grpcContentType        = "application/grpc"
+	grpcWebContentType     = "application/grpc-web"
+	grpcWebTextContentType = "application/grpc-web-text"
+)
+
+// trailerFrameFlag marks the final frame of a gRPC-Web response as the trailer frame.
+const trailerFrameFlag = 1 << 7
+
+// WrapServer wraps a gRPC server for gRPC-Web the same way grpcweb.WrapServer does,
+// except that gRPC-Web responses get a canonically encoded trailer frame.
+func WrapServer(server *grpc.Server, options ...grpcweb.Option) http.Handler {
+	return WrapHandler(server, grpcweb.WrapServer(server, options...))
+}
+
+// WrapHandler routes gRPC-Web requests to grpcHandler through this package's response
+// writer and everything else to fallback, which is expected to be the equivalent
+// grpcweb-wrapped handler.
+func WrapHandler(grpcHandler, fallback http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if IsGrpcWebRequest(req) {
+			serveGrpcWeb(grpcHandler, resp, req)
+			return
+		}
+		fallback.ServeHTTP(resp, req)
+	})
+}
+
+// IsGrpcWebRequest reports whether req is a gRPC-Web request, using the same rule as
+// grpcweb.WrappedGrpcServer.IsGrpcWebRequest so that the two stay in agreement about
+// which requests this package takes over.
+func IsGrpcWebRequest(req *http.Request) bool {
+	return req.Method == http.MethodPost && strings.HasPrefix(req.Header.Get("content-type"), grpcWebContentType)
+}
+
+func serveGrpcWeb(grpcHandler http.Handler, resp http.ResponseWriter, req *http.Request) {
+	nativeReq, isTextFormat := toNativeGrpcRequest(req)
+	webResp := newResponseWriter(resp, isTextFormat)
+	grpcHandler.ServeHTTP(webResp, nativeReq)
+	webResp.finishRequest()
+}
+
+// toNativeGrpcRequest rewrites a gRPC-Web request into the plain gRPC request the
+// grpc-go server expects.
+func toNativeGrpcRequest(req *http.Request) (*http.Request, bool) {
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+
+	contentType := req.Header.Get("content-type")
+	incomingContentType := grpcWebContentType
+	isTextFormat := strings.HasPrefix(contentType, grpcWebTextContentType)
+	if isTextFormat {
+		// the body is base64 encoded; decode it while keeping the original Body closable
+		req.Body = &readerCloser{reader: base64.NewDecoder(base64.StdEncoding, req.Body), closer: req.Body}
+		incomingContentType = grpcWebTextContentType
+	}
+	req.Header.Set("content-type", strings.Replace(contentType, incomingContentType, grpcContentType, 1))
+
+	// content-length describes the http1.1 payload, not the sum of the h2 DATA frame
+	// lengths, and a mismatch makes the request malformed. Dropping it switches to
+	// chunked encoding, which is the h2 default.
+	req.Header.Del("content-length")
+
+	return req, isTextFormat
+}
+
+// responseWriter turns the grpc-go server's plain gRPC response into a gRPC-Web one:
+// the headers are copied through, and the trailers are appended to the body as a
+// trailer frame instead of being sent as HTTP trailers.
+type responseWriter struct {
+	wroteHeaders bool
+	wroteBody    bool
+	headers      http.Header
+	// wrapped must be flushed before returning so the base64 encoder, when used, emits
+	// its final segment.
+	wrapped http.ResponseWriter
+	// contentType replaces the standard "application/grpc" content type.
+	contentType string
+}
+
+func newResponseWriter(resp http.ResponseWriter, isTextFormat bool) *responseWriter {
+	w := &responseWriter{
+		headers:     make(http.Header),
+		wrapped:     resp,
+		contentType: grpcWebContentType,
+	}
+	if isTextFormat {
+		w.wrapped = newBase64ResponseWriter(w.wrapped)
+		w.contentType = grpcWebTextContentType
+	}
+	return w
+}
+
+func (w *responseWriter) Header() http.Header {
+	return w.headers
+}
+
+func (w *responseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeaders {
+		w.prepareHeaders()
+	}
+	w.wroteBody, w.wroteHeaders = true, true
+	return w.wrapped.Write(b)
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	w.prepareHeaders()
+	w.wrapped.WriteHeader(code)
+	w.wroteHeaders = true
+}
+
+func (w *responseWriter) Flush() {
+	// WriteHeader followed by a Flush would otherwise force a 200 response even when
+	// there is no payload at all.
+	if w.wroteHeaders || w.wroteBody {
+		flushWriter(w.wrapped)
+	}
+}
+
+// prepareHeaders copies the headers the gRPC handler set onto the real response
+// writer, translating the content type and exposing the response headers to browsers.
+func (w *responseWriter) prepareHeaders() {
+	flushed := w.wrapped.Header()
+	for key, values := range w.headers {
+		if strings.EqualFold(key, "trailer") {
+			// the trailer declaration is meaningless once trailers move into the body
+			continue
+		}
+		key = strings.Replace(key, http.TrailerPrefix, "", 1)
+		if strings.EqualFold(key, "content-type") {
+			replaced := make([]string, len(values))
+			for i, value := range values {
+				replaced[i] = strings.Replace(value, grpcContentType, w.contentType, 1)
+			}
+			values = replaced
+		}
+		flushed[http.CanonicalHeaderKey(key)] = values
+	}
+
+	exposed := make([]string, 0, len(flushed)+2)
+	for key := range flushed {
+		exposed = append(exposed, key)
+	}
+	sort.Strings(exposed)
+	// grpc-status and grpc-message travel in the body, but browsers still expect them
+	// to be listed here, matching grpcweb's behaviour.
+	exposed = append(exposed, "grpc-status", "grpc-message")
+	flushed.Set(http.CanonicalHeaderKey("access-control-expose-headers"), strings.Join(exposed, ", "))
+}
+
+func (w *responseWriter) finishRequest() {
+	if w.wroteHeaders || w.wroteBody {
+		w.writeTrailerFrame()
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	flushWriter(w.wrapped)
+}
+
+// writeTrailerFrame appends the trailer frame that terminates a gRPC-Web response.
+func (w *responseWriter) writeTrailerFrame() {
+	payload := encodeTrailers(w.extractTrailers())
+	frame := make([]byte, 5, 5+len(payload))
+	frame[0] = trailerFrameFlag
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	frame = append(frame, payload...)
+	w.wrapped.Write(frame)
+	flushWriter(w.wrapped)
+}
+
+// extractTrailers returns the headers the gRPC handler set after the response headers
+// had already been flushed - grpc-status, grpc-message and anything the handler sent
+// as an undeclared trailer.
+func (w *responseWriter) extractTrailers() http.Header {
+	flushed := w.wrapped.Header()
+	trailers := make(http.Header)
+	for key, values := range w.headers {
+		if strings.EqualFold(key, "trailer") {
+			continue
+		}
+		if strings.Contains(key, http.TrailerPrefix) {
+			key = strings.Replace(key, http.TrailerPrefix, "", 1)
+		} else if _, alreadySent := flushed[http.CanonicalHeaderKey(key)]; alreadySent {
+			continue
+		}
+		// the gRPC-Web spec requires lower-case trailer names, and names that differ only
+		// in case have to merge rather than overwrite one another
+		key = strings.ToLower(key)
+		trailers[key] = append(trailers[key], values...)
+	}
+	return trailers
+}
+
+// encodeTrailers writes the trailer block as "key:value\r\n" pairs. The colon is not
+// followed by whitespace: RFC 7230 permits it, but receivers that split on ':' without
+// trimming then read grpc-status as " 0" and reject the response.
+func encodeTrailers(trailers http.Header) []byte {
+	keys := make([]string, 0, len(trailers))
+	for key := range trailers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	buf := new(bytes.Buffer)
+	for _, key := range keys {
+		for _, value := range trailers[key] {
+			buf.WriteString(key)
+			buf.WriteByte(':')
+			buf.WriteString(sanitizeFieldValue(value))
+			buf.WriteString("\r\n")
+		}
+	}
+	return buf.Bytes()
+}
+
+// sanitizeFieldValue strips the surrounding optional whitespace a receiver would have
+// to trim anyway, and replaces CR/LF, which would otherwise split one trailer into
+// several or truncate the block.
+func sanitizeFieldValue(value string) string {
+	if strings.ContainsAny(value, "\r\n") {
+		value = strings.NewReplacer("\r", " ", "\n", " ").Replace(value)
+	}
+	return strings.TrimSpace(value)
+}
+
+// base64ResponseWriter writes base64 encoded payloads for the grpc-web-text format.
+// Flush must be called to make the encoder emit its final segment.
+type base64ResponseWriter struct {
+	wrapped http.ResponseWriter
+	encoder io.WriteCloser
+}
+
+func newBase64ResponseWriter(wrapped http.ResponseWriter) http.ResponseWriter {
+	w := &base64ResponseWriter{wrapped: wrapped}
+	w.newEncoder()
+	return w
+}
+
+func (w *base64ResponseWriter) newEncoder() {
+	w.encoder = base64.NewEncoder(base64.StdEncoding, w.wrapped)
+}
+
+func (w *base64ResponseWriter) Header() http.Header {
+	return w.wrapped.Header()
+}
+
+func (w *base64ResponseWriter) Write(b []byte) (int, error) {
+	return w.encoder.Write(b)
+}
+
+func (w *base64ResponseWriter) WriteHeader(code int) {
+	w.wrapped.WriteHeader(code)
+}
+
+func (w *base64ResponseWriter) Flush() {
+	// closing the encoder flushes it; gRPC-Web allows multiple padded base64 parts
+	if err := w.encoder.Close(); err != nil {
+		// Flush cannot report an error
+		grpclog.Errorf("ignoring error flushing base64 encoder: %v", err)
+	}
+	w.newEncoder()
+	flushWriter(w.wrapped)
+}
+
+func flushWriter(w http.ResponseWriter) {
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// readerCloser pairs an io.Reader with the io.Closer of the reader it decorates.
+type readerCloser struct {
+	reader io.Reader
+	closer io.Closer
+}
+
+func (r *readerCloser) Read(dest []byte) (int, error) {
+	return r.reader.Read(dest)
+}
+
+func (r *readerCloser) Close() error {
+	return r.closer.Close()
+}

--- a/protocol/grpcwebcompat/grpcwebcompat_test.go
+++ b/protocol/grpcwebcompat/grpcwebcompat_test.go
@@ -1,0 +1,255 @@
+package grpcwebcompat
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testMethod = "/lavanet.test.Echo/Echo"
+
+// rawCodec passes message bytes through untouched, the way the gRPC gateway's proxy
+// codec does, so these tests do not need generated protobuf types.
+type rawCodec struct{}
+
+func (rawCodec) Marshal(v interface{}) ([]byte, error) { return v.([]byte), nil }
+
+func (rawCodec) Unmarshal(data []byte, v interface{}) error {
+	*(v.(*[]byte)) = data
+	return nil
+}
+func (rawCodec) Name() string   { return "lava/test-raw-codec" }
+func (rawCodec) String() string { return rawCodec{}.Name() }
+
+// newEchoServer returns a gRPC server that echoes the request back, sets a response
+// header and a trailer, and then fails with handlerErr when it is not nil. The message
+// is sent before the error so the status has to travel in the trailer frame; a handler
+// that fails without sending anything produces a Trailers-Only response instead.
+func newEchoServer(handlerErr error) *grpc.Server {
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		var reqBytes []byte
+		if err := stream.RecvMsg(&reqBytes); err != nil {
+			return err
+		}
+		// a value carrying the optional whitespace a misbehaving upstream may have added
+		stream.SetTrailer(metadata.Pairs("x-padded-trailer", "  padded  "))
+		if err := stream.SetHeader(metadata.Pairs("x-node-height", "12345")); err != nil {
+			return err
+		}
+		if err := stream.SendMsg(append([]byte("echo-"), reqBytes...)); err != nil {
+			return err
+		}
+		return handlerErr
+	}
+	return grpc.NewServer(grpc.UnknownServiceHandler(handler), grpc.ForceServerCodec(rawCodec{}))
+}
+
+// newFailFastServer returns a gRPC server that fails before writing anything, which is
+// what makes the wrapper emit a Trailers-Only response.
+func newFailFastServer(handlerErr error) *grpc.Server {
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		var reqBytes []byte
+		if err := stream.RecvMsg(&reqBytes); err != nil {
+			return err
+		}
+		return handlerErr
+	}
+	return grpc.NewServer(grpc.UnknownServiceHandler(handler), grpc.ForceServerCodec(rawCodec{}))
+}
+
+// grpcFrame wraps payload in a gRPC length prefixed frame.
+func grpcFrame(payload []byte) []byte {
+	frame := make([]byte, 5, 5+len(payload))
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(payload)))
+	return append(frame, payload...)
+}
+
+// splitFrames walks a gRPC-Web response body and separates the message frames from
+// the trailer frame (the one whose most significant flag bit is set).
+func splitFrames(t *testing.T, body []byte) (messages [][]byte, trailers []byte) {
+	t.Helper()
+	for len(body) > 0 {
+		require.GreaterOrEqual(t, len(body), 5, "truncated frame header")
+		flags := body[0]
+		length := int(binary.BigEndian.Uint32(body[1:5]))
+		require.GreaterOrEqual(t, len(body), 5+length, "truncated frame payload")
+		payload := body[5 : 5+length]
+		if flags&trailerFrameFlag != 0 {
+			require.Nil(t, trailers, "more than one trailer frame")
+			trailers = payload
+		} else {
+			messages = append(messages, payload)
+		}
+		body = body[5+length:]
+	}
+	return messages, trailers
+}
+
+// decodeGrpcWebText decodes a grpc-web-text body, which is a concatenation of
+// independently padded base64 segments.
+func decodeGrpcWebText(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var decoded []byte
+	for len(body) > 0 {
+		require.Zero(t, len(body)%4, "base64 body is not a multiple of 4 bytes")
+		segmentEnd := len(body)
+		for i := 0; i+4 <= len(body); i += 4 {
+			if bytes.ContainsRune(body[i:i+4], '=') {
+				segmentEnd = i + 4
+				break
+			}
+		}
+		segment, err := base64.StdEncoding.DecodeString(string(body[:segmentEnd]))
+		require.NoError(t, err)
+		decoded = append(decoded, segment...)
+		body = body[segmentEnd:]
+	}
+	return decoded
+}
+
+// doGrpcWebRequest performs a gRPC-Web call against handler and returns the response
+// along with the decoded body.
+func doGrpcWebRequest(t *testing.T, handler http.Handler, contentType string, payload []byte) (*http.Response, []byte) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	body := grpcFrame(payload)
+	if contentType == grpcWebTextContentType {
+		body = []byte(base64.StdEncoding.EncodeToString(body))
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+testMethod, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("content-type", contentType)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if contentType == grpcWebTextContentType {
+		raw = decodeGrpcWebText(t, raw)
+	}
+	return resp, raw
+}
+
+// TestTrailerFrameHasNoOptionalWhitespace is the regression test for the reported
+// failure: a trailer block written as "grpc-status: 0" is read as " 0" by receivers
+// that split on ':' without trimming, which rejects the call with
+// "transport: malformed grpc-status" and drops the message the caller already got.
+func TestTrailerFrameHasNoOptionalWhitespace(t *testing.T) {
+	for _, contentType := range []string{grpcWebContentType + "+proto", grpcWebTextContentType} {
+		t.Run(contentType, func(t *testing.T) {
+			resp, body := doGrpcWebRequest(t, WrapServer(newEchoServer(nil)), contentType, []byte("ping"))
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			messages, trailers := splitFrames(t, body)
+			require.Equal(t, [][]byte{[]byte("echo-ping")}, messages)
+			require.NotNil(t, trailers, "response is missing its trailer frame")
+
+			require.Contains(t, string(trailers), "grpc-status:0\r\n")
+			require.NotContains(t, string(trailers), "grpc-status: ")
+			// the padded trailer value is trimmed rather than passed on
+			require.Contains(t, string(trailers), "x-padded-trailer:padded\r\n")
+
+			// response headers are still copied through, with the gRPC-Web content type
+			require.Equal(t, "12345", resp.Header.Get("X-Node-Height"))
+			require.Equal(t, contentType, resp.Header.Get("Content-Type"))
+			require.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "grpc-status")
+		})
+	}
+}
+
+// TestTrailerFrameOnError checks a non-OK status is encoded the same way once the
+// response body has already started.
+func TestTrailerFrameOnError(t *testing.T) {
+	handlerErr := status.Error(codes.NotFound, "no such block")
+	resp, body := doGrpcWebRequest(t, WrapServer(newEchoServer(handlerErr)), grpcWebContentType+"+proto", []byte("ping"))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	messages, trailers := splitFrames(t, body)
+	require.Equal(t, [][]byte{[]byte("echo-ping")}, messages)
+	require.NotNil(t, trailers)
+	require.Contains(t, string(trailers), "grpc-status:5\r\n")
+	require.Contains(t, string(trailers), "grpc-message:no such block\r\n")
+	require.NotContains(t, string(trailers), ": ")
+}
+
+// TestTrailersOnlyResponse pins the shape of a call that fails before writing anything:
+// the gRPC-Web spec allows the trailers to be sent as response headers with no body, and
+// net/http serializes those, so they never pick up the stray whitespace.
+func TestTrailersOnlyResponse(t *testing.T) {
+	handlerErr := status.Error(codes.NotFound, "no such block")
+	resp, body := doGrpcWebRequest(t, WrapServer(newFailFastServer(handlerErr)), grpcWebContentType+"+proto", []byte("ping"))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, body)
+	require.Equal(t, "5", resp.Header.Get("Grpc-Status"))
+	require.Equal(t, "no such block", resp.Header.Get("Grpc-Message"))
+	// the transport's trailer declaration must not leak into a response that has none
+	require.Empty(t, resp.Header.Get("Trailer"))
+}
+
+// TestNativeGrpcIsUnaffected makes sure requests that are not gRPC-Web still reach the
+// wrapped gRPC server untouched.
+func TestNativeGrpcIsUnaffected(t *testing.T) {
+	grpcServer := newEchoServer(nil)
+	httpServer := &http.Server{Handler: h2c.NewHandler(WrapServer(grpcServer), &http2.Server{})}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go httpServer.Serve(lis)
+	t.Cleanup(func() { httpServer.Close() })
+
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(rawCodec{})))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var respBytes []byte
+	var trailer metadata.MD
+	require.NoError(t, conn.Invoke(ctx, testMethod, []byte("ping"), &respBytes, grpc.Trailer(&trailer)))
+	require.Equal(t, []byte("echo-ping"), respBytes)
+	require.Equal(t, []string{"  padded  "}, trailer.Get("x-padded-trailer"))
+}
+
+func TestIsGrpcWebRequest(t *testing.T) {
+	newRequest := func(method, contentType string) *http.Request {
+		req := httptest.NewRequest(method, testMethod, nil)
+		req.Header.Set("content-type", contentType)
+		return req
+	}
+	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebContentType)))
+	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebContentType+"+proto")))
+	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebTextContentType)))
+	require.False(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcContentType)))
+	require.False(t, IsGrpcWebRequest(newRequest(http.MethodGet, grpcWebContentType)))
+}
+
+func TestSanitizeFieldValue(t *testing.T) {
+	require.Equal(t, "0", sanitizeFieldValue(" 0"))
+	require.Equal(t, "0", sanitizeFieldValue("0\t"))
+	// CR and LF each become a space, matching net/http's own header serialization
+	require.Equal(t, "a  b", sanitizeFieldValue("a\r\nb"))
+	require.Equal(t, "", sanitizeFieldValue("   "))
+	require.Equal(t, "keep me", sanitizeFieldValue("keep me"))
+}

--- a/protocol/grpcwebcompat/grpcwebcompat_test.go
+++ b/protocol/grpcwebcompat/grpcwebcompat_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -28,10 +29,20 @@ const testMethod = "/lavanet.test.Echo/Echo"
 // codec does, so these tests do not need generated protobuf types.
 type rawCodec struct{}
 
-func (rawCodec) Marshal(v interface{}) ([]byte, error) { return v.([]byte), nil }
+func (rawCodec) Marshal(v interface{}) ([]byte, error) {
+	payload, ok := v.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("rawCodec cannot marshal %T", v)
+	}
+	return payload, nil
+}
 
 func (rawCodec) Unmarshal(data []byte, v interface{}) error {
-	*(v.(*[]byte)) = data
+	buffer, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("rawCodec cannot unmarshal into %T", v)
+	}
+	*buffer = data
 	return nil
 }
 func (rawCodec) Name() string   { return "lava/test-raw-codec" }
@@ -150,11 +161,11 @@ func doGrpcWebRequest(t *testing.T, handler http.Handler, contentType string, pa
 	return resp, raw
 }
 
-// TestTrailerFrameHasNoOptionalWhitespace is the regression test for the reported
+// TestEncodeTrailers_NoOptionalWhitespace is the regression test for the reported
 // failure: a trailer block written as "grpc-status: 0" is read as " 0" by receivers
 // that split on ':' without trimming, which rejects the call with
 // "transport: malformed grpc-status" and drops the message the caller already got.
-func TestTrailerFrameHasNoOptionalWhitespace(t *testing.T) {
+func TestEncodeTrailers_NoOptionalWhitespace(t *testing.T) {
 	for _, contentType := range []string{grpcWebContentType + "+proto", grpcWebTextContentType} {
 		t.Run(contentType, func(t *testing.T) {
 			resp, body := doGrpcWebRequest(t, WrapServer(newEchoServer(nil)), contentType, []byte("ping"))
@@ -177,9 +188,9 @@ func TestTrailerFrameHasNoOptionalWhitespace(t *testing.T) {
 	}
 }
 
-// TestTrailerFrameOnError checks a non-OK status is encoded the same way once the
+// TestEncodeTrailers_NonOKStatus checks a non-OK status is encoded the same way once the
 // response body has already started.
-func TestTrailerFrameOnError(t *testing.T) {
+func TestEncodeTrailers_NonOKStatus(t *testing.T) {
 	handlerErr := status.Error(codes.NotFound, "no such block")
 	resp, body := doGrpcWebRequest(t, WrapServer(newEchoServer(handlerErr)), grpcWebContentType+"+proto", []byte("ping"))
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -192,10 +203,10 @@ func TestTrailerFrameOnError(t *testing.T) {
 	require.NotContains(t, string(trailers), ": ")
 }
 
-// TestTrailersOnlyResponse pins the shape of a call that fails before writing anything:
+// TestResponseWriter_TrailersOnly pins the shape of a call that fails before writing anything:
 // the gRPC-Web spec allows the trailers to be sent as response headers with no body, and
 // net/http serializes those, so they never pick up the stray whitespace.
-func TestTrailersOnlyResponse(t *testing.T) {
+func TestResponseWriter_TrailersOnly(t *testing.T) {
 	handlerErr := status.Error(codes.NotFound, "no such block")
 	resp, body := doGrpcWebRequest(t, WrapServer(newFailFastServer(handlerErr)), grpcWebContentType+"+proto", []byte("ping"))
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -206,9 +217,9 @@ func TestTrailersOnlyResponse(t *testing.T) {
 	require.Empty(t, resp.Header.Get("Trailer"))
 }
 
-// TestNativeGrpcIsUnaffected makes sure requests that are not gRPC-Web still reach the
+// TestWrapServer_NativeGrpcPassthrough makes sure requests that are not gRPC-Web still reach the
 // wrapped gRPC server untouched.
-func TestNativeGrpcIsUnaffected(t *testing.T) {
+func TestWrapServer_NativeGrpcPassthrough(t *testing.T) {
 	grpcServer := newEchoServer(nil)
 	httpServer := &http.Server{Handler: h2c.NewHandler(WrapServer(grpcServer), &http2.Server{})}
 
@@ -232,24 +243,80 @@ func TestNativeGrpcIsUnaffected(t *testing.T) {
 	require.Equal(t, []string{"  padded  "}, trailer.Get("x-padded-trailer"))
 }
 
-func TestIsGrpcWebRequest(t *testing.T) {
-	newRequest := func(method, contentType string) *http.Request {
-		req := httptest.NewRequest(method, testMethod, nil)
-		req.Header.Set("content-type", contentType)
-		return req
-	}
-	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebContentType)))
-	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebContentType+"+proto")))
-	require.True(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcWebTextContentType)))
-	require.False(t, IsGrpcWebRequest(newRequest(http.MethodPost, grpcContentType)))
-	require.False(t, IsGrpcWebRequest(newRequest(http.MethodGet, grpcWebContentType)))
+// TestResponseContentType_NotReflectedFromRequest checks the response content type is assembled
+// from this package's constants. The request header is attacker controlled, so echoing
+// it back is a cross-site scripting sink.
+func TestResponseContentType_NotReflectedFromRequest(t *testing.T) {
+	hostile := grpcWebContentType + `+<script>alert(1)</script>`
+	resp, _ := doGrpcWebRequest(t, WrapServer(newEchoServer(nil)), hostile, []byte("ping"))
+
+	require.Equal(t, grpcWebContentType, resp.Header.Get("Content-Type"))
+	require.NotContains(t, resp.Header.Get("Content-Type"), "script")
 }
 
-func TestSanitizeFieldValue(t *testing.T) {
-	require.Equal(t, "0", sanitizeFieldValue(" 0"))
-	require.Equal(t, "0", sanitizeFieldValue("0\t"))
-	// CR and LF each become a space, matching net/http's own header serialization
-	require.Equal(t, "a  b", sanitizeFieldValue("a\r\nb"))
-	require.Equal(t, "", sanitizeFieldValue("   "))
-	require.Equal(t, "keep me", sanitizeFieldValue("keep me"))
+func TestResponseContentType_SubTypes(t *testing.T) {
+	playbook := []struct {
+		name      string
+		base      string
+		requested string
+		expected  string
+	}{
+		{"bare", grpcWebContentType, grpcWebContentType, grpcWebContentType},
+		{"proto", grpcWebContentType, grpcWebContentType + "+proto", grpcWebContentType + "+proto"},
+		{"json", grpcWebContentType, grpcWebContentType + "+json", grpcWebContentType + "+json"},
+		{"text", grpcWebTextContentType, grpcWebTextContentType, grpcWebTextContentType},
+		{"text proto", grpcWebTextContentType, grpcWebTextContentType + "+proto", grpcWebTextContentType + "+proto"},
+		// anything outside the known sub-types collapses to the base rather than echoing
+		{"unknown sub-type", grpcWebContentType, grpcWebContentType + "+<script>", grpcWebContentType},
+		{"empty", grpcWebContentType, "", grpcWebContentType},
+	}
+	for _, tt := range playbook {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, responseContentType(tt.base, tt.requested))
+		})
+	}
+}
+
+func TestIsGrpcWebRequest_MethodAndContentType(t *testing.T) {
+	playbook := []struct {
+		name        string
+		method      string
+		contentType string
+		expected    bool
+	}{
+		{"grpc-web", http.MethodPost, grpcWebContentType, true},
+		{"grpc-web proto", http.MethodPost, grpcWebContentType + "+proto", true},
+		{"grpc-web text", http.MethodPost, grpcWebTextContentType, true},
+		{"native grpc", http.MethodPost, grpcContentType, false},
+		{"not a post", http.MethodGet, grpcWebContentType, false},
+		// case sensitivity is deliberate: it mirrors the fallback's own predicate
+		{"mixed case", http.MethodPost, "Application/Grpc-Web", false},
+	}
+	for _, tt := range playbook {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, testMethod, nil)
+			req.Header.Set("content-type", tt.contentType)
+			require.Equal(t, tt.expected, isGrpcWebRequest(req))
+		})
+	}
+}
+
+func TestSanitizeFieldValue_Whitespace(t *testing.T) {
+	playbook := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"leading space", " 0", "0"},
+		{"trailing tab", "0\t", "0"},
+		// CR and LF each become a space, matching net/http's own header serialization
+		{"embedded crlf", "a\r\nb", "a  b"},
+		{"all whitespace", "   ", ""},
+		{"inner space kept", "keep me", "keep me"},
+	}
+	for _, tt := range playbook {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, sanitizeFieldValue(tt.value))
+		})
+	}
 }

--- a/protocol/performance/connection/connection_cmd.go
+++ b/protocol/performance/connection/connection_cmd.go
@@ -8,8 +8,8 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/lavanet/lava/v5/protocol/chainlib"
+	"github.com/lavanet/lava/v5/protocol/grpcwebcompat"
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/utils"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
@@ -50,7 +50,7 @@ func CreateTestConnectionServerCobraCommand() *cobra.Command {
 			serverSendMaxMessageSize := grpc.MaxSendMsgSize(1024 * 1024 * 512)    // setting send size to 512mb for large debug responses
 			grpcServer := grpc.NewServer(serverReceiveMaxMessageSize, serverSendMaxMessageSize)
 
-			wrappedServer := grpcweb.WrapServer(grpcServer)
+			wrappedServer := grpcwebcompat.WrapServer(grpcServer)
 			handler := func(resp http.ResponseWriter, req *http.Request) {
 				// Set CORS headers
 				resp.Header().Set("Access-Control-Allow-Origin", "*")

--- a/protocol/rpcprovider/provider_listener.go
+++ b/protocol/rpcprovider/provider_listener.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 
 	"github.com/gogo/status"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/lavanet/lava/v5/protocol/chainlib"
 	"github.com/lavanet/lava/v5/protocol/common"
+	"github.com/lavanet/lava/v5/protocol/grpcwebcompat"
 	"github.com/lavanet/lava/v5/protocol/lavaprotocol/protocolerrors"
 	"github.com/lavanet/lava/v5/protocol/lavasession"
 	"github.com/lavanet/lava/v5/utils"
@@ -70,7 +70,7 @@ func NewProviderListener(ctx context.Context, networkAddress lavasession.Network
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	}
 	grpcServer := grpc.NewServer(opts...)
-	wrappedServer := grpcweb.WrapServer(grpcServer)
+	wrappedServer := grpcwebcompat.WrapServer(grpcServer)
 	handler := func(resp http.ResponseWriter, req *http.Request) {
 		// Set CORS headers
 		resp.Header().Set("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
# Description

Adds a new `grpcwebcompat` package that wraps gRPC servers to serve gRPC-Web requests with canonically encoded trailer frames, fixing compatibility issues with strict gRPC-Web clients.

## Problem

The `github.com/improbable-eng/grpc-web` library encodes gRPC-Web trailer frames using `http.Header.Write()`, which emits headers as `"key: value\r\n"` with optional whitespace after the colon. While RFC 7230 allows this optional whitespace (OWS), receivers that naively split on `:` without trimming read `grpc-status` as `" 0"` (with leading space), causing parsing failures:

```
transport: malformed grpc-status: strconv.ParseInt: parsing " 0": invalid syntax
```

This surfaces as a Trailers-Only response with an Internal error and no message for the caller.

## Solution

The new `grpcwebcompat` package provides:

1. **`WrapServer()`** - Wraps a gRPC server for gRPC-Web with canonical trailer encoding
2. **`WrapHandler()`** - Routes gRPC-Web requests through a custom response writer while passing other requests to a fallback handler
3. **Canonical trailer encoding** - Emits trailers as `"key:value\r\n"` (no whitespace after colon) matching Envoy's reference implementation
4. **Value sanitization** - Strips surrounding whitespace and replaces CR/LF characters that would corrupt frame boundaries
5. **gRPC-Web-text support** - Handles base64-encoded payloads for text format requests
6. **Comprehensive test coverage** - Tests for both binary and text formats, error cases, and native gRPC passthrough

## Changes

- **New file**: `protocol/grpcwebcompat/grpcwebcompat.go` - Core implementation with request/response handling
- **New file**: `protocol/grpcwebcompat/grpcwebcompat_test.go` - Comprehensive test suite (255 lines)
- **Modified files**: Updated imports in `grpcproxy.go`, `chain_tracker.go`, `connection_cmd.go`, and `provider_listener.go` to use the new package instead of direct `grpcweb` dependency

The implementation maintains full compatibility with native gRPC requests and CORS pre-flights by delegating non-gRPC-Web requests to the wrapped handler.

## Test Coverage

- Trailer frame encoding without optional whitespace
- Error status encoding in trailer frames
- Trailers-Only responses (failures before body write)
- Native gRPC request passthrough
- Both `application/grpc-web` and `application/grpc-web-text` formats
- Field value sanitization (whitespace trimming, CR/LF replacement)

https://claude.ai/code/session_01ThUAjPPzmZ4wqSJcoyXPRm