### PR TITLE
fix(consumer): reject implausible seen block advances

### DIFF
--- a/protocol/integration/protocol_test.go
+++ b/protocol/integration/protocol_test.go
@@ -271,7 +271,7 @@ func createRpcConsumer(t *testing.T, ctx context.Context, rpcConsumerOptions rpc
 		}
 	}
 
-	consumerConsistency := relaycore.NewConsistency(rpcConsumerOptions.specId)
+	consumerConsistency := relaycore.NewConsistency(rpcConsumerOptions.specId, 0)
 	consumerCmdFlags := common.ConsumerCmdFlags{}
 	rpcconsumerLogs, err := metrics.NewRPCConsumerLogs(nil, nil, nil)
 	require.NoError(t, err)

--- a/protocol/relaycore/consistency.go
+++ b/protocol/relaycore/consistency.go
@@ -20,10 +20,13 @@ const (
 	// bursty block production, clock skew and provider spread never trip the guard —
 	// it is meant to reject values that are impossible, not merely surprising.
 	seenBlockAdvanceSafetyFactor = 4
-	// seenBlockAdvanceFloor is always accepted regardless of block time, so chains
-	// slower than EntryTTL per block (where the computed bound rounds to zero) and
-	// freshly-started chains are never gated.
-	seenBlockAdvanceFloor = 1000
+	// minSeenBlockAdvance keeps the bound usable on chains that produce less than one
+	// block per EntryTTL, where the computed bound truncates to zero and would reject
+	// every advance. It is deliberately small: a blanket allowance large enough for a
+	// fast chain would leave a slow one — BTC produces a block every 10 minutes —
+	// accepting jumps of days' worth of blocks, which is exactly what this guard is
+	// supposed to catch.
+	minSeenBlockAdvance = 16
 )
 
 // Consistency interface for managing block consistency
@@ -52,7 +55,10 @@ func (cc *ConsistencyImpl) maxPlausibleSeenBlockAdvance() int64 {
 		return math.MaxInt64
 	}
 	blocksWithinTTL := int64(EntryTTL / cc.averageBlockTime)
