### PR TITLE
fix: classify archive-unavailable REST 4xx as node errors, not successful relays

### DIFF
--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy"
 	"github.com/lavanet/lava/v5/protocol/chainlib/chainproxy/rpcclient"
+	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/protocol/parser"
 	"github.com/lavanet/lava/v5/utils"
 	"github.com/lavanet/lava/v5/utils/sigs"
@@ -66,7 +67,24 @@ func (jm RestMessage) CheckResponseError(data []byte, httpStatusCode int) (hasEr
 		return false, ""
 	}
 
-	// 4xx (except 429) are client errors — not node errors, pass through to consumer
+	// 4xx (except 429) are client errors by default — not node errors, pass
+	// through to the consumer. The exception is a node that reports its own
+	// inability to serve a well-formed request with a client-error status: an
+	// archive endpoint that does not hold the requested depth answers HTTP 400
+	// even though the block exists and a peer serves the identical request.
+	// Only response bodies the shared error registry recognises as node- or
+	// chain-attributed flip to a node error; the status code alone never does,
+	// so ordinary 400/404/405 responses keep passing straight through.
+	//
+	// Scoped to 4xx rather than to "everything that reached here" so 1xx and 3xx
+	// keep their existing pass-through behaviour untouched.
+	if httpStatusCode >= 400 && httpStatusCode < 500 {
+		errorMessage = extractErrorMessage(data, httpStatusCode)
+		if common.ClassifyRESTClientErrorStatus(errorMessage) != nil {
+			return true, errorMessage
+		}
+	}
+
 	return false, ""
 }
 

