### PR TITLE
chore: bump target protocol version to 6.2.5

### DIFF
--- a/x/protocol/types/params.go
+++ b/x/protocol/types/params.go
@@ -11,8 +11,12 @@ import (
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
+// TARGET_VERSION is the protocol version lavap reports for itself, and together
+// with MIN_VERSION seeds the default protocol version params at genesis. It is
+// compiled into the binary rather than derived from the git tag, so it has to be
+// bumped by hand alongside a release.
 const (
-	TARGET_VERSION = "6.1.0"
+	TARGET_VERSION = "6.2.5"
 	MIN_VERSION    = "5.5.1"
 )
 


### PR DESCRIPTION
# Description

Updates the target protocol version from 6.1.0 to 6.2.5 in the protocol parameters.

`x/protocol/types/params.go` still declared `TARGET_VERSION = "6.1.0"` while the repo went on to release v6.2.0 through v6.2.4. The tag `v6.2.4` points at `e293c30`, the current tip of `main`, which still carried `6.1.0`.

This is not purely cosmetic: `protocol/upgrade/protocol_version.go` seeds the binary's self-reported protocol version from this constant rather than from the git ldflags version, so the shipped `lavap` reports the stale value in:

* `lavap version` / `lavavisor` output
* the provider relay trailer and consumer relay metadata
* the `lava_provider_protocol_version` / `lava_consumer_protocol_version` gauges
* the startup `lavap Binary Version:` log line

`lavad` is unaffected — it uses the ldflags version and reports the tag correctly.

Because the constant is compiled in, the already-published v6.2.4 binaries and `ghcr.io` images cannot be corrected in place. This targets **6.2.5** instead, to be picked up by the next tag.

`MIN_VERSION` is deliberately left at `5.5.1` — it remains valid below the target, and raising it would drop support for older providers and consumers.

Note that this constant only seeds the genesis default. Moving the live network's required version is a separate governance action (`lavad tx protocol set-version`).

---

## Author Checklist

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

https://claude.ai/code/session_0117V1emoRbzp5M19LFjnVs3