### PR TITLE
feat(solana): support V1 transactions and map the full Agave RPC error surface

### DIFF
--- a/error-registry-design.md
+++ b/error-registry-design.md
@@ -131,6 +131,7 @@ Uses a **tiered classification system** (see Section 3 for details):
 | 3309 | `CHAIN_SOLANA_BLOCK_STATUS_UNAVAILABLE` | Block status unavailable (-32014) | No | Solana |
 | 3310 | `CHAIN_SOLANA_TX_VERSION_UNSUPPORTED` | Transaction version not supported (-32015) | No | Solana |
 | 3311 | `CHAIN_SOLANA_MIN_CONTEXT_SLOT_NOT_REACHED` | Minimum context slot not reached (-32016) | No | Solana |
+| 3312 | `CHAIN_SOLANA_EPOCH_REWARDS_ACTIVE` | Epoch rewards distribution period still active (-32017) | No | Solana |
 | **Starknet-Specific (3320-3339) — Tier 2** |||||
 | 3320 | `CHAIN_STARKNET_FAILED_TO_RECEIVE_TX` | Failed to receive tx (code 1) | No | Starknet |
 | 3321 | `CHAIN_STARKNET_CLASS_NOT_FOUND` | Class hash not found (code 28) | No | Starknet |

--- a/protocol/common/error_classifier.go
+++ b/protocol/common/error_classifier.go
@@ -25,14 +25,23 @@ var chainErrorMappings = map[ChainFamily][]errorMapping{
 		{CodeEquals(-32003), LavaErrorChainSolanaSignatureVerifyFailed},                        // "Signature verification failure"
 		{CodeEquals(-32004), LavaErrorChainBlockNotFound},                                      // "Block not available for slot N"
 		{CodeEquals(-32005), LavaErrorNodeSolanaUnhealthy},                                     // "Node is unhealthy" / "Node is behind by N slots"
+		{CodeEquals(-32006), LavaErrorChainInvalidSignature},                                   // "Transaction precompile verification failure" (ed25519/secp256k1 precompiles)
 		{CodeEquals(-32007), LavaErrorChainSolanaLedgerJump},                                   // "Slot skipped or missing"
+		{CodeEquals(-32008), LavaErrorNodeResourceUnavailable},                                 // "No snapshot"
 		{CodeEquals(-32009), LavaErrorChainSolanaMissingLongTerm},                              // "Slot missing in long-term storage"
 		{MessageContains("missing in long-term storage"), LavaErrorChainSolanaMissingLongTerm}, // message-based fallback
 		{CodeEquals(-32010), LavaErrorChainSolanaExcludedFromIndex},                            // "Excluded from account secondary indexes"
+		{CodeEquals(-32011), LavaErrorChainDataNotAvailable},                                   // "Transaction history is not available from this node"
+		{CodeEquals(-32012), LavaErrorNodeInternalError},                                       // scan error (account scan aborted mid-flight)
 		{CodeEquals(-32013), LavaErrorChainSolanaSignatureLengthMismatch},                      // "Signature length mismatch"
 		{CodeEquals(-32014), LavaErrorChainSolanaBlockStatusUnavailable},                       // "Block status unavailable"
 		{CodeEquals(-32015), LavaErrorChainSolanaTxVersionUnsupported},                         // "Transaction version not supported"
 		{CodeEquals(-32016), LavaErrorChainSolanaMinContextSlotNotReached},                     // "Minimum context slot not reached"
+		{CodeEquals(-32017), LavaErrorChainSolanaEpochRewardsActive},                           // "Epoch rewards period still active at slot N"
+		{CodeEquals(-32018), LavaErrorUserInvalidParams},                                       // "Rewards cannot be found; slot N is not epoch boundary"
+		{CodeEquals(-32019), LavaErrorNodeServiceUnavailable},                                  // "Failed to query long-term storage; please try again"
+		{CodeEquals(-32020), LavaErrorChainTxNotFound},                                         // "Transaction N not found" (getSignaturesForAddress before/until)
+		{CodeEquals(-32021), LavaErrorChainDataNotAvailable},                                   // "No slot history"
 		// Blockhash expiry — extremely common under load when clients submit tx
 		// with a recent blockhash that has since rolled off the 150-slot window.
 		// Placed before generic Tier-1 matchers would see it; case-insensitive

--- a/protocol/common/error_codes.go
+++ b/protocol/common/error_codes.go
@@ -451,6 +451,13 @@ var (
 		Code: 3311, Name: "CHAIN_SOLANA_MIN_CONTEXT_SLOT_NOT_REACHED", Category: CategoryExternal,
 		Description: "Minimum context slot not reached (-32016)", Retryable: true,
 	})
