### PR TITLE
fix(specs): move Cardano mempool and tx-evaluate routes to addons

### DIFF
--- a/config/provider_examples/cardano_example.yml
+++ b/config/provider_examples/cardano_example.yml
@@ -3,6 +3,14 @@
 # Get your project_id at https://blockfrost.io after creating a project for the
 # corresponding network (mainnet, preprod).
 # Port 2221 is the default Lava provider listen port.
+#
+# Addons: the `mempool` and `txs-evaluate` addons are optional. The hosted
+# Blockfrost service serves them; the self-hosted blockfrost-backend-ryo does
+# not implement /mempool/* or /utils/txs/evaluate*, so a RYO-backed provider
+# should leave both out. Declaring an addon here is only half of it - it must
+# also be declared in the provider stake entry, e.g.
+#   "127.0.0.1:2221,1,rest,mempool,txs-evaluate"
+# otherwise pairing will never route addon requests to this provider.
 endpoints:
   - api-interface: rest
     chain-id: CARDANO
@@ -13,6 +21,9 @@ endpoints:
         auth-config:
           auth-headers:
             project_id: <YOUR_PROJECT_ID> # Blockfrost mainnet project ID
+        addons:
+          - mempool       # drop this line when backing the provider with RYO
+          - txs-evaluate  # drop this line when backing the provider with RYO
   - api-interface: rest
     chain-id: CARDANOT
     network-address:
@@ -22,3 +33,6 @@ endpoints:
         auth-config:
           auth-headers:
             project_id: <YOUR_PROJECT_ID> # Blockfrost preprod project ID
+        addons:
+          - mempool       # drop this line when backing the provider with RYO
+          - txs-evaluate  # drop this line when backing the provider with RYO

--- a/cookbook/plans/gateway-full.json
+++ b/cookbook/plans/gateway-full.json
@@ -284,6 +284,54 @@
                         },
                         {
                             "apis": [],
+                            "chain_id": "CARDANO",
+                            "requirements": [
+                                {
+                                    "collection": {
+                                        "api_interface": "rest",
+                                        "internal_path": "",
+                                        "type": "GET",
+                                        "add_on": "mempool"
+                                    },
+                                    "mixed": true
+                                },
+                                {
+                                    "collection": {
+                                        "api_interface": "rest",
+                                        "internal_path": "",
+                                        "type": "POST",
+                                        "add_on": "txs-evaluate"
+                                    },
+                                    "mixed": true
+                                }
+                            ]
+                        },
+                        {
+                            "apis": [],
+                            "chain_id": "CARDANOT",
+                            "requirements": [
+                                {
+                                    "collection": {
+                                        "api_interface": "rest",
+                                        "internal_path": "",
+                                        "type": "GET",
+                                        "add_on": "mempool"
+                                    },
+                                    "mixed": true
+                                },
+                                {
+                                    "collection": {
+                                        "api_interface": "rest",
+                                        "internal_path": "",
+                                        "type": "POST",
+                                        "add_on": "txs-evaluate"
+                                    },
+                                    "mixed": true
+                                }
+                            ]
+                        },
+                        {
+                            "apis": [],
                             "chain_id": "*",
                             "requirements": []
                         }

--- a/protocol/chainlib/rest_test.go
+++ b/protocol/chainlib/rest_test.go
@@ -444,3 +444,101 @@ func TestCardanoSpec_HistoricalBlockActivatesArchive(t *testing.T) {
 		})
 	}
 }