--- a/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
+++ b/protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage_test.go
@@ -642,3 +642,141 @@ func TestCheckResponseError_ServerErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckResponseError_ArchiveDepthBoundary covers the AXELAR/AXELART archive
+// regression: a provider advertising the `archive` extension answers a deep
+// historical read with HTTP 400 and a Cosmos SDK "height is bigger then the
+// chain length" body. The block exists — peer providers return 200 with a valid
+// block for the identical height and path — so the failure belongs to the node,
+// not the client, and must be reported as a node error so the relay is retried
+// against another provider instead of being recorded as a success.
+func TestCheckResponseError_ArchiveDepthBoundary(t *testing.T) {
+	// The exact body observed in production, verbatim including the upstream
+	// "then" typo.
+	const axelarArchiveBody = `{"code":3,"message":"rpc error: code = InvalidArgument desc = requested block height is bigger then the chain length: invalid request"}`
+
+	testCases := []struct {
+		name          string
+		httpStatus    int
+		response      string
+		expectedError bool
+		expectMessage string
+	}{
+		{
+			name:          "400 archive depth boundary (the reported bug)",
+			httpStatus:    400,
+			response:      axelarArchiveBody,
+			expectedError: true,
+			expectMessage: "requested block height is bigger then the chain length",
+		},
+		{
+			name:          "400 archive depth boundary with the typo corrected upstream",
+			httpStatus:    400,
+			response:      `{"message":"requested block height is bigger than the chain length"}`,
+			expectedError: true,
+			expectMessage: "bigger than the chain length",
+		},
+		{
+			name:          "404 carrying the same node-side body",
+			httpStatus:    404,
+			response:      axelarArchiveBody,
+			expectedError: true,
+			expectMessage: "chain length",
+		},
+		{
+			name:          "matching is case-insensitive",
+			httpStatus:    400,
+			response:      `{"message":"Requested Block Height Is Bigger Then The Chain Length"}`,
+			expectedError: true,
+		},
+		{
+			name:          "plain-text body is matched too",
+			httpStatus:    400,
+			response:      `requested block height is bigger then the chain length`,
+			expectedError: true,
+		},
+
+		// --- Negative cases: the status code alone must never flip the verdict.
+		{
+			name:          "400 genuine client error stays a client error",
+			httpStatus:    400,
+			response:      `{"error":"invalid request"}`,
+			expectedError: false,
+		},
+		{
+			name:          "400 malformed address stays a client error",
+			httpStatus:    400,
+			response:      `{"code":3,"message":"decoding bech32 failed: invalid checksum"}`,
+			expectedError: false,
+		},
+		{
+			name:          "404 endpoint not found stays a client error",
+			httpStatus:    404,
+			response:      `{"code":5,"message":"endpoint not found"}`,
+			expectedError: false,
+		},
+		{
+			name:          "404 block not found stays a client error",
+			httpStatus:    404,
+			response:      `{"code":5,"message":"block not found"}`,
+			expectedError: false,
+		},
+		{
+			name:          "405 method not allowed stays a client error",
+			httpStatus:    405,
+			response:      `{"message":"method not allowed"}`,
+			expectedError: false,
+		},
+		{
+			name:          "403 forbidden stays a client error",
+			httpStatus:    403,
+			response:      `{"message":"forbidden"}`,
+			expectedError: false,
+		},
+		{
+			name:          "400 with an empty body stays a client error",
+			httpStatus:    400,
+			response:      ``,
+			expectedError: false,
+		},
+		{
+			name:          "400 with a non-JSON body stays a client error",
+			httpStatus:    400,
+			response:      `<html><body>Bad Request</body></html>`,
+			expectedError: false,
+		},
+		{
+			name:          "200 carrying the node-side phrase is untouched",
+			httpStatus:    200,
+			response:      `{"message":"requested block height is bigger then the chain length"}`,
+			expectedError: false,
+		},
+		{
+			// The gate is scoped to 4xx, so redirects keep their previous
+			// pass-through behaviour even if the body were to match.
+			name:          "302 carrying the node-side phrase is untouched",
+			httpStatus:    302,
+			response:      `{"message":"requested block height is bigger then the chain length"}`,
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			restMsg := RestMessage{}
+
+			hasError, errorMessage := restMsg.CheckResponseError([]byte(tc.response), tc.httpStatus)
+
+			require.Equal(t, tc.expectedError, hasError,
+				"expected node error=%v for HTTP %d body %s", tc.expectedError, tc.httpStatus, tc.response)
+
+			if tc.expectMessage != "" {
+				require.Contains(t, errorMessage, tc.expectMessage,
+					"node error must carry the node's own message through for logging and classification")
+			}
+			if !tc.expectedError {
+				require.Empty(t, errorMessage, "client errors must not report an error message")
+			}
+		})
+	}
+}

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -336,12 +336,76 @@ func httpStatusMessageMappings() []errorMapping {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// HTTP 4xx bodies that actually blame the node
+// ---------------------------------------------------------------------------
+
+// A 4xx status conventionally means the client sent a bad request, so REST
+// responses in that range are passed through to the consumer rather than being
+// treated as node errors. Some nodes break that convention and report their own
+// inability to serve a well-formed request with a 4xx. An archive endpoint that
+// does not actually hold the requested depth is the case this list exists for.
+//
+// Entries here are matched against the RESPONSE BODY ONLY, never the status
+// code. That restriction is the whole safety argument: this list is appended to
+// the REST bucket by init(), but ClassifyRESTClientErrorStatus walks it directly
+// with errorCode 0 rather than running genericErrorMappings[TransportREST],
+// because that bucket's CodeEquals/HTTPStatusContains matchers would re-classify
+// every 404 and 405 as a node error — a far broader behaviour change than the
+// one intended here.
+//
+// Keep entries phrase-specific. Each one must name a failure no well-formed
+// client request could provoke, because a false positive here converts a real
+// client error into a retry across every provider in the pairing list, billed
+// at full CU each time.
+var restClientErrorStatusNodeMappings = []errorMapping{
+	// Cosmos SDK / CometBFT: the requested height is past this node's own tip.
+	// Observed on AXELAR/AXELART REST endpoints that advertise the `archive`
+	// extension but are backed by a pruned or shallow node — the identical
+	// height and path return 200 with a valid block on a peer provider, so the
+	// block exists, the request is valid, and the failure is the node's.
+	// Full body: {"code":3,"message":"rpc error: code = InvalidArgument desc =
+	// requested block height is bigger then the chain length: invalid request"}
+	// "then" is the upstream typo; "than" covers it being corrected later.
+	{MessageRegex(`(?i)block height is bigger th(?:e|a)n the chain length`), LavaErrorChainDataNotAvailable},
+}
+
+// ClassifyRESTClientErrorStatus classifies the body of a REST response whose HTTP
+// status is a client error (4xx). It returns the node- or chain-attributed
+// LavaError when the body matches a known node-side failure, and nil otherwise.
+//
+// nil means "this really is a client error, pass it through" — which is the
+// answer for the overwhelming majority of 4xx responses and is why the caller
+// must treat nil as the default rather than the exception.
+func ClassifyRESTClientErrorStatus(message string) *LavaError {
+	if message == "" {
+		return nil
+	}
+	loweredMessage := strings.ToLower(message)
+	for _, mapping := range restClientErrorStatusNodeMappings {
+		// errorCode 0 deliberately: match on the body, never on the status.
+		if matchMapping(mapping.Matcher, 0, message, loweredMessage) {
+			return mapping.LavaError
+		}
+	}
+	return nil
+}
+
 // init is the ONLY place allowed to mutate genericErrorMappings. It runs before
 // any reader can observe the map, so the runtime invariant ("read-only after
 // package init") holds. Do not add mutations outside this function.
 func init() {
 	// Append shared HTTP status message matchers to JSON-RPC transport
 	genericErrorMappings[TransportJsonRPC] = append(genericErrorMappings[TransportJsonRPC], httpStatusMessageMappings()...)
+
+	// Append the 4xx-body node-error matchers to REST transport. They are
+	// phrase-specific and go in FIRST, ahead of the status-code matchers, so a
+	// body this list recognises is named as the node/chain error it is rather
+	// than being swallowed by a broader CodeEquals/HTTPStatusContains match.
+	// Without this the consumer would still retry correctly (an unmatched node
+	// error classifies as Unknown, which is retryable by default) but the error
+	// would be unnamed in logs and metrics.
+	genericErrorMappings[TransportREST] = append(genericErrorMappings[TransportREST], restClientErrorStatusNodeMappings...)
 
 	// Append both CodeEquals and HTTPStatusContains matchers to REST transport
 	genericErrorMappings[TransportREST] = append(genericErrorMappings[TransportREST], httpStatusCodeMappings()...)

--- a/protocol/common/error_registry_test.go
+++ b/protocol/common/error_registry_test.go
@@ -1102,3 +1102,83 @@ func checkShadow(t *testing.T, i, j int, a, b errorMapping) {
 			i, aCode.code, a.LavaError.Name, j, bCode.code, b.LavaError.Name)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// HTTP 4xx bodies that blame the node
+// ---------------------------------------------------------------------------
+
+// The Cosmos SDK body an archive-advertising node returns for a depth it cannot
+// serve, verbatim from production including the upstream "then" typo.
+const axelarArchiveDepthMessage = "rpc error: code = InvalidArgument desc = requested block height is bigger then the chain length: invalid request"
+
+func TestClassifyRESTClientErrorStatus_ArchiveDepthBoundary(t *testing.T) {
+	classification := ClassifyRESTClientErrorStatus(axelarArchiveDepthMessage)
+
+	require.NotNil(t, classification, "archive depth boundary must be recognised as a node-side failure")
+	require.Equal(t, LavaErrorChainDataNotAvailable, classification)
+	require.True(t, classification.Retryable,
+		"the block exists and peers serve it, so the relay must be retried against another provider")
+}
+
+func TestClassifyRESTClientErrorStatus_PassesThroughClientErrors(t *testing.T) {
+	// Nothing in this list may be claimed as a node error. The status code is
+	// never consulted, so these stand in for the whole 4xx range.
+	clientErrors := []string{
+		"",
+		"invalid request",
+		"bad request",
+		"decoding bech32 failed: invalid checksum",
+		"endpoint not found",
+		"route not found",
+		"method not allowed",
+		"block not found",
+		"forbidden",
+		"HTTP 400",
+		"<html><body>Bad Request</body></html>",
+	}
+
+	for _, message := range clientErrors {
+		t.Run(message, func(t *testing.T) {
+			require.Nil(t, ClassifyRESTClientErrorStatus(message),
+				"%q must stay a client error — a false positive here retries a doomed request across every provider at full CU", message)
+		})
+	}
+}
+
+// TestClassifyRESTClientErrorStatus_IgnoresStatusCodes pins the safety property
+// that separates this narrow fix from a broad "4xx are node errors" change: the
+// curated list is walked with errorCode 0, so the REST bucket's CodeEquals and
+// HTTPStatusContains matchers cannot fire. Were they to fire, every 404 would
+// resolve to NODE_ENDPOINT_NOT_FOUND and be re-classified as a node error.
+func TestClassifyRESTClientErrorStatus_IgnoresStatusCodes(t *testing.T) {
+	// 404 and 405 both have CodeEquals entries in the REST bucket and would
+	// match if the status code reached the matchers.
+	require.Nil(t, ClassifyRESTClientErrorStatus("404"))
+	require.Nil(t, ClassifyRESTClientErrorStatus("405"))
+	require.Nil(t, ClassifyRESTClientErrorStatus("HTTP status 404"))
+}
+
+// TestArchiveDepthBoundary_ConsumerPolicy asserts what the consumer does with the
+// classification once CheckResponseError flags it. Retrying is the fix; the CU
+// and jailing questions are deliberately left as they are, so this test fails if
+// a later change silently zeroes CU for this error class.
+func TestArchiveDepthBoundary_ConsumerPolicy(t *testing.T) {
+	classification := ClassifyNodeErrorForRetry(
+		ChainFamilyUnknown, TransportREST, 400, axelarArchiveDepthMessage,
+	)
+
+	require.False(t, classification.IsNonRetryable,
+		"must be retried against another provider — that is the entire point of the fix")
+	require.False(t, classification.IsUnsupportedMethod,
+		"must NOT take the zero-CU carve-out: whether this error class should be discounted is an open product decision, not one this change makes")
+}
+
+// TestArchiveDepthBoundary_NamedInRegistry proves the matcher is reachable through
+// the ordinary REST classification path, so the error is named in logs and metrics
+// rather than surfacing as UNKNOWN_ERROR.
+func TestArchiveDepthBoundary_NamedInRegistry(t *testing.T) {
+	classification := ClassifyError(nil, ChainFamilyUnknown, TransportREST, 400, axelarArchiveDepthMessage)
+
+	require.Equal(t, LavaErrorChainDataNotAvailable, classification)
+	require.NotEqual(t, LavaErrorUnknown, classification)
+}


### PR DESCRIPTION
# Description

REST archive requests on AXELAR/AXELART that fail with `HTTP 400` and a Cosmos SDK `requested block height is bigger then the chain length` body were classified as **client** errors. `RestMessage.CheckResponseError()` returned `hasError=false`, so the relay landed in `successResults`, was never retried against another provider, and was billed full CU including the archive multiplier (`block: 14800`, multiplier 5).

Reported by Sergey (Stake Village). The failure is the node's, not the client's: providers advertising the `archive` extension fail deep reads that **peer providers serve with HTTP 200 for the identical height and REST path**. The block exists and the request is well-formed.

Most critical files to review: `protocol/common/error_classifier.go` and `protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go`.

## Scope decision: narrow, not a broad 4xx re-classification

The bug report left this open — match the specific error text, or re-evaluate REST 4xx handling generally. **This PR takes the narrow option**, and the safety argument is worth stating because it is what the code is shaped around.

Re-classifying 4xx by *status* would be actively harmful. `genericErrorMappings[TransportREST]` carries `CodeEquals(404) → NODE_ENDPOINT_NOT_FOUND` and `CodeEquals(405) → NODE_METHOD_NOT_ALLOWED`, both node-attributed. Feeding the HTTP status to the registry from this path would therefore convert **every** 404 and 405 into a node error, turning genuine client mistakes into retries across the whole pairing list, billed at full CU each time.

So the new list is matched against the **response body only, with `errorCode` hardcoded to 0**. The status code never reaches a matcher. `TestClassifyRESTClientErrorStatus_IgnoresStatusCodes` pins this property directly.

## What changed

**`protocol/common/error_classifier.go`**
- New curated list `restClientErrorStatusNodeMappings` — 4xx response bodies that actually blame the node. One entry today: the Cosmos SDK / CometBFT height-past-tip message, as a regex covering both the upstream `then` typo and a future corrected `than`.
- New `ClassifyRESTClientErrorStatus(message)` — returns the node/chain `LavaError` for a recognised body, `nil` otherwise. `nil` is the answer for the overwhelming majority of 4xx and is documented as the default, not the exception.
- `init()` also appends the list to the REST bucket, ahead of the status-code matchers, so the error is **named** (`CHAIN_DATA_NOT_AVAILABLE`) in logs and metrics instead of surfacing as `UNKNOWN_ERROR`. Behaviour is identical either way — an unmatched node error classifies as `Unknown`, which is already retryable — this is purely observability.

**`protocol/chainlib/chainproxy/rpcInterfaceMessages/restMessage.go`**
- The 4xx fall-through now consults the registry on the extracted body. Gated to `400 ≤ status < 500`, so 1xx and 3xx keep their previous pass-through behaviour untouched.

## What this deliberately does *not* decide

The bug write-up flagged CU/tokenomics and jailing policy as product decisions. This PR does not make them:

| Behaviour | Before | After |
| --- | --- | --- |
| Retried against another provider | ❌ | ✅ |
| Named in node-error logs/metrics | ❌ | ✅ `CHAIN_DATA_NOT_AVAILABLE` |
| Reaches `ReportedProviders` node-error path | ❌ | ✅ |
| CU charged | full | **full, unchanged** |
| Unresponsive-provider jailing | no signal | **still no direct signal** |

The error resolves to `CHAIN_DATA_NOT_AVAILABLE` (`Retryable: true`) and is **not** routed through the `SubCategoryUnsupportedMethod` zero-CU carve-out. `TestArchiveDepthBoundary_ConsumerPolicy` asserts both, so it will fail loudly if a later change silently zeroes CU for this class rather than deciding it deliberately.

Open follow-ups, unchanged from the report:
- Should this error class be CU-discounted the way unsupported methods are?
- Should it feed unresponsive-provider jailing?
- Sibling phrasing (the standard SDK `height X must be less than or equal to the current blockchain height`, usually on tendermintrpc) is **not** matched here — deliberately out of scope for the narrow fix, easy to add to the same list.
- Provider-side root cause (pruned / misrouted archive backend) remains out of scope.

## A note on the existing tests

The bug write-up predicted that `TestCheckResponseError_HTTPStatusCodeVariations` and `TestCheckResponseError_ServerErrors` — which explicitly assert HTTP 400 → `false` — would have to change.

**They did not, and that is the point.** Their 400 cases (`{"error":"invalid request"}`, `{"message":"bad request"}`) and their 404 case (`{"code":5,"message":"block not found"}`) are all still client errors under the new gate, and still pass unmodified. That no existing expectation needed rewriting is the clearest evidence the change is as narrow as claimed. Note `block not found` is a matcher in the **JSON-RPC** bucket, not the REST one, so it does not leak in.

## Side effects worth a reviewer's eye

- **Provider side.** `provider_state_machine.go` `SendNodeMessage()` now sees `isNodeError=true` for this body and retries locally once before returning, then caches the failed request hash. Bounded and consistent with every other node error, but it is a real behaviour change on the provider.
- **`chain_fetcher.go:544`.** Archive verification will now treat this response as a node error. Arguably correct — the node genuinely cannot serve archive — but it changes provider startup/verification behaviour.
- **Cost.** `extractErrorMessage` now runs on 4xx responses, where previously it ran only on 5xx/429. One bounded JSON unmarshal on an error path.

## Verification

Locally:

```
go build ./protocol/...                                    # clean
go vet ./protocol/common/... ./protocol/chainlib/...        # clean
gofmt -l / gofumpt -l / goimports -l   (changed files)      # clean
misspell               (changed files)                      # clean
go test -count=1 ./protocol/common/... ./protocol/chainlib/... \
        ./protocol/relaycore/... ./protocol/relaypolicy/... \
        ./protocol/rpcprovider/... ./protocol/rpcconsumer/...  # all pass
```

New tests: 15 subtests in `TestCheckResponseError_ArchiveDepthBoundary` (the verbatim production body at 400, the corrected-typo variant, case-insensitivity, plain-text bodies, plus 400/403/404/405/empty/non-JSON/200/302 negatives), and 5 tests in `protocol/common/error_registry_test.go` covering classification, pass-through, status-code isolation, consumer policy, and registry naming.

On CI, green: `lint`, `test-protocol`, `test-consensus`, `test-payment-e2e`, `validate-check`, CodeQL, and every `lavad`/`lavap`/`lavavisor` build target. Codecov reports **all modified lines covered by tests** (`restMessage.go` +2.44%, `error_classifier.go` +1.63%).

> An earlier revision of this description warned that `golangci-lint` could not be run locally — the CI-pinned v1.62.0 is OOM-killed in the authoring container, so `staticcheck`/`gosimple` were unverified at push time. **CI's `lint` job has since passed**, so that caveat is resolved and noted here only for the record.

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct type prefix in the PR title (`fix`)
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking; the only signature-level addition is a new exported helper in `protocol/common`
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — reported via Telegram, no GitHub issue; evidence summarised above
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for documenting Go code
* [x] confirmed all CI checks have passed — all completed checks green; `build_docker` and `test-protocol-e2e` still running at time of writing

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage