### PR TITLE
 fix(specs): align AVALANCHEC debug addon and AVALANCHEP methods with avalanchego

### DIFF
--- a/specs/mainnet-1/specs/avalanche_c.json
+++ b/specs/mainnet-1/specs/avalanche_c.json
@@ -66,7 +66,13 @@
                             "type": "POST",
                             "add_on": "debug"
                         },
-                        "apis": [],
+                        "apis": [
+                            {
+                                "name": "debug_traceBlock",
+                                "compute_units": 1,
+                                "enabled": false
+                            }
+                        ],
                         "headers": [],
                         "inheritance_apis": [
                             {

--- a/specs/mainnet-1/specs/avalanche_p.json
+++ b/specs/mainnet-1/specs/avalanche_p.json
@@ -29,6 +29,24 @@
                         },
                         "apis": [
                             {
+                                "name": "platform.getBalance",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "platform.getBlock",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -79,6 +97,24 @@
                                 "category": {
                                     "deterministic": false,
                                     "local": true,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "platform.getBlockchains",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
                                     "subscription": false,
                                     "stateful": 0
                                 },
@@ -211,6 +247,42 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "platform.getRewardUTXOs",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "platform.getStake",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 15,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "platform.getMinStake",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -248,6 +320,24 @@
                             },
                             {
                                 "name": "platform.getSubnet",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "platform.getSubnets",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"


### PR DESCRIPTION
Closes: N/A (no tracking issue, found while auditing the Avalanche specs against avalanchego and coreth)

This PR makes two small corrections to the Avalanche specs in `specs/mainnet-1/specs`.

**AVALANCHEC (`avalanche_c.json`)**

AVALANCHEC inherits the ETH1 debug collection, which includes `debug_traceBlock`. Coreth's tracer API only exposes `traceBlockByNumber`, `traceBlockByHash`, `traceCall`, `traceTransaction`, `traceBadBlock` and `traceChain`, so every `debug_traceBlock` relay currently ends as a node error on the provider. The method is now overridden with `enabled: false` in the `/C/rpc` debug collection, the same pattern `avalanche.json` already uses for methods coreth does not implement. Everything else in the inherited debug collection stays as is, including the `debug_getRaw*` family that the `enabled` verification relies on; those exist in coreth under the `internal-debug` api.

**AVALANCHEP (`avalanche_p.json`)**

The mainnet spec was missing five methods that avalanchego serves on the platform chain: `platform.getBalance`, `platform.getBlockchains`, `platform.getRewardUTXOs`, `platform.getStake` and `platform.getSubnets`. Four of them were added to the testnet-2 spec in #2305 but never made it to mainnet-1, so the two files had drifted. All five are added with the same block parsing, categories and compute units as the neighbouring methods. With this the spec covers the complete public `platform.*` service.

**Scope and risk**

Both changes are either additive or disable a single method. No verifications, parse directives, extensions, collection flags or existing compute units are touched. AVALANCHECT and AVALANCHEPT pick the changes up through inheritance.

Files to review: `specs/mainnet-1/specs/avalanche_c.json`, `specs/mainnet-1/specs/avalanche_p.json`.

**Verification**

Loaded `ethereum.json`, `avalanche.json`, `avalanche_c.json` and `avalanche_p.json` into the spec keeper and ran `ExpandSpec` plus `ValidateSpec` for AVAX, AVAXT, AVALANCHEC, AVALANCHECT, AVALANCHEP and AVALANCHEPT. All six expand and validate, and the expanded AVALANCHEC debug collection shows only `debug_traceBlock` disabled. `go test ./x/spec/... ./utils/keeper/...` passes. Method lists were checked against coreth (`eth/tracers/api.go`, `internal/ethapi/api.go`, `eth/api_debug.go`) and avalanchego (`vms/platformvm/service.go`).

---

## Author Checklist

*All items are required. Please ade item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type
prefix](https://github.com/commitipes/blob/v3.0.0/index.json) in the
PR title, you can find examples of
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only c
    * `style`: Changes that do not code (white-space, formatting,
missing semi-colons, etc)
    * `refactor`: A code change th adds a feature    * `perf`: A code change that i    * `test`: Adding missing testssts    * `build`: Changes that affectnal dependencies (example scopes:gulp, broccoli, npm)
    * `ci`: Changes to our CI confs (example scopes: Travis, Circle,
BrowserStack, SauceLabs)
    * `chore`: Other changes that iles
    * `revert`: Reverts a previous * [x] confirmed `!` in the type prking change (not breaking, no `!`) * [x] targeted the `main` branch * [x] provided a link to the relev (no issue; references to coreth and avalanchego sources are in the des
* [x] reviewed "Files changed" andy
* [x] included the necessary unit c only change, covered by the
existing spec validation; no new t
* [x] updated the relevant documenncluding comments for [documenting
Go code](https://blog.golang.org/gs are the change)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviselected items.*

I have...

* [ ] confirmed the correct [typeprefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklied
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and
test coverage