### PR TITLE
fix(specs): parse requested block on Cardano /blocks/{hash_or_number} routes

### DIFF
--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/lavanet/lava/v5/protocol/chainlib/extensionslib"
 	"github.com/lavanet/lava/v5/protocol/common"
 	"github.com/lavanet/lava/v5/protocol/parser"
+	specutils "github.com/lavanet/lava/v5/utils/keeper"
 	pairingtypes "github.com/lavanet/lava/v5/x/pairing/types"
+	plantypes "github.com/lavanet/lava/v5/x/plans/types"
 	spectypes "github.com/lavanet/lava/v5/x/spec/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -316,5 +318,129 @@ func TestRegexParsing(t *testing.T) {
 		} else {
 			assert.ErrorIs(t, err, common.APINotSupportedError)
 		}
+	}
+}
+
+// TestCardanoSpec_HistoricalBlockRequestsAreNotLatest pins the block parsing of the
+// Blockfrost-style `/blocks/{hash_or_number}` routes in the CARDANO spec.
+//
+// The routes used to declare `DEFAULT latest`, so `GET /blocks/1` was classified as a
+// request for the latest block: the archive rule never fired, archive providers were
+// not selected, and the archive CU multiplier was not applied. A numeric path parameter
+// must now surface as the requested block, and a block hash must be captured as a
+// requested hash (the consumer resolves hashes to heights through its cache) while the
+// block itself falls back to latest.
+func TestCardanoSpec_HistoricalBlockRequestsAreNotLatest(t *testing.T) {
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"height": 12000000, "hash": "4ea1ba291e8eef538635a53e59fddba7810d1679631cc3aed7c8e6c4091a5b1f"}`)
+	})
+	chainParser, _, _, closeServer, _, err := CreateChainLibMocks(ctx, "CARDANO", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	require.NoError(t, err)
+	defer func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	}()
+
+	const blockHash = "4ea1ba291e8eef538635a53e59fddba7810d1679631cc3aed7c8e6c4091a5b1f"
+
+	tests := []struct {
+		path          string
+		expectedBlock int64
+		expectedHash  string
+	}{
+		{path: "/blocks/latest", expectedBlock: spectypes.LATEST_BLOCK},
+		{path: "/blocks/1", expectedBlock: 1},
+		{path: "/blocks/11500000", expectedBlock: 11500000},
+		{path: "/blocks/1/next", expectedBlock: 1},
+		{path: "/blocks/1/previous", expectedBlock: 1},
+		{path: "/blocks/1/txs", expectedBlock: 1},
+		{path: "/blocks/1/txs/cbor", expectedBlock: 1},
+		{path: "/blocks/1/addresses", expectedBlock: 1},
+		{path: "/blocks/" + blockHash, expectedBlock: spectypes.LATEST_BLOCK, expectedHash: blockHash},
+		{path: "/blocks/" + blockHash + "/txs", expectedBlock: spectypes.LATEST_BLOCK, expectedHash: blockHash},
+		// epoch and slot numbers are not block heights and must keep resolving to latest
+		{path: "/epochs/1", expectedBlock: spectypes.LATEST_BLOCK},
+		{path: "/blocks/slot/1", expectedBlock: spectypes.LATEST_BLOCK},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			chainMessage, err := chainParser.ParseMsg(test.path, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+			requestedBlock, _ := chainMessage.RequestedBlock()
+			require.Equal(t, test.expectedBlock, requestedBlock)
+			if test.expectedHash == "" {
+				require.Empty(t, chainMessage.GetRequestedBlocksHashes())
+			} else {
+				require.Equal(t, []string{test.expectedHash}, chainMessage.GetRequestedBlocksHashes())
+			}
+		})
+	}
+}
+
+// TestCardanoSpec_HistoricalBlockActivatesArchive checks the end-to-end effect of the
+// parsing fix: with the archive extension enabled by policy, an old numeric block goes
+// to archive with the archive CU multiplier, while latest and recent blocks do not.
+func TestCardanoSpec_HistoricalBlockActivatesArchive(t *testing.T) {
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"height": 12000000, "hash": "4ea1ba291e8eef538635a53e59fddba7810d1679631cc3aed7c8e6c4091a5b1f"}`)
+	})
+	chainParser, _, _, closeServer, _, err := CreateChainLibMocks(ctx, "CARDANO", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	require.NoError(t, err)
+	defer func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	}()
+
+	chainParser.SetPolicy(&plantypes.Policy{ChainPolicies: []plantypes.ChainPolicy{{ChainId: "CARDANO", Requirements: []plantypes.ChainRequirement{{Collection: spectypes.CollectionData{ApiInterface: spectypes.APIInterfaceRest}, Extensions: []string{"archive"}}}}}}, "CARDANO", spectypes.APIInterfaceRest)
+
+	spec, err := specutils.GetASpec("CARDANO", "../../", nil, nil)
+	require.NoError(t, err)
+	var archiveRuleBlock uint64
+	var archiveCuMultiplier uint64
+	for _, apiCollection := range spec.ApiCollections {
+		for _, extension := range apiCollection.Extensions {
+			if extension.Name == "archive" {
+				archiveRuleBlock = extension.Rule.Block
+				archiveCuMultiplier = extension.CuMultiplier
+			}
+		}
+	}
+	require.NotZero(t, archiveRuleBlock)
+	require.NotZero(t, archiveCuMultiplier)
+
+	const latestBlock = uint64(12000000)
+	baseCu := uint64(10) // /blocks/{hash_or_number} compute units
+
+	tests := []struct {
+		name       string
+		path       string
+		archive    bool
+		expectedCu uint64
+	}{
+		{name: "latest", path: "/blocks/latest", archive: false, expectedCu: baseCu},
+		{name: "recent block", path: fmt.Sprintf("/blocks/%d", latestBlock-1), archive: false, expectedCu: baseCu},
+		{name: "block just inside the archive boundary", path: fmt.Sprintf("/blocks/%d", latestBlock-archiveRuleBlock-1), archive: true, expectedCu: baseCu * archiveCuMultiplier},
+		{name: "genesis-era block", path: "/blocks/1", archive: true, expectedCu: baseCu * archiveCuMultiplier},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chainMessage, err := chainParser.ParseMsg(test.path, nil, http.MethodGet, nil, extensionslib.ExtensionInfo{LatestBlock: latestBlock})
+			require.NoError(t, err)
+			if test.archive {
+				require.Len(t, chainMessage.GetExtensions(), 1)
+				require.Equal(t, "archive", chainMessage.GetExtensions()[0].Name)
+			} else {
+				require.Empty(t, chainMessage.GetExtensions())
+			}
+			require.Equal(t, test.expectedCu, chainMessage.GetApi().ComputeUnits)
+		})
 	}
 }