-	return blocksWithinTTL*seenBlockAdvanceSafetyFactor + seenBlockAdvanceFloor
+	if bound := blocksWithinTTL * seenBlockAdvanceSafetyFactor; bound > minSeenBlockAdvance {
+		return bound
+	}
+	return minSeenBlockAdvance
 }
 
 func (cc *ConsistencyImpl) SetLatestBlock(key string, block int64) {
@@ -85,7 +91,17 @@ func (cc *ConsistencyImpl) SetSeenBlockFromKey(blockSeen int64, key string) {
 	if cc == nil {
 		return
 	}
-	if block, found := cc.GetLatestBlock(key); found {
+	block, found := cc.GetLatestBlock(key)
+	if !found {
+		// Cache writes are applied asynchronously, so a value written moments ago may
+		// not be readable yet. Flush once and look again before concluding the entry is
+		// genuinely cold: relay responses are handled back-to-back, and treating a
+		// not-yet-visible baseline as absent would skip the guard for precisely the
+		// rapid successive updates it exists to police.
+		cc.cache.Wait()
+		block, found = cc.GetLatestBlock(key)
+	}
+	if found {
 		// seen block is only increasing
 		if block >= blockSeen {
 			return

--- a/protocol/relaycore/consistency.go
+++ b/protocol/relaycore/consistency.go
@@ -1,6 +1,7 @@
 package relaycore
 
 import (
+	"math"
 	"time"
 
 	"github.com/dgraph-io/ristretto/v2"
@@ -12,6 +13,17 @@ const (
 	CacheMaxCost     = 20000 // each item cost would be 1
 	CacheNumCounters = 20000 // expect 2000 items
 	EntryTTL         = 5 * time.Minute
+
+	// A seen block entry lives at most EntryTTL, so the largest advance a healthy
+	// chain can legitimately show between two updates is the number of blocks it
+	// produces in that window. seenBlockAdvanceSafetyFactor multiplies that bound so
+	// bursty block production, clock skew and provider spread never trip the guard —
+	// it is meant to reject values that are impossible, not merely surprising.
+	seenBlockAdvanceSafetyFactor = 4
+	// seenBlockAdvanceFloor is always accepted regardless of block time, so chains
+	// slower than EntryTTL per block (where the computed bound rounds to zero) and
+	// freshly-started chains are never gated.
+	seenBlockAdvanceFloor = 1000
 )
 
 // Consistency interface for managing block consistency
@@ -24,8 +36,23 @@ type Consistency interface {
 
 // ConsistencyImpl is the default implementation of Consistency
 type ConsistencyImpl struct {
-	cache  *ristretto.Cache[string, any]
-	specId string
+	cache            *ristretto.Cache[string, any]
+	specId           string
+	averageBlockTime time.Duration
+}
+
+// maxPlausibleSeenBlockAdvance is the largest jump in seen block this chain could
+// legitimately produce within the lifetime of a cache entry. Anything beyond it did
+// not come from the chain advancing.
+//
+// A zero or negative average block time means the chain's cadence is unknown, so the
+// guard fails open rather than gating on a number it cannot justify.
+func (cc *ConsistencyImpl) maxPlausibleSeenBlockAdvance() int64 {
+	if cc.averageBlockTime <= 0 {
+		return math.MaxInt64
+	}
+	blocksWithinTTL := int64(EntryTTL / cc.averageBlockTime)
+	return blocksWithinTTL*seenBlockAdvanceSafetyFactor + seenBlockAdvanceFloor
 }
 
 func (cc *ConsistencyImpl) SetLatestBlock(key string, block int64) {
@@ -58,9 +85,28 @@ func (cc *ConsistencyImpl) SetSeenBlockFromKey(blockSeen int64, key string) {
 	if cc == nil {
 		return
 	}
-	// seen block is only increasing
-	if block, found := cc.GetLatestBlock(key); found && block >= blockSeen {
-		return
+	if block, found := cc.GetLatestBlock(key); found {
+		// seen block is only increasing
+		if block >= blockSeen {
+			return
+		}
+		// The seen block is taken from whatever a provider reports as its latest block
+		// and is then sent to every other provider, which bail when they cannot reach
+		// it. A single provider reporting a value from outside this chain's numeric
+		// domain — a different unit, a bug, or a deliberately inflated number — would
+		// otherwise pin the seen block out of reach and make every honest provider look
+		// hopelessly behind, for the lifetime of the entry.
+		if advance := blockSeen - block; advance > cc.maxPlausibleSeenBlockAdvance() {
+			utils.LavaFormatWarning("discarding implausible seen block advance", nil,
+				utils.LogAttr("specId", cc.specId),
+				utils.LogAttr("storedSeenBlock", block),
+				utils.LogAttr("reportedSeenBlock", blockSeen),
+				utils.LogAttr("advance", advance),
+				utils.LogAttr("maxPlausibleAdvance", cc.maxPlausibleSeenBlockAdvance()),
+				utils.LogAttr("averageBlockTime", cc.averageBlockTime),
+			)
+			return
+		}
 	}
 	cc.SetLatestBlock(key, blockSeen)
 }
@@ -83,10 +129,13 @@ func (cc *ConsistencyImpl) GetSeenBlock(userData common.UserData) (int64, bool) 
 	return cc.GetLatestBlock(cc.Key(userData))
 }
 
-func NewConsistency(specId string) Consistency {
+// NewConsistency builds the per-chain seen block store. averageBlockTime comes from
+// the spec and bounds how far the seen block may advance at once; pass 0 when it is
+// not known, which disables that guard.
+func NewConsistency(specId string, averageBlockTime time.Duration) Consistency {
 	cache, err := ristretto.NewCache(&ristretto.Config[string, any]{NumCounters: CacheNumCounters, MaxCost: CacheMaxCost, BufferItems: 64, IgnoreInternalCost: true})
 	if err != nil {
 		utils.LavaFormatFatal("failed setting up cache for consistency", err)
 	}
-	return &ConsistencyImpl{cache: cache, specId: specId}
+	return &ConsistencyImpl{cache: cache, specId: specId, averageBlockTime: averageBlockTime}
 }

--- a/protocol/relaycore/consistency_test.go
+++ b/protocol/relaycore/consistency_test.go
@@ -15,12 +15,23 @@ func setupConsistency() Consistency {
 }
 
 // solanaBlockTime is SOLANA's average_block_time from the spec. At 400ms the guard
-// admits 4*(5min/400ms)+1000 = 4000 blocks per update, far beyond anything the chain
-// can actually produce in an entry's lifetime.
+// admits 4*(5min/400ms) = 3000 blocks per update, far beyond anything the chain can
+// actually produce in an entry's lifetime.
 const solanaBlockTime = 400 * time.Millisecond
 
-// TestSeenBlockImplausibleAdvanceRejected covers the consumer-side defense against a
-// provider reporting a latest block from outside the chain's numeric domain.
+// setSeenBlockSync records a seen block and flushes the cache so the write is readable
+// before the test continues. Sleeping instead would make these tests depend on runner
+// scheduling, which is a source of intermittent CI failures rather than a guarantee.
+func setSeenBlockSync(t *testing.T, consistency Consistency, blockSeen int64, userData common.UserData) {
+	t.Helper()
+	consistency.SetSeenBlock(blockSeen, userData)
+	impl, ok := consistency.(*ConsistencyImpl)
+	require.True(t, ok, "expected *ConsistencyImpl")
+	impl.cache.Wait()
+}
+
+// TestConsistency_ImplausibleSeenBlockAdvanceRejected covers the consumer-side defense
+// against a provider reporting a latest block from outside the chain's numeric domain.
 //
 // The seen block is taken from a provider's reported latest block and then sent to
 // every other provider, which bail when they cannot reach it. Without this guard a
@@ -28,7 +39,7 @@ const solanaBlockTime = 400 * time.Millisecond
 // block out of reach and makes every honest provider look hopelessly behind for the
 // entry's lifetime. The Solana slot-vs-block-height gap (~22M) is the naturally
 // occurring instance.
-func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
+func TestConsistency_ImplausibleSeenBlockAdvanceRejected(t *testing.T) {
 	const (
 		blockHeightDomain = int64(414654108) // what a pre-fix provider reports
 		slotDomain        = int64(436597938) // what a post-fix provider reports
@@ -37,11 +48,8 @@ func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
 
 	t.Run("cross-domain jump is discarded", func(t *testing.T) {
 		consistency := NewConsistency("SOLANA", solanaBlockTime)
-		consistency.SetSeenBlock(blockHeightDomain, userData)
-		time.Sleep(4 * time.Millisecond)
-
-		consistency.SetSeenBlock(slotDomain, userData)
-		time.Sleep(4 * time.Millisecond)
+		setSeenBlockSync(t, consistency, blockHeightDomain, userData)
+		setSeenBlockSync(t, consistency, slotDomain, userData)
 
 		block, found := consistency.GetSeenBlock(userData)
 		require.True(t, found)
@@ -51,14 +59,12 @@ func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
 
 	t.Run("ordinary advance is still accepted", func(t *testing.T) {
 		consistency := NewConsistency("SOLANA", solanaBlockTime)
-		consistency.SetSeenBlock(slotDomain, userData)
-		time.Sleep(4 * time.Millisecond)
+		setSeenBlockSync(t, consistency, slotDomain, userData)
 
 		// A generous but realistic advance: more than the chain produces in an entry
 		// lifetime at 400ms, still nowhere near the domain gap.
 		advanced := slotDomain + 900
-		consistency.SetSeenBlock(advanced, userData)
-		time.Sleep(4 * time.Millisecond)
+		setSeenBlockSync(t, consistency, advanced, userData)
 
 		block, found := consistency.GetSeenBlock(userData)
 		require.True(t, found)
@@ -67,11 +73,8 @@ func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
 
 	t.Run("unknown block time fails open", func(t *testing.T) {
 		consistency := NewConsistency("test", 0)
-		consistency.SetSeenBlock(blockHeightDomain, userData)
-		time.Sleep(4 * time.Millisecond)
-
-		consistency.SetSeenBlock(slotDomain, userData)
-		time.Sleep(4 * time.Millisecond)
+		setSeenBlockSync(t, consistency, blockHeightDomain, userData)
+		setSeenBlockSync(t, consistency, slotDomain, userData)
 
 		block, found := consistency.GetSeenBlock(userData)
 		require.True(t, found)
@@ -83,8 +86,7 @@ func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
 		// Documents a known limit: the guard bounds advances, so a cold entry adopts
 		// whatever it is first told. Closing this needs a cross-provider signal.
 		consistency := NewConsistency("SOLANA", solanaBlockTime)
-		consistency.SetSeenBlock(slotDomain, userData)
-		time.Sleep(4 * time.Millisecond)
+		setSeenBlockSync(t, consistency, slotDomain, userData)
 
 		block, found := consistency.GetSeenBlock(userData)
 		require.True(t, found)
@@ -92,20 +94,80 @@ func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
 	})
 }
 
-func TestMaxPlausibleSeenBlockAdvance(t *testing.T) {
-	// 5min/400ms = 750 blocks in an entry lifetime, *4 safety, +1000 floor.
-	solana, ok := NewConsistency("SOLANA", solanaBlockTime).(*ConsistencyImpl)
-	require.True(t, ok)
-	require.Equal(t, int64(4000), solana.maxPlausibleSeenBlockAdvance())
+func TestConsistency_MaxPlausibleSeenBlockAdvance(t *testing.T) {
+	tests := []struct {
+		name             string
+		averageBlockTime time.Duration
+		expected         int64
+	}{
+		{
+			// 5min/400ms = 750 blocks in an entry lifetime, times the safety factor.
+			name:             "fast chain uses the computed bound",
+			averageBlockTime: solanaBlockTime,
+			expected:         3000,
+		},
+		{
+			// 5min/12s = 25 blocks, still far above any real provider spread.
+			name:             "medium chain uses the computed bound",
+			averageBlockTime: 12 * time.Second,
+			expected:         100,
+		},
+		{
+			// BTC produces a block every 10 minutes, so fewer than one fits in the TTL
+			// and the computed bound truncates to zero. The minimum keeps the guard
+			// usable without handing slow chains a huge allowance — the bound stays far
+			// below the thousands of blocks a flat floor would have permitted.
+			name:             "chain slower than the TTL falls back to the minimum",
+			averageBlockTime: 10 * time.Minute,
+			expected:         minSeenBlockAdvance,
+		},
+		{
+			name:             "unknown block time disables the guard",
+			averageBlockTime: 0,
+			expected:         math.MaxInt64,
+		},
+	}
 
-	// A chain slower than the TTL per block rounds to zero and relies on the floor.
-	slow, ok := NewConsistency("SLOW", time.Hour).(*ConsistencyImpl)
-	require.True(t, ok)
-	require.Equal(t, int64(seenBlockAdvanceFloor), slow.maxPlausibleSeenBlockAdvance())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consistency, ok := NewConsistency("TEST", tt.averageBlockTime).(*ConsistencyImpl)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, consistency.maxPlausibleSeenBlockAdvance())
+		})
+	}
+}
 
-	unknown, ok := NewConsistency("UNKNOWN", 0).(*ConsistencyImpl)
+// TestConsistency_GuardAppliesToBackToBackUpdates exercises the ordering the relay
+// path actually produces: two updates for the same key with no flush between them,
+// which is how consecutive provider responses arrive.
+//
+// The hazard it covers is that cache writes are applied asynchronously, so the
+// baseline read at the start of the second update can miss a write that has not
+// drained yet — and a missing baseline skips the guard entirely. Honest caveat: the
+// window is narrow and the buffer drains quickly, so this test does not reliably
+// reproduce it, and it passes against code without the flush-and-recheck. It is kept
+// as an assertion of the ordering's outcome, not as a regression lock; the flush in
+// SetSeenBlockFromKey is what closes the window regardless of timing.
+func TestConsistency_GuardAppliesToBackToBackUpdates(t *testing.T) {
+	const (
+		baseline = int64(414654108)
+		poisoned = int64(436597938)
+	)
+	userData := common.UserData{DappId: "dapp", ConsumerIp: "1.1.1.1:443"}
+
+	consistency := NewConsistency("SOLANA", solanaBlockTime)
+	// No flush between the two calls: this is the ordering the relay path produces.
+	consistency.SetSeenBlock(baseline, userData)
+	consistency.SetSeenBlock(poisoned, userData)
+
+	impl, ok := consistency.(*ConsistencyImpl)
 	require.True(t, ok)
-	require.Equal(t, int64(math.MaxInt64), unknown.maxPlausibleSeenBlockAdvance())
+	impl.cache.Wait()
+
+	block, found := consistency.GetSeenBlock(userData)
+	require.True(t, found)
+	require.Equal(t, baseline, block,
+		"the guard must apply even when the baseline write has not drained yet")
 }
 
 func TestSetGet(t *testing.T) {

--- a/protocol/relaycore/consistency_test.go
+++ b/protocol/relaycore/consistency_test.go
@@ -1,6 +1,7 @@
 package relaycore
 
 import (
+	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -10,7 +11,101 @@ import (
 )
 
 func setupConsistency() Consistency {
-	return NewConsistency("test")
+	return NewConsistency("test", 0)
+}
+
+// solanaBlockTime is SOLANA's average_block_time from the spec. At 400ms the guard
+// admits 4*(5min/400ms)+1000 = 4000 blocks per update, far beyond anything the chain
+// can actually produce in an entry's lifetime.
+const solanaBlockTime = 400 * time.Millisecond
+
+// TestSeenBlockImplausibleAdvanceRejected covers the consumer-side defense against a
+// provider reporting a latest block from outside the chain's numeric domain.
+//
+// The seen block is taken from a provider's reported latest block and then sent to
+// every other provider, which bail when they cannot reach it. Without this guard a
+// single provider — buggy, adversarial, or reporting a different unit — pins the seen
+// block out of reach and makes every honest provider look hopelessly behind for the
+// entry's lifetime. The Solana slot-vs-block-height gap (~22M) is the naturally
+// occurring instance.
+func TestSeenBlockImplausibleAdvanceRejected(t *testing.T) {
+	const (
+		blockHeightDomain = int64(414654108) // what a pre-fix provider reports
+		slotDomain        = int64(436597938) // what a post-fix provider reports
+	)
+	userData := common.UserData{DappId: "dapp", ConsumerIp: "1.1.1.1:443"}
+
+	t.Run("cross-domain jump is discarded", func(t *testing.T) {
+		consistency := NewConsistency("SOLANA", solanaBlockTime)
+		consistency.SetSeenBlock(blockHeightDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		consistency.SetSeenBlock(slotDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		block, found := consistency.GetSeenBlock(userData)
+		require.True(t, found)
+		require.Equal(t, blockHeightDomain, block,
+			"a ~22M jump cannot come from the chain advancing and must not pin the seen block")
+	})
+
+	t.Run("ordinary advance is still accepted", func(t *testing.T) {
+		consistency := NewConsistency("SOLANA", solanaBlockTime)
+		consistency.SetSeenBlock(slotDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		// A generous but realistic advance: more than the chain produces in an entry
+		// lifetime at 400ms, still nowhere near the domain gap.
+		advanced := slotDomain + 900
+		consistency.SetSeenBlock(advanced, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		block, found := consistency.GetSeenBlock(userData)
+		require.True(t, found)
+		require.Equal(t, advanced, block, "normal chain progress must not be gated")
+	})
+
+	t.Run("unknown block time fails open", func(t *testing.T) {
+		consistency := NewConsistency("test", 0)
+		consistency.SetSeenBlock(blockHeightDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		consistency.SetSeenBlock(slotDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		block, found := consistency.GetSeenBlock(userData)
+		require.True(t, found)
+		require.Equal(t, slotDomain, block,
+			"with no average block time the guard cannot justify a bound and must not gate")
+	})
+
+	t.Run("first value has no baseline to check against", func(t *testing.T) {
+		// Documents a known limit: the guard bounds advances, so a cold entry adopts
+		// whatever it is first told. Closing this needs a cross-provider signal.
+		consistency := NewConsistency("SOLANA", solanaBlockTime)
+		consistency.SetSeenBlock(slotDomain, userData)
+		time.Sleep(4 * time.Millisecond)
+
+		block, found := consistency.GetSeenBlock(userData)
+		require.True(t, found)
+		require.Equal(t, slotDomain, block)
+	})
+}
+
+func TestMaxPlausibleSeenBlockAdvance(t *testing.T) {
+	// 5min/400ms = 750 blocks in an entry lifetime, *4 safety, +1000 floor.
+	solana, ok := NewConsistency("SOLANA", solanaBlockTime).(*ConsistencyImpl)
+	require.True(t, ok)
+	require.Equal(t, int64(4000), solana.maxPlausibleSeenBlockAdvance())
+
+	// A chain slower than the TTL per block rounds to zero and relies on the floor.
+	slow, ok := NewConsistency("SLOW", time.Hour).(*ConsistencyImpl)
+	require.True(t, ok)
+	require.Equal(t, int64(seenBlockAdvanceFloor), slow.maxPlausibleSeenBlockAdvance())
+
+	unknown, ok := NewConsistency("UNKNOWN", 0).(*ConsistencyImpl)
+	require.True(t, ok)
+	require.Equal(t, int64(math.MaxInt64), unknown.maxPlausibleSeenBlockAdvance())
 }
 
 func TestSetGet(t *testing.T) {

--- a/protocol/relaycore/relay_processor_test.go
+++ b/protocol/relaycore/relay_processor_test.go
@@ -107,7 +107,7 @@ func TestRelayProcessorHappyFlow(t *testing.T) {
 		dappId := "dapp"
 		consumerIp := "123.11"
 		protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, dappId, consumerIp)
-		consistency := NewConsistency(specId)
+		consistency := NewConsistency(specId, 0)
 		usedProviders := lavasession.NewUsedProviders(nil)
 		relayProcessor := NewRelayProcessor(ctx, nil, consistency, RelayProcessorMetrics, RelayProcessorMetrics, RelayRetriesManagerInstance, newMockRelayStateMachine(protocolMessage, usedProviders))
 

--- a/protocol/rpcconsumer/consumer_relay_state_machine_test.go
+++ b/protocol/rpcconsumer/consumer_relay_state_machine_test.go
@@ -251,7 +251,7 @@ func TestConsumerStateMachineHappyFlow(t *testing.T) {
 		dappId := "dapp"
 		consumerIp := "123.11"
 		protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, dappId, consumerIp)
-		consistency := relaycore.NewConsistency(specId)
+		consistency := relaycore.NewConsistency(specId, 0)
 		usedProviders := lavasession.NewUsedProviders(nil)
 		stateMachine, err := NewRelayStateMachine(ctx, usedProviders, &ConsumerRelaySenderMock{retValue: nil}, protocolMessage, nil, false)
 		require.NoError(t, err)
@@ -324,7 +324,7 @@ func TestConsumerStateMachineExhaustRetries(t *testing.T) {
 		dappId := "dapp"
 		consumerIp := "123.11"
 		protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, nil, dappId, consumerIp)
-		consistency := relaycore.NewConsistency(specId)
+		consistency := relaycore.NewConsistency(specId, 0)
 		usedProviders := lavasession.NewUsedProviders(nil)
 		stateMachine, err := NewRelayStateMachine(ctx, usedProviders, &ConsumerRelaySenderMock{retValue: nil, tickerValue: 10 * time.Second}, protocolMessage, nil, false)
 		require.NoError(t, err)
@@ -394,7 +394,7 @@ func TestConsumerStateMachineArchiveRetry(t *testing.T) {
 
 		relayRequestData := lavaprotocol.NewRelayData(ctx, http.MethodPost, "", jsonData, seenBlock, reqBlock, spectypes.APIInterfaceJsonRPC, chainMsg.GetRPCMessage().GetHeaders(), chainlib.GetAddon(chainMsg), common.GetExtensionNames(chainMsg.GetExtensions()))
 		protocolMessage := chainlib.NewProtocolMessage(chainMsg, nil, relayRequestData, dappId, consumerIp)
-		consistency := relaycore.NewConsistency(specId)
+		consistency := relaycore.NewConsistency(specId, 0)
 		usedProviders := lavasession.NewUsedProviders(nil)
 		stateMachine, err := NewRelayStateMachine(
 			ctx,
@@ -500,7 +500,7 @@ func TestConsumerStateMachineBatchRequestRetryCondition(t *testing.T) {
 		require.True(t, ok, "expected ConsumerRelayStateMachine")
 
 		// Create a mock results checker
-		consistency := relaycore.NewConsistency(specId)
+		consistency := relaycore.NewConsistency(specId, 0)
 		relayProcessor := relaycore.NewRelayProcessor(
 			ctx,
 			nil, // Stateless mode - no cross-validation params

--- a/protocol/rpcconsumer/rpcconsumer.go
+++ b/protocol/rpcconsumer/rpcconsumer.go
@@ -503,7 +503,7 @@ func (rpcc *RPCConsumer) CreateConsumerEndpoint(
 		}
 
 		// Create / Use existing Consistency
-		newConsumerConsistency := relaycore.NewConsistency(chainID)
+		newConsumerConsistency := relaycore.NewConsistency(chainID, averageBlockTime)
 		consumerConsistency, _, err = consumerConsistencies.LoadOrStore(chainID, newConsumerConsistency)
 		if err != nil {
 			return utils.LavaFormatError("failed loading consumer consistency", err, utils.LogAttr("endpoint", rpcEndpoint.Key()))

--- a/protocol/rpcconsumer/rpcconsumer_server_test.go
+++ b/protocol/rpcconsumer/rpcconsumer_server_test.go
@@ -92,7 +92,7 @@ func createRpcConsumer(t *testing.T, ctrl *gomock.Controller, ctx context.Contex
 		},
 	}, nil)
 
-	consumerConsistency := relaycore.NewConsistency(specId)
+	consumerConsistency := relaycore.NewConsistency(specId, 0)
 	consumerCmdFlags := common.ConsumerCmdFlags{
 		RelaysHealthEnableFlag: false,
 	}


### PR DESCRIPTION
# Description

The consumer takes `seenBlock` from whatever a provider reports as its latest block, ratchets it monotonically, and then sends it to every other provider — where `handleConsistency` makes them bail when they cannot reach it. Nothing validated that number anywhere in the consumer path.

So a single provider reporting a value from outside the chain's numeric domain — a different unit, a bug, or a deliberately inflated number — pins the seen block out of reach and makes every honest provider look hopelessly behind, for the lifetime of the entry. With cache-be in shared-state mode the poisoned value also propagates across consumer processes and survives an hour rather than five minutes.

## The fix

Bound the advance by what the chain can actually produce. A cache entry lives at most `EntryTTL`, so any legitimate advance fits inside the blocks produced in that window:

```
maxPlausibleAdvance = max(blocksWithinTTL * 4, 16)
    where blocksWithinTTL = EntryTTL / averageBlockTime
```

| chain | average block time | bound |
|---|---|---|
| SOLANA | 400ms | 3,000 |
| ETH1 | ~12s | 100 |
| BTC | 10min (fewer than one block per TTL) | 16 |

The bound is deliberately loose — its job is to reject the impossible, not to police normal provider spread or bursty block production. The minimum is deliberately *small*: an allowance sized for a fast chain would leave a slow one accepting jumps of days' worth of blocks, which is exactly what this guard exists to catch.

Two safety properties worth calling out:

* an unknown `averageBlockTime` **disables** the guard rather than gating on a number it cannot justify;
* the baseline is re-read after a cache flush when the first lookup misses. Cache writes are applied asynchronously, and treating a not-yet-visible baseline as absent would skip the guard for precisely the back-to-back updates it exists to police, since relay responses are handled one after another.

`averageBlockTime` was already in scope at the construction site (`rpcconsumer.go`), so this only widens `NewConsistency`.

## Most critical files to review

* `protocol/relaycore/consistency.go` — the guard, its bound, and the flush-and-recheck
* `protocol/relaycore/consistency_test.go` — new tests are table-driven and flush rather than sleep; the pre-existing tests pass unchanged

## Known limits

* **Cold entries.** This bounds *advances*, so an entry with no baseline still adopts whatever it is first told. Closing that needs a cross-provider reference; `LatestBlockEstimator` already keeps per-provider observations and a median, which is the natural source. Deliberately out of scope here.
* **The async test is not a regression lock.** `TestConsistency_GuardAppliesToBackToBackUpdates` asserts the ordering's outcome, but the write buffer drains quickly enough that it does not reliably reproduce the race and it passes without the flush. The flush is what closes the window; the test is documentation of the scenario, and its comment says so.

## Relationship to #2322

Independent and separately reviewable. #2322 (now merged) is provider-side (`chaintracker`, `rpcprovider`); this is consumer-side only. Neither depends on the other — this closes a standing exposure that exists regardless of the Solana work. Verified to merge cleanly on top of #2322.

---

## Author Checklist

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not needed; no wire or client behavior changes, and the guard is fail-open
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — no issue; found while analysing the rollout risk in #2322
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed — green; the one `test-protocol` failure was the pre-existing `protocol/lavasession` flake and passed on re-run of the identical commit

## Reviewers Checklist

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BqbitFAAqDiatYCs12prn