+	// Non-retryable on purpose: the epoch rewards distribution period is chain
+	// state, identical on every provider, so rotating to another one during the
+	// window just burns a retry. It clears on its own once distribution ends.
+	LavaErrorChainSolanaEpochRewardsActive = registerError(&LavaError{
+		Code: 3312, Name: "CHAIN_SOLANA_EPOCH_REWARDS_ACTIVE", Category: CategoryExternal,
+		Description: "Epoch rewards distribution period still active (-32017)", Retryable: false,
+	})
 
 	// Starknet-specific (3320-3349) — Tier 2
 	// Source: Starknet JSON-RPC spec error codes

--- a/protocol/common/error_registry_test.go
+++ b/protocol/common/error_registry_test.go
@@ -883,6 +883,15 @@ func TestClassifyError_ChainSpecificMappings(t *testing.T) {
 		{"Solana -32005", ChainFamilySolana, -32005, "", LavaErrorNodeSolanaUnhealthy},
 		{"Solana -32004", ChainFamilySolana, -32004, "", LavaErrorChainBlockNotFound},
 		{"Solana -32001", ChainFamilySolana, -32001, "", LavaErrorChainStatePruned},
+		{"Solana -32006 precompile verify", ChainFamilySolana, -32006, "", LavaErrorChainInvalidSignature},
+		{"Solana -32008 no snapshot", ChainFamilySolana, -32008, "", LavaErrorNodeResourceUnavailable},
+		{"Solana -32011 no tx history", ChainFamilySolana, -32011, "", LavaErrorChainDataNotAvailable},
+		{"Solana -32012 scan error", ChainFamilySolana, -32012, "", LavaErrorNodeInternalError},
+		{"Solana -32017 epoch rewards active", ChainFamilySolana, -32017, "", LavaErrorChainSolanaEpochRewardsActive},
+		{"Solana -32018 not epoch boundary", ChainFamilySolana, -32018, "", LavaErrorUserInvalidParams},
+		{"Solana -32019 long-term storage unreachable", ChainFamilySolana, -32019, "", LavaErrorNodeServiceUnavailable},
+		{"Solana -32020 filter tx not found", ChainFamilySolana, -32020, "", LavaErrorChainTxNotFound},
+		{"Solana -32021 no slot history", ChainFamilySolana, -32021, "", LavaErrorChainDataNotAvailable},
 		// Bitcoin Tier 2 — source: Bitcoin Core src/rpc/protocol.h
 		{"Bitcoin warmup -28", ChainFamilyBitcoin, -28, "", LavaErrorNodeBitcoinWarmup},
 		{"Bitcoin initial download -10", ChainFamilyBitcoin, -10, "", LavaErrorNodeBitcoinInitialDownload},
@@ -1181,4 +1190,26 @@ func TestArchiveDepthBoundary_NamedInRegistry(t *testing.T) {
 
 	require.Equal(t, LavaErrorChainDataNotAvailable, classification)
 	require.NotEqual(t, LavaErrorUnknown, classification)
+}
+
+// TestClassifyError_SolanaAgaveCodeCoverage pins the whole Solana custom-error
+// surface, not just the codes someone happened to hit in production.
+//
+// Agave defines a contiguous block of JSON-RPC server error codes in
+// rpc-client-api/src/custom_error.rs (-32001 through -32021). Anything in that
+// block that Lava does not map falls through to UNKNOWN_ERROR, which is
+// retryable by default — so a permanent, deterministic node answer would be
+// retried across every provider in the pairing before failing. That is exactly
+// what happened to -32020 (added in Agave v4.0) until this test existed.
+//
+// If Agave adds a code past -32021, extend the range here together with the
+// mapping; a bare range bump with no mapping fails this test by design.
+func TestClassifyError_SolanaAgaveCodeCoverage(t *testing.T) {
+	const firstAgaveCode, lastAgaveCode = -32001, -32021
+	for code := firstAgaveCode; code >= lastAgaveCode; code-- {
+		result := ClassifyError(nil, ChainFamilySolana, TransportJsonRPC, code, "")
+		assert.NotEqual(t, LavaErrorUnknown, result,
+			"Solana code %d is defined by agave rpc-client-api/src/custom_error.rs but is unmapped in "+
+				"chainErrorMappings[ChainFamilySolana]; it would classify as UNKNOWN_ERROR and be retried across providers", code)
+	}
 }

--- a/specs/mainnet-1/specs/solana.json
+++ b/specs/mainnet-1/specs/solana.json
@@ -991,7 +991,7 @@
                             },
                             {
                                 "function_tag": "GET_BLOCK_BY_NUM",
-                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getBlock\",\"params\":[%d,{\"transactionDetails\":\"none\",\"rewards\":false,\"maxSupportedTransactionVersion\":0}],\"id\":1}",
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getBlock\",\"params\":[%d,{\"transactionDetails\":\"none\",\"rewards\":false,\"maxSupportedTransactionVersion\":1}],\"id\":1}",
                                 "result_parsing": {
                                     "parser_arg": [
                                         "0",

--- a/specs/testnet-2/specs/solana.json
+++ b/specs/testnet-2/specs/solana.json
@@ -991,7 +991,7 @@
                             },
                             {
                                 "function_tag": "GET_BLOCK_BY_NUM",
-                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getBlock\",\"params\":[%d,{\"transactionDetails\":\"none\",\"rewards\":false,\"maxSupportedTransactionVersion\":0}],\"id\":1}",
+                                "function_template": "{\"jsonrpc\":\"2.0\",\"method\":\"getBlock\",\"params\":[%d,{\"transactionDetails\":\"none\",\"rewards\":false,\"maxSupportedTransactionVersion\":1}],\"id\":1}",
                                 "result_parsing": {
                                     "parser_arg": [
                                         "0",


### PR DESCRIPTION
# Description

Closes: N/A (Notion TSK-45 / Lava board "Solana Spec Upgrade – Support Upcoming V1 Transactions")

Three commits from one review pass over Solana's upgrade path. Everything is additive; nothing is removed or renamed.

1. **`feat(specs)`** — bump `maxSupportedTransactionVersion` `0` → `1` in the SOLANA `GET_BLOCK_BY_NUM` parse directive.
2. **`feat(errors)`** — map the 9 Agave JSON-RPC error codes Lava was missing, including `-32020` which is new in Agave v4.0.
3. **`test(solana)`** — pin the spec value and the per-code retry policy, in response to the Qodo review.

Neither of the first two was prompted by an observed failure. Both come from Solana's published upgrade material and Agave's own source, checked against the repo.

## 1. V1 transaction support

Solana is activating **V1 transactions** (SIMD-0385): new wire format (discriminator byte `0x81`), max size **4,096 bytes** (was 1,232), no address-lookup tables. Active on Devnet and Testnet, pending on Mainnet.

The bump lands in both `specs/mainnet-1/specs/solana.json` and `specs/testnet-2/specs/solana.json` (otherwise identical files). `SOLANAT` and `KOII` import `SOLANA` and inherit it.

**Honest scope note:** the directive uses `"transactionDetails":"none"`, and the node never applies the version check in `none`/`signatures` mode, so the chain tracker would not have broken at `0` either. This is a correctness fix for the declared value, not a live-bug fix. It matters for any future directive that requests transaction details, and it removes the footgun before Mainnet activation.

The rest of the spec was reviewed against the current RPC docs and found complete:

| Area | Finding |
| --- | --- |
| `maxSupportedTransactionVersion` | Only occurrence in the repo is this directive. Nothing else pins a transaction version. |
| HTTP method coverage | 52 in spec, 52 in docs. Exact match. |
| WebSocket method coverage | 18 in spec, 18 in docs. Exact match. |
| Agave v4.0 method removals | All 16 removed legacy methods (`getConfirmedBlock`, `getRecentBlockhash`, `getFees`, …) are absent from the spec. |
| `getBlock` / `getTransaction` / `blockSubscribe` | Pass-through. Clients opt in with their own `maxSupportedTransactionVersion`; Lava does not inject or rewrite params. |
| `sendTransaction` / `simulateTransaction` | Pass-through. Over 1,232 bytes the node requires `base64`. |
| Payload limits | Consumer HTTP body limit 4 MB (fiber default), provider gRPC 512 MB. A 4,096-byte tx is ~5.5 KB base64. No change needed. |
| Rent reduction | No rent assumptions in protocol code. No change needed. |

## 2. Agave RPC error-code coverage

Agave defines a contiguous block of JSON-RPC server error codes, `-32001` through `-32021`, in `rpc-client-api/src/custom_error.rs`. Lava mapped 12. The other 9 fell through to `UNKNOWN_ERROR`, **whose retry behaviour is the default rather than a choice** — and the default is to retry, so a permanent, deterministic node answer was rotated across every provider in the pairing before failing.

`-32020` is the one reachable on mainnet today: Agave v4.0 changed `getSignaturesForAddress` to return it when the `before`/`until` signature is not found, instead of returning an empty array. The other 8 are mapped alongside it so the gap does not reopen.

| Agave code | Meaning | Mapped to | Retryable |
| --- | --- | --- | --- |
| `-32006` | Transaction precompile verification failure | `CHAIN_INVALID_SIGNATURE` (3016) | No |
| `-32008` | No snapshot | `NODE_RESOURCE_UNAVAILABLE` (2013) | Yes |
| `-32011` | Transaction history not available from this node | `CHAIN_DATA_NOT_AVAILABLE` (3205) | Yes |
| `-32012` | Scan error (account scan aborted) | `NODE_INTERNAL_ERROR` (2003) | Yes |
| `-32017` | Epoch rewards period still active | **`CHAIN_SOLANA_EPOCH_REWARDS_ACTIVE` (3312, new)** | No |
| `-32018` | Slot is not an epoch boundary | `USER_INVALID_PARAMS` (4003) | No |
| `-32019` | Long-term storage unreachable | `NODE_SERVICE_UNAVAILABLE` (2006) | Yes |
| `-32020` | Filter transaction not found | `CHAIN_TX_NOT_FOUND` (3202) | Yes |
| `-32021` | No slot history | `CHAIN_DATA_NOT_AVAILABLE` (3205) | Yes |

Eight reuse existing generic errors, per the design doc's rule that a Tier-2 code is warranted only where retryability differs from the generic pattern.

**`-32017` is the one new code.** The epoch rewards distribution window is chain state — identical on every provider — so rotating during it is always wasted work. No existing error carries "data unavailable **and** non-retryable", hence code 3312.

## 3. Tests added in response to review

Two real gaps, both now closed. Tests only; no production behaviour changed by this commit.

**The spec bump had no test.** `TestSolanaSpec_GetBlockByNumSupportsV1Transactions` is table-driven over both deployed copies. It decodes the rendered request rather than substring-matching the template, so it survives key reordering and rejects the quoted `"1"` form Solana does not accept, and it asserts the two networks' directives are byte-identical. Nothing previously stopped `mainnet-1` and `testnet-2` drifting.

**The classifier tests never asserted retryability.** They pinned which error each code maps to, but most targets are generic errors shared with other chain families, so flipping `Retryable` on one would have changed Solana's provider rotation with every test still green. `TestClassifyError_SolanaRetryPolicy` now pins the retry decision for all 21 codes with the policy argument recorded beside each value.

**`-32020` stays retryable, against the review's suggestion.** The `before`/`until` signature may be absent from one node's history but present on a provider with a deeper ledger or long-term storage enabled, and the error is byte-identical in both cases, so the classifier cannot distinguish them. `CHAIN_TX_NOT_FOUND` and `CHAIN_RECEIPT_NOT_FOUND` are already retryable for this same ambiguity on every other chain, and the costs are asymmetric: a wasted rotation costs latency, whereas suppressing the retry reports "not found" for data another provider holds. Reasoning and the one open question are on [that review thread](https://github.com/lavanet/lava/pull/2336#discussion_r3975494941), left unresolved so the decision stays visible.

## Verification

**Unit tests** (all pass):

```
go test ./x/spec/keeper/ -run 'TestSolanaSpecAddMultipleSubscribe|TestSpecProposal|TestSpecAdd' -count=1   ok
go test ./protocol/common/... ./protocol/relaycore/... ./protocol/parser/... ./protocol/chaintracker/...   ok
```

**Every new test was mutation-tested — proven to fail, not just to pass.** Each guard was broken deliberately, then restored:

| Mutation | Test that caught it |
| --- | --- |
| `specs/testnet-2` reverted to `0` (half-applied edit) | spec test, on both the value and the parity assertion |
| `CHAIN_TX_NOT_FOUND` flipped to non-retryable | retry-policy test, quoting the policy argument |
| `-32021` mapping deleted | coverage test *and* retry-policy test |

For example:

```
Solana code -32021 is defined by agave rpc-client-api/src/custom_error.rs but is unmapped in
chainErrorMappings[ChainFamilySolana]; it would classify as UNKNOWN_ERROR and be retried across providers
```

**Lava chain fetcher against live clusters** (temporary test, not committed): built a jsonrpc chain parser + router + fetcher from the modified spec and ran `GET_BLOCKNUM` then `GET_BLOCK_BY_NUM` end to end.

```
devnet  (solana-core 4.3.0-beta.3, V1 active):  latest slot 495199468, slot 495199428 -> 3RTWHSJnoJN8sU7rv4n2MPNdZjXS9G4HZ8QkMZpUfiVD
mainnet (solana-core 4.2.2, V1 not active):    latest slot 445388103, slot 445388063 -> 8GNYTCri7ALtAKsn51byPg3H5QiJ2Azkq7CjF5s38zXn
```

Mainnet accepts `maxSupportedTransactionVersion: 1` (and higher) in the raw `getBlock` call today, so the bump is safe to propose before Mainnet activation.

**V1 transaction flows on Devnet** (direct RPC, exercising what Lava passes through):

- Built a real V1 transaction with `solders` 0.29: version 1, first byte `0x81`, **1,983 bytes**.
- `simulateTransaction` with `encoding: base64`: `err: null`, memo program executed.
- Same transaction with `encoding: base58`: `-32602 "... too large: 2708 bytes (max: encoded/raw 1683/1232)"`, confirming base64 is mandatory above 1,232 bytes.
- `-32020` reproduced on both clusters with a well-formed signature that exists nowhere, confirming the error shape and message.

## Not covered here

- **`getTransaction`/`getBlock` at version `0` against a real V1 transaction.** No V1 transaction was observed in the last 400 Devnet slots or the 2,000 most recent Memo/ComputeBudget signatures — only legacy and v0. Per the docs `getTransaction` returns `-32015` and `getBlock` fails the whole call in `full`/`accounts` mode; Lava already maps `-32015` to `CHAIN_SOLANA_TX_VERSION_UNSUPPORTED` (non-retryable) and passes it through.
- **The retryable branch of `-32020`** could not be demonstrated live, as no pruned Solana node was available to query. That argument rests on Agave's lookup path plus repo convention.
- **Full local chain run** (`scripts/pre_setups/init_solana_only_with_node.sh` against Devnet): not executed in the sandbox, which has no `screen`/`lavad`.
- **`sendTransaction` of a signed V1 tx:** the Devnet faucet returned `-32603 Internal error` on every `requestAirdrop`, so no funded key was available. Simulation covers the same encoding and size path.
- **Governance proposal** for the updated spec is a separate ops step.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change (not breaking — additive only)
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification ([V1 transactions](https://solana.com/upgrades/larger-transaction-sizes), [agave custom_error.rs](https://github.com/anza-xyz/agave/blob/master/rpc-client-api/src/custom_error.rs))
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests (spec value and parity, retry policy for all 21 codes, contiguous coverage — each mutation-tested)
* [x] updated the relevant documentation or specification (`error-registry-design.md` table; the spec JSON is its own documentation)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

https://claude.ai/code/session_01BmDq4Jk3Xh9EJhC9UdJoy3