### PR TITLE
chore: bump protocol TARGET_VERSION to 6.2.8

### DIFF
--- a/x/protocol/types/params.go
+++ b/x/protocol/types/params.go
@@ -16,7 +16,7 @@ var _ paramtypes.ParamSet = (*Params)(nil)
 // compiled into the binary rather than derived from the git tag, so it has to be
 // bumped by hand alongside a release.
 const (
-	TARGET_VERSION = "6.2.7"
+	TARGET_VERSION = "6.2.8"
 	MIN_VERSION    = "5.5.1"
 )
 


### PR DESCRIPTION
# Description

Bumps the protocol `TARGET_VERSION` from `6.2.7` to `6.2.8`.

`x/protocol/types/params.go` is the only file to review — it holds the single source of the compiled-in protocol version, which seeds `DefaultVersion` for both provider and consumer targets at genesis. `MIN_VERSION` is unchanged at `5.5.1`.

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`chore`)
* [x] confirmed `!` in the type prefix if API or client breaking change — n/a, not breaking
* [x] targeted the `main` branch
* [ ] provided a link to the relevant issue or specification — n/a, routine release version bump
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests — n/a, no behavior change; existing `x/protocol/...` tests pass
* [x] updated the relevant documentation or specification — n/a, the constant's existing comment already documents the manual bump
* [ ] confirmed all CI checks have passed — pending CI on this PR

## Reviewers Checklist

*To be completed by reviewers.*

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

---
https://claude.ai/code/session_01Eds5gQiQYRGdCw6Qrd5f5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eds5gQiQYRGdCw6Qrd5f5A)_