+
+// cardanoAddonPolicy builds a consumer policy for CARDANO that requires the given addons.
+// Passing no addons reproduces every plan shipped today (empty or wildcard chain policies),
+// which resolve to the base collection only.
+func cardanoAddonPolicy(addons ...struct{ addOn, connectionType string }) *plantypes.Policy {
+	requirements := []plantypes.ChainRequirement{}
+	for _, addon := range addons {
+		requirements = append(requirements, plantypes.ChainRequirement{
+			Collection: spectypes.CollectionData{
+				ApiInterface: spectypes.APIInterfaceRest,
+				Type:         addon.connectionType,
+				AddOn:        addon.addOn,
+			},
+			Mixed: true,
+		})
+	}
+	return &plantypes.Policy{ChainPolicies: []plantypes.ChainPolicy{{ChainId: "CARDANO", Requirements: requirements}}}
+}
+
+// TestCardanoSpec_MempoolAndEvaluateAreAddons pins the resolution of lavanet/lava#2333:
+// the three /mempool routes and the two /utils/txs/evaluate routes are not implemented by
+// the self-hosted blockfrost-backend-ryo, so they must not be part of the mandatory base
+// collection. They live in the "mempool" and "txs-evaluate" addons instead, which a
+// provider opts into and a consumer policy must request.
+func TestCardanoSpec_MempoolAndEvaluateAreAddons(t *testing.T) {
+	ctx := context.Background()
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"height": 12000000}`)
+	})
+	chainParser, _, _, closeServer, _, err := CreateChainLibMocks(ctx, "CARDANO", spectypes.APIInterfaceRest, serverHandler, nil, "../../", nil)
+	require.NoError(t, err)
+	defer func() {
+		if closeServer != nil {
+			closeServer()
+		}
+	}()
+
+	mempoolAddon := struct{ addOn, connectionType string }{"mempool", http.MethodGet}
+	evaluateAddon := struct{ addOn, connectionType string }{"txs-evaluate", http.MethodPost}
+
+	addonRoutes := []struct {
+		path           string
+		connectionType string
+	}{
+		{path: "/mempool", connectionType: http.MethodGet},
+		{path: "/mempool/4ea1ba291e8eef538635a53e59fddba7810d1679631cc3aed7c8e6c4091a5b1f", connectionType: http.MethodGet},
+		{path: "/mempool/addresses/addr1qxqs59lphg8g6qndelq8xwqn60ag3aeyfcp33c2kdp46a09re5df3pzwwmyq946axfcejy5n4x0y99wqpgtp2gd0k09qsgy6pz", connectionType: http.MethodGet},
+		{path: "/utils/txs/evaluate", connectionType: http.MethodPost},
+		{path: "/utils/txs/evaluate/utxos", connectionType: http.MethodPost},
+	}
+	baseRoutes := []struct {
+		path           string
+		connectionType string
+	}{
+		{path: "/blocks/latest", connectionType: http.MethodGet},
+		{path: "/tx/submit", connectionType: http.MethodPost},
+	}
+
+	// a policy without the addons - every plan in cookbook/plans today - reaches the base
+	// collection only, and the five routes are rejected before they ever leave the consumer
+	require.NoError(t, chainParser.SetPolicy(cardanoAddonPolicy(), "CARDANO", spectypes.APIInterfaceRest))
+	for _, route := range addonRoutes {
+		t.Run("rejected without addon "+route.path, func(t *testing.T) {
+			_, err := ParseAndValidateMessage(chainParser, route.path, nil, route.connectionType, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.Error(t, err)
+		})
+	}
+	for _, route := range baseRoutes {
+		t.Run("base reachable without addon "+route.path, func(t *testing.T) {
+			_, err := ParseAndValidateMessage(chainParser, route.path, nil, route.connectionType, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+		})
+	}
+
+	// once the policy asks for both addons the same routes resolve, and they carry the
+	// addon so pairing can route them to a provider that declared it
+	require.NoError(t, chainParser.SetPolicy(cardanoAddonPolicy(mempoolAddon, evaluateAddon), "CARDANO", spectypes.APIInterfaceRest))
+	for _, route := range addonRoutes {
+		t.Run("allowed with addon "+route.path, func(t *testing.T) {
+			chainMessage, err := ParseAndValidateMessage(chainParser, route.path, nil, route.connectionType, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+			expectedAddon := mempoolAddon.addOn
+			if route.connectionType == http.MethodPost {
+				expectedAddon = evaluateAddon.addOn
+			}
+			require.Equal(t, expectedAddon, GetAddon(chainMessage))
+		})
+	}
+	// the base collection is unaffected by the addons being present
+	for _, route := range baseRoutes {
+		t.Run("base unaffected by addon "+route.path, func(t *testing.T) {
+			chainMessage, err := ParseAndValidateMessage(chainParser, route.path, nil, route.connectionType, nil, extensionslib.ExtensionInfo{LatestBlock: 0})
+			require.NoError(t, err)
+			require.Equal(t, "", GetAddon(chainMessage))
+		})
+	}
+}

--- a/specs/mainnet-1/specs/cardano.json
+++ b/specs/mainnet-1/specs/cardano.json
@@ -1290,60 +1290,6 @@
                                 "extra_compute_units": 0
                             },
                             {
-                                "name": "/mempool",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 20,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "/mempool/{hash}",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "/mempool/addresses/{address}",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 20,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
                                 "name": "/metadata/txs/labels",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -2237,7 +2183,28 @@
                                     "hanging_api": true
                                 },
                                 "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [
+                            {
+                                "name": "content-type",
+                                "kind": "pass_send"
                             },
+                            {
+                                "name": "project_id",
+                                "kind": "pass_send"
+                            }
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": "txs-evaluate"
+                        },
+                        "apis": [
                             {
                                 "name": "/utils/txs/evaluate",
                                 "block_parsing": {
@@ -2274,15 +2241,70 @@
                                 },
                                 "extra_compute_units": 0
                             }
-                        ],
-                        "headers": [
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "GET",
+                            "add_on": "mempool"
+                        },
+                        "apis": [
                             {
-                                "name": "content-type",
-                                "kind": "pass_send"
+                                "name": "/mempool",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             },
                             {
-                                "name": "project_id",
-                                "kind": "pass_send"
+                                "name": "/mempool/{hash}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/mempool/addresses/{address}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             }
                         ]
                     }

--- a/specs/testnet-2/specs/cardano.json
+++ b/specs/testnet-2/specs/cardano.json
@@ -1290,60 +1290,6 @@
                                 "extra_compute_units": 0
                             },
                             {
-                                "name": "/mempool",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 20,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "/mempool/{hash}",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 10,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
-                                "name": "/mempool/addresses/{address}",
-                                "block_parsing": {
-                                    "parser_arg": [
-                                        "latest"
-                                    ],
-                                    "parser_func": "DEFAULT"
-                                },
-                                "compute_units": 20,
-                                "enabled": true,
-                                "category": {
-                                    "deterministic": false,
-                                    "local": false,
-                                    "subscription": false,
-                                    "stateful": 0
-                                },
-                                "extra_compute_units": 0
-                            },
-                            {
                                 "name": "/metadata/txs/labels",
                                 "block_parsing": {
                                     "parser_arg": [
@@ -2237,7 +2183,28 @@
                                     "hanging_api": true
                                 },
                                 "extra_compute_units": 0
+                            }
+                        ],
+                        "headers": [
+                            {
+                                "name": "content-type",
+                                "kind": "pass_send"
                             },
+                            {
+                                "name": "project_id",
+                                "kind": "pass_send"
+                            }
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "POST",
+                            "add_on": "txs-evaluate"
+                        },
+                        "apis": [
                             {
                                 "name": "/utils/txs/evaluate",
                                 "block_parsing": {
@@ -2274,15 +2241,70 @@
                                 },
                                 "extra_compute_units": 0
                             }
-                        ],
-                        "headers": [
+                        ]
+                    },
+                    {
+                        "enabled": true,
+                        "collection_data": {
+                            "api_interface": "rest",
+                            "internal_path": "",
+                            "type": "GET",
+                            "add_on": "mempool"
+                        },
+                        "apis": [
                             {
-                                "name": "content-type",
-                                "kind": "pass_send"
+                                "name": "/mempool",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             },
                             {
-                                "name": "project_id",
-                                "kind": "pass_send"
+                                "name": "/mempool/{hash}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 10,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
+                            },
+                            {
+                                "name": "/mempool/addresses/{address}",
+                                "block_parsing": {
+                                    "parser_arg": [
+                                        "latest"
+                                    ],
+                                    "parser_func": "DEFAULT"
+                                },
+                                "compute_units": 20,
+                                "enabled": true,
+                                "category": {
+                                    "deterministic": false,
+                                    "local": false,
+                                    "subscription": false,
+                                    "stateful": 0
+                                },
+                                "extra_compute_units": 0
                             }
                         ]
                     }


### PR DESCRIPTION
# Description

Closes: #2333

## The bug

The `CARDANO` spec (and therefore `CARDANOT`, which imports it) declares five Blockfrost routes in the **mandatory** base collections that the self-hosted `blockfrost-backend-ryo` does not implement:

| Route | Collection | CU |
| --- | --- | --- |
| `GET /mempool` | rest / GET | 20 |
| `GET /mempool/{hash}` | rest / GET | 10 |
| `GET /mempool/addresses/{address}` | rest / GET | 20 |
| `POST /utils/txs/evaluate` | rest / POST | 100 |
| `POST /utils/txs/evaluate/utxos` | rest / POST | 100 |

Confirmed against the RYO route tree on `master`: there is no `mempool` route directory, and `utils` contains only `addresses/xpub/{xpub}/{role}`. This matches the reporter's `HTTP 400: Invalid path` on `v6.7.2`, `v6.8.0` and `master`.

These are capability gaps, not misconfiguration. Serving the mempool needs a live `LocalTxMonitor` subscription to the node; evaluation needs a Plutus evaluator (Ogmios). RYO reads confirmed data from its chain index, so neither is reachable from its current architecture. The hosted Blockfrost service serves all five, which is what the spec was written against.

**Scope of the impact** — worth stating precisely, because it is narrower than "cannot stake". `validateGeoLocationAndApiInterfaces` checks whole collections, not individual APIs (`GetExpectedServicesForExpandedSpec(spec, true)` treats `add_on == ""` as mandatory), so a RYO-backed provider stakes fine today. The damage is at relay time: every request to those five routes fails and costs the provider QoS, pushing it toward being unpaired.

## The fix

**Spec** (`specs/mainnet-1/specs/cardano.json`, `specs/testnet-2/specs/cardano.json`, kept byte-identical as before):

Two new collections, following the `ETHBEACON` `debug` REST addon and `ETH1` `debug`/`trace` pattern:

```json
{ "api_interface": "rest", "internal_path": "", "type": "POST", "add_on": "txs-evaluate" }
{ "api_interface": "rest", "internal_path": "", "type": "GET",  "add_on": "mempool" }
```

| | base GET | base POST | `mempool` | `txs-evaluate` |
| --- | --- | --- | --- | --- |
| Before | 113 | 3 | — | — |
| After | 110 | 1 | 3 | 2 |

### How to review this diff

**The spec change is 100% relocation.** No API definition is edited — compute units, categories, block parsing and parsers are byte-identical to `main`. Only the collection each API belongs to changed. That is worth verifying mechanically rather than by eye, because the diff is noisy:

```bash
python3 - <<'EOF'
import json, subprocess
old = json.loads(subprocess.run(['git','show','main:specs/mainnet-1/specs/cardano.json'],
                                capture_output=True, text=True).stdout)