--- a/specs/mainnet-1/specs/cardano.json
+++ b/specs/mainnet-1/specs/cardano.json
@@ -444,6 +444,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "/assets/{asset}/utxos",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "/assets/policy/{policy_id}",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -519,9 +537,12 @@
                                 "name": "/blocks/{hash_or_number}",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 10,
                                 "enabled": true,
@@ -531,15 +552,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/next",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -549,15 +579,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/previous",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -567,7 +606,13 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/slot/{slot_number}",
@@ -609,9 +654,12 @@
                                 "name": "/blocks/{hash_or_number}/txs",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -621,15 +669,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/txs/cbor",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -639,15 +696,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/addresses",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -657,7 +723,13 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/epochs/latest",
@@ -931,6 +1003,60 @@
                             },
                             {
                                 "name": "/governance/dreps/{drep_id}/votes",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee/votes",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee/{cc_id}/votes",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"
@@ -1597,6 +1723,24 @@
                             },
                             {
                                 "name": "/scripts/{script_hash}/redeemers",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/scripts/{script_hash}/utxos",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"

--- a/specs/testnet-2/specs/cardano.json
+++ b/specs/testnet-2/specs/cardano.json
@@ -444,6 +444,24 @@
                                 "extra_compute_units": 0
                             },
                             {
+                                "name": "/assets/{asset}/utxos",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
                                 "name": "/assets/policy/{policy_id}",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -519,9 +537,12 @@
                                 "name": "/blocks/{hash_or_number}",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 10,
                                 "enabled": true,
@@ -531,15 +552,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/next",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -549,15 +579,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/previous",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -567,7 +606,13 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/slot/{slot_number}",
@@ -609,9 +654,12 @@
                                 "name": "/blocks/{hash_or_number}/txs",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -621,15 +669,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/txs/cbor",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -639,15 +696,24 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/blocks/{hash_or_number}/addresses",
                                 "block_parsing": {
                                     "parser_arg": [
-                                        "latest"
+                                        "hash_or_number",
+                                        "=",
+                                        "0"
                                     ],
-                                    "parser_func": "DEFAULT"
+                                    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
+                                    "default_value": "latest"
                                 },
                                 "compute_units": 20,
                                 "enabled": true,
@@ -657,7 +723,13 @@
                                     "subscription": false,
                                     "stateful": 0
                                 },