new = json.load(open('specs/mainnet-1/specs/cardano.json'))
def flat(s):
    return {(p['index'], ac['collection_data']['type'], a['name']): json.dumps(a, sort_keys=True)
            for p in s['proposal']['specs'] for ac in p['api_collections'] for a in ac['apis']}
o, n = flat(old), flat(new)
assert set(o) == set(n), set(o) ^ set(n)
changed = [k for k in o if o[k] != n[k]]
print(f"{len(o)} APIs; definitions changed: {changed or 'NONE - pure relocation'}")
EOF
```

Each spec file reports 142 changed lines, which overstates the change. The arithmetic:

```
  3 mempool API blocks         54 lines
  2 utils/evaluate blocks      36 lines
  ---------------------------------
  API text that must move      90 lines  -> appears as BOTH a deletion and an addition
  new collection wrappers      22 lines  (2 collections x 11)
  ---------------------------------
  naive total                 202 lines
  git context-matching saves  -60 lines
  reported diff               142 lines  (82+ / 60-)
```

A unified diff has no concept of a move: every relocated line is one deletion plus one addition. Those 90 lines of API bodies are the floor. Three `/mempool` blocks in particular have to travel ~870 lines to leave the base GET collection's `apis` array and land in a sibling collection, and because every API block shares identical `block_parsing` / `category` boilerplate, the line-based diff pairs unrelated blocks — you may see `-"compute_units": 100` next to `+"compute_units": 20` for two APIs that have nothing to do with each other. That is a diff artifact, not a change.

Collection order was chosen by measuring all six valid orderings against `main`; placing `txs-evaluate` directly after the base POST collection it came from keeps those two API blocks within ~12 lines of their old position, which is what lets git match them. The alternatives cost 4 to 8 more lines each, and the only cheaper one (140) puts the base POST collection after both addons, which reads worse for no meaningful gain.

`git diff --color-moved=zebra` on the spec files follows the relocation better than the GitHub view.

### Notes on the addon collections

Three things they deliberately do *not* carry:

- **No `headers`.** Headers register into a flat map keyed by header name + connection type (`base_chain_parser.go:626`), so the base collections' `project_id` already covers every GET/POST. `ETH1` and `ETHBEACON` addons likewise declare `headers: null`.
- **No `inheritance_apis`.** Addons are additive — a provider serving `mempool` also serves base.
- **No `enabled` verification, on purpose.** An empty mempool is normal, so a naive `PARSE_BY_ARG ["0"]` probe of `GET /mempool` would fail on an idle chain and jail honest providers; a `POST /utils/txs/evaluate` probe would need a valid CBOR transaction as a static template. Shipping a flaky verification is worse than shipping none. Left as a follow-up.

**`CARDANOT` needs no change of its own.** It declares only a base GET collection; `DoExpandSpec` → `CombineCollections` carries over any parent collection the child does not declare. Verified: both indexes expand to the same `{base GET: 110, base POST: 1, mempool: 3, txs-evaluate: 2}`.

### Plan policy (`cookbook/plans/gateway-full.json`)

`GetSupportedAddons` returns `[""]` plus only addons named in the policy's `Requirements` — and an empty *or* wildcard chain policy resolves to zero requirements. Without a policy change no consumer could reach these five routes at all, so `CARDANO` and `CARDANOT` entries are added requiring both addons with `mixed: true`, modelled on the existing `SQDSUBGRAPH` entry.

`mixed: true` is load-bearing. `Requirements` act as a pairing filter (`x/pairing/keeper/filters/addon_filter.go`); without it, pairing would return *only* addon-supporting providers for CARDANO entirely, recreating this issue pointed the other way.

The four plans carrying `chain_policies: []` are **left alone**. `ChainPolicy()` returns "not allowed" for any chain absent from a non-empty list, so adding a single CARDANO entry to those would make every *other* chain unreachable for them. Fixing that needs a wildcard entry alongside, which is a separate decision about customer-facing plans.

### Provider example

`config/provider_examples/cardano_example.yml` documents the `addons:` block, that it must also appear in the stake entry (`"127.0.0.1:2221,1,rest,mempool,txs-evaluate"`), and that RYO-backed providers should omit both.

## What this means for providers

| | Blockfrost SaaS backend | Self-hosted RYO |
| --- | --- | --- |
| Today | serves all 116 | serves 111, fails 5 → QoS penalty |
| After | 111 base + 5 addon | 111 base, clean |
| Action needed | add `addons:` to config **and re-stake** | none |

If RYO adds these routes later, providers opt in with a config change and a re-stake — no governance proposal. That is the main reason for an addon over disabling the five APIs, which would have frozen today's RYO limitations into the spec until someone proposed a reversal.

## Proposal sequencing

Two proposals, and the order is not interchangeable:

1. **Spec proposal first.** `ValidatePlanFields` (`x/plans/keeper/plan.go:110`) rejects a policy naming an addon the spec does not define, so the plans proposal cannot land first.
2. **Plans proposal immediately after.** Between the two, the five routes are unreachable for consumers. Worth warning Cardano providers before submitting.

## Verification

New `TestCardanoSpec_MempoolAndEvaluateAreAddons` in `protocol/chainlib/rest_test.go` drives the real spec through `ParseAndValidateMessage`, the same entry point the consumer and provider use:

- with a policy carrying no requirements (every plan shipped today), all five routes are rejected with `consumer policy does not allow addon`, while `/blocks/latest` and `/tx/submit` still resolve;
- with both addons required, the same five resolve and report the right addon via `GetAddon`, and base routes still report `""`.

```
go test ./x/spec/keeper -run 'TestSpecs$' -count=1     ok   (both spec copies load, expand, validate)
go test ./protocol/chainlib -count=1                   ok   (10.4s, full package)
go test ./x/plans/keeper -count=1                      ok
go vet ./protocol/chainlib                             ok
```

Separately verified and then removed: `CARDANOT` inherits both addons through expansion, and every addon named by the new plan policies resolves against the spec with `mixed: true`.

Not verified here: whether a future RYO release adds any of the five. If one does, the addon still models it correctly — that provider just opts in.

---

## Author Checklist

I have...

* [x] read the [contribution guide](https://github.com/lavanet/lava/blob/main/CONTRIBUTING.md)
* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change — see note below
* [x] targeted the `main` branch
* [x] provided a link to the relevant issue or specification — #2333, and the RYO backend at https://github.com/blockfrost/blockfrost-backend-ryo
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] updated the relevant documentation or specification — the spec files and the provider example are the documentation
* [x] confirmed all CI checks have passed — pending on this push

On the breaking-change box: not marked `!` because no API is removed or renamed and no client call changes shape. It is a **routing** change though — consumers on a plan without the addon lose access to those five routes until the plans proposal lands, and providers must re-stake to keep serving them. Flagging it here rather than in the title, but say the word if you would rather it carried `!`.

## Reviewers Checklist

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

https://claude.ai/code/session_0174ZD9merkC3nHPA3KbXLMh