-                                "extra_compute_units": 0
+                                "extra_compute_units": 0,
+                                "parsers": [
+                                    {
+                                        "parse_path": ".params.hash_or_number",
+                                        "parse_type": "BLOCK_HASH"
+                                    }
+                                ]
                             },
                             {
                                 "name": "/epochs/latest",
@@ -931,6 +1003,60 @@
                             },
                             {
                                 "name": "/governance/dreps/{drep_id}/votes",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee/votes",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/governance/committee/{cc_id}/votes",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"
@@ -1597,6 +1723,24 @@
                             },
                             {
                                 "name": "/scripts/{script_hash}/redeemers",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": true,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/scripts/{script_hash}/utxos",
                                 "block_parsing": {
                                     "parser_arg": [
                                         "latest"


### PR DESCRIPTION
# Description

Closes: N/A (reported by Stake Village during their audit of the Cardano spec, tracked on the Lava product board as "Cardano Specs Update"; needed for the Sep 17 CARDANO / CARDANOT incentivization)

## The bug

The six Blockfrost `/blocks/{hash_or_number}` routes in the `CARDANO` spec (and therefore in `CARDANOT`, which imports it) declared:

```json
"block_parsing": { "parser_arg": ["latest"], "parser_func": "DEFAULT" }
```

so `GET /blocks/1` was classified as a request for the latest block. The URL sent to the provider was untouched, but on the Lava side:

1. the archive rule (`"block": 8192`) never fired, so archive providers were not guaranteed for historical blocks and a non-archive provider could return an error even when archive providers were available;
2. when an archive provider did answer, the archive extension and its `cu_multiplier: 5` were not applied;
3. requested-block tracking, QoS and data-reliability logic saw `latest` instead of the real height.

## The fix

`specs/mainnet-1/specs/cardano.json` and `specs/testnet-2/specs/cardano.json` (kept identical, as before):

**Block parsing on the six `{hash_or_number}` routes** — `/blocks/{hash_or_number}`, `/next`, `/previous`, `/txs`, `/txs/cbor`, `/addresses`:

```json
"block_parsing": {
    "parser_arg": ["hash_or_number", "=", "0"],
    "parser_func": "PARSE_DICTIONARY_OR_ORDERED",
    "default_value": "latest"
},
"parsers": [
    { "parse_path": ".params.hash_or_number", "parse_type": "BLOCK_HASH" }
]
```

- `PARSE_DICTIONARY_OR_ORDERED` on the path parameter is the existing Aptos (`/blocks/by_height/{block_height}`) and Cosmos SDK (`/cosmos/base/tendermint/v1beta1/blocks/{height}`) pattern. `RestMessage.GetParams()` exposes path parameters as a map keyed by the placeholder name, so a numeric value resolves to that block height.
- A Cardano block hash is 64 hex chars without a `0x` prefix, which `ParseDefaultBlockParameter` rejects. `default_value: "latest"` makes hash requests keep exactly today's behaviour (latest, `UsedDefaultValue = true`) instead of degrading to `NOT_APPLICABLE`.
- The `BLOCK_HASH` generic parser surfaces the hash as a requested block hash. The consumer already ships it in `BlocksHashesToHeights` and resolves it through the relay cache (`resolveRequestedBlock` picks the cached height when the block was parsed from the default value), so hash requests can be routed to archive once the height is known. For a numeric value the hash parser fails the minimum-length check and falls through to the legacy parser, as in `TestParseBlockFromParamsHash`.

**Routes deliberately left on `DEFAULT latest`:** `/epochs/{number}/...` (epoch numbers, ~500 on mainnet) and `/blocks/slot/{slot_number}` / `/blocks/epoch/{epoch_number}/slot/{slot_number}` (slot numbers, far above the block height). Both would be mis-classified against the archive boundary if parsed as block heights. A hash-to-height decision for those is a separate routing policy question.

**Spec gaps** — diffed the API list against the current Blockfrost OpenAPI (`blockfrost/openapi`, `master`). Added the chain-data endpoints that were missing, with the same CU convention as their siblings (10 for a single object, 20 for a list):

| Endpoint | CU |
| --- | --- |
| `/assets/{asset}/utxos` | 20 |
| `/scripts/{script_hash}/utxos` | 20 |
| `/governance/committee` | 10 |
| `/governance/committee/votes` | 20 |
| `/governance/committee/{cc_id}/votes` | 20 |

Not added, on purpose: `/addresses/{address}/txs` and `/assets/{asset}/txs` (marked `deprecated` in the OpenAPI, superseded by `/transactions`), `/`, `/health`, `/health/clock`, `/metrics`, `/metrics/endpoints` (Blockfrost account/service status, not chain data), and `/ipfs/*` (separate Blockfrost add-on product). Every endpoint currently in the spec exists in the OpenAPI and none is deprecated.

Everything else in the spec (verifications, `pruning` at `latest_distance: 8193` vs the 8192 archive rule, finalization and block-time values, min stake, `CARDANOT` chain-id override) was reviewed and left unchanged.

## Verification

New tests in `protocol/chainlib/rest_test.go` load the real spec through `CreateChainLibMocks("CARDANO", rest, ...)`:

- `TestCardanoSpec_HistoricalBlockRequestsAreNotLatest` — `/blocks/1`, `/blocks/11500000` and the five sub-routes resolve to the numeric height; a 64-hex hash resolves to latest with the hash captured in `GetRequestedBlocksHashes()`; `/blocks/latest`, `/epochs/1` and `/blocks/slot/1` stay latest.
- `TestCardanoSpec_HistoricalBlockActivatesArchive` — with the archive extension enabled by policy and `LatestBlock = 12,000,000`: latest and `latest-1` get no extension and 10 CU; `latest-8193` and `/blocks/1` get the `archive` extension and 50 CU.

Against the original spec the first test fails on every numeric route with `expected: 1, actual: -2` (`LATEST_BLOCK`), which reproduces the report.

```
go test ./x/spec/keeper -run 'TestSpecs$' -count=1        ok   (both spec copies load, expand and validate)
go test ./protocol/chainlib -run TestCardanoSpec -count=1  ok
go test ./protocol/chainlib -count=1                      ok   (9.9s)
go test ./protocol/parser -count=1                        ok
go vet ./protocol/chainlib                                ok
```

CI on `8e92aae`: all 30 checks green (lint, CodeQL, test-protocol, test-consensus, protocol e2e, payment e2e, codecov patch, binaries, docker images).

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
* [x] confirmed `!` in the type prefix if API or client breaking change — not breaking
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — Blockfrost OpenAPI: https://github.com/blockfrost/openapi
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc) — the spec files are the specification
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

https://claude.ai/code/session_015Zn1TrLFU2xyth1vqGmz